### PR TITLE
Adding support for import, ipool resource and os patch config in cluster resource

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ terraform.tfstate
 terraform.tfvars
 
 kubeconfig_*
+
+.local

--- a/docs/resources/cluster_aws.md
+++ b/docs/resources/cluster_aws.md
@@ -28,6 +28,10 @@ resource "spectrocloud_cluster_aws" "cluster" {
   cluster_profile_id = data.spectrocloud_cluster_profile.profile.id
   cloud_account_id   = data.spectrocloud_cloudaccount_aws.account.id
 
+  os_patch_on_boot = true
+  os_patch_schedule = "0 0 * * 0"
+  #os_patch_after = "2021-02-03T14:59:37.000Z"
+
   cloud_config {
     ssh_key_name = "default"
     region       = "us-west-2"
@@ -88,6 +92,10 @@ resource "spectrocloud_cluster_aws" "cluster" {
 - **id** (String) The ID of this resource.
 - **pack** (Block Set) (see [below for nested schema](#nestedblock--pack))
 - **timeouts** (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
+- **os_patch_on_boot** (Boolean, Optional) OS Patch on boot when set, updates security patch of host OS 
+of all nodes and monitors new nodes (which gets created when cluster is scaled up or cluster k8s version is upgraded) for security patch
+- **os_patch_schedule** (String, Optional) Cron schedule to patch security updates on host OS for all nodes. Please see https://en.wikipedia.org/wiki/Cron for valid cron syntax
+- **os_patch_after** (String, Optional) On demand security patch on host OS for all nodes. Please follow RFC3339 Date and Time Standards. Eg 2021-01-01T00:00:00.000Z
 
 ### Read-only
 

--- a/docs/resources/cluster_azure.md
+++ b/docs/resources/cluster_azure.md
@@ -90,6 +90,10 @@ resource "spectrocloud_cluster_azure" "cluster" {
 - **id** (String) The ID of this resource.
 - **pack** (Block Set) (see [below for nested schema](#nestedblock--pack))
 - **timeouts** (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
+- **os_patch_on_boot** (Boolean, Optional) OS Patch on boot when set, updates security patch of host OS 
+of all nodes and monitors new nodes (which gets created when cluster is scaled up or cluster k8s version is upgraded) for security patch
+- **os_patch_schedule** (String, Optional) Cron schedule to patch security updates on host OS for all nodes. Please see https://en.wikipedia.org/wiki/Cron for valid cron syntax
+- **os_patch_after** (String, Optional) On demand security patch on host OS for all nodes. Please follow RFC3339 Date and Time Standards. Eg 2021-01-01T00:00:00.000Z
 
 ### Read-only
 

--- a/docs/resources/cluster_gcp.md
+++ b/docs/resources/cluster_gcp.md
@@ -89,6 +89,10 @@ resource "spectrocloud_cluster_gcp" "cluster" {
 - **id** (String) The ID of this resource.
 - **pack** (Block Set) (see [below for nested schema](#nestedblock--pack))
 - **timeouts** (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
+- **os_patch_on_boot** (Boolean, Optional) OS Patch on boot when set, updates security patch of host OS 
+of all nodes and monitors new nodes (which gets created when cluster is scaled up or cluster k8s version is upgraded) for security patch
+- **os_patch_schedule** (String, Optional) Cron schedule to patch security updates on host OS for all nodes. Please see https://en.wikipedia.org/wiki/Cron for valid cron syntax
+- **os_patch_after** (String, Optional) On demand security patch on host OS for all nodes. Please follow RFC3339 Date and Time Standards. Eg 2021-01-01T00:00:00.000Z
 
 ### Read-only
 

--- a/docs/resources/cluster_import.md
+++ b/docs/resources/cluster_import.md
@@ -1,0 +1,86 @@
+---
+page_title: "spectrocloud_cluster_import Resource - terraform-provider-spectrocloud"
+subcategory: ""
+description: |-
+  
+---
+
+# Resource `spectrocloud_cluster_import`
+
+
+
+## Example Usage
+
+```terraform
+data "spectrocloud_cluster_profile" "profile" {
+  # id = <uid>
+  name = var.cluster_cluster_profile_name
+}
+resource "spectrocloud_cluster_import" "cluster" {
+  name = "vsphere-import-01"
+  cloud = "vsphere"
+  cluster_profile_id = spectrocloud_cluster_profile.profile.id
+/*  pack {
+     name   = "k8s-dashboard"
+     tag    = "2.1.x"
+     values = <<-EOT
+        manifests:
+          k8s-dashboard:
+            #Namespace to install kubernetes-dashboard
+            namespace: "kubernetes-dashboard"
+            #The ClusterRole to assign for kubernetes-dashboard. By default, a ready-only cluster role is provisioned
+            clusterRole: "k8s-dashboard-readonly"
+            #Self-Signed Certificate duration in hours
+            certDuration: 9000h
+            #Self-Signed Certificate renewal in hours
+            certRenewal: 720h     #30d
+            #The service type for dashboard. Supported values are ClusterIP / LoadBalancer / NodePort
+            serviceType: ClusterIP
+            #Flag to enable skip login option on the dashboard login page
+            skipLogin: false
+            #Ingress config
+            ingress:
+              enabled: false
+     EOT
+  }*/
+}
+```
+
+## Schema
+
+### Required
+
+- **cloud** (String)
+- **name** (String)
+
+### Optional
+
+- **cluster_profile_id** (String) The ID of this resource.
+- **pack** (Block Set) (see [below for nested schema](#nestedblock--pack))
+- **timeouts** (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
+
+### Read-only
+
+- **cloud_config_id** (String)
+- **cluster_import_manifest_apply_command** (String)
+- **cluster_import_manifest** (String)
+
+
+<a id="nestedblock--pack"></a>
+### Nested Schema for `pack`
+
+Required:
+
+- **name** (String)
+- **tag** (String)
+- **values** (String)
+
+
+<a id="nestedblock--timeouts"></a>
+### Nested Schema for `timeouts`
+
+Optional:
+
+- **create** (String)
+- **delete** (String)
+- **update** (String)

--- a/docs/resources/cluster_vsphere.md
+++ b/docs/resources/cluster_vsphere.md
@@ -26,6 +26,10 @@ description: |-
 - **id** (String) The ID of this resource.
 - **pack** (Block Set) (see [below for nested schema](#nestedblock--pack))
 - **timeouts** (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
+- **os_patch_on_boot** (Boolean, Optional) OS Patch on boot when set, updates security patch of host OS 
+of all nodes and monitors new nodes (which gets created when cluster is scaled up or cluster k8s version is upgraded) for security patch
+- **os_patch_schedule** (String, Optional) Cron schedule to patch security updates on host OS for all nodes. Please see https://en.wikipedia.org/wiki/Cron for valid cron syntax
+- **os_patch_after** (String, Optional) On demand security patch on host OS for all nodes. Please follow RFC3339 Date and Time Standards. Eg 2021-01-01T00:00:00.000Z
 
 ### Read-only
 

--- a/docs/resources/privatecloudgateway_ippool.md
+++ b/docs/resources/privatecloudgateway_ippool.md
@@ -1,0 +1,58 @@
+---
+page_title: "spectrocloud_privatecloudgateway_ippool Resource - terraform-provider-spectrocloud"
+subcategory: ""
+description: |-
+  
+---
+
+# Resource `spectrocloud_privatecloudgateway_ippool`
+
+
+
+## Example Usage
+
+```terraform
+resource "spectrocloud_privatecloudgateway_ippool" "ippool" {
+  name                 = "ippool-dev"
+  private_cloud_gateway_id = "5fbb9195f4a3d7b95f888211"
+  network_type = "range"
+  ip_start_range = "10.10.10.100"
+  ip_end_range = "10.10.10.199"
+  prefix = 24
+  gateway = "10.10.10.1"
+  nameserver_addresses = "8.8.8.8"
+  nameserver_search_suffix = "test.com"
+  restrict_to_single_cluster = true
+}
+
+resource "spectrocloud_privatecloudgateway_ippool" "ippoolprod" {
+  name                 = "ippool-prod"
+  private_cloud_gateway_id = "5fbb9195f4a3d7b95f888211"
+  network_type = "subnet"
+  subnet_cidr = "10.10.10.100/16"
+  prefix = 30
+  gateway = "10.10.10.1"
+  nameserver_addresses = "8.8.8.8"
+  nameserver_search_suffix = "test.com"
+  restrict_to_single_cluster = true
+}
+```
+
+## Schema
+
+### Required
+
+- **name** (String)
+- **private_cloud_gateway_id** (String)
+- **network_type** (String) one of ["range", "subnet""]
+- **prefix** (Int)
+- **gateway** (String)
+- **ip_start_range** (String) if `network_type` is `range`
+- **ip_end_range** (String) if `network_type` is `range`
+- **subnet_cidr** (String) if `network_type` is `subnet`
+
+### Optional
+
+- **nameserver_addresses** (String) Comma seperated value
+- **nameserver_search_suffix** (String) Comma seperated value
+- **restrict_to_single_cluster** (Boolean)

--- a/docs/resources/privatecloudgateway_ippool.md
+++ b/docs/resources/privatecloudgateway_ippool.md
@@ -22,7 +22,7 @@ resource "spectrocloud_privatecloudgateway_ippool" "ippool" {
   gateway = "10.10.10.1"
   nameserver_addresses = "8.8.8.8"
   nameserver_search_suffix = "test.com"
-  restrict_to_single_cluster = true
+  restrict_to_single_cluster = false
 }
 
 resource "spectrocloud_privatecloudgateway_ippool" "ippoolprod" {
@@ -44,7 +44,7 @@ resource "spectrocloud_privatecloudgateway_ippool" "ippoolprod" {
 
 - **name** (String)
 - **private_cloud_gateway_id** (String)
-- **network_type** (String) one of ["range", "subnet""]
+- **network_type** (String) one of [`range`, `subnet`]
 - **prefix** (Int)
 - **gateway** (String)
 - **ip_start_range** (String) if `network_type` is `range`

--- a/examples/e2e/ippool/providers.tf
+++ b/examples/e2e/ippool/providers.tf
@@ -1,0 +1,34 @@
+terraform {
+  required_providers {
+    spectrocloud = {
+      version = ">= 0.1"
+      source  = "spectrocloud/spectrocloud"
+    }
+  }
+}
+
+variable "sc_host" {
+  description = "Spectro Cloud Endpoint"
+  default     = "api.spectrocloud.com"
+}
+
+variable "sc_username" {
+  description = "Spectro Cloud Username"
+}
+
+variable "sc_password" {
+  description = "Spectro Cloud Password"
+  sensitive   = true
+}
+
+variable "sc_project_name" {
+  description = "Spectro Cloud Project (e.g: Default)"
+  default     = "Default"
+}
+
+provider "spectrocloud" {
+  host         = var.sc_host
+  username     = var.sc_username
+  password     = var.sc_password
+  project_name = var.sc_project_name
+}

--- a/examples/e2e/ippool/resource_ippool.tf
+++ b/examples/e2e/ippool/resource_ippool.tf
@@ -1,0 +1,14 @@
+data "spectrocloud_cloudaccount_vsphere" "account" {
+  name = var.shared_vmware_cloud_account_name
+}
+
+# If creating a new cloud account, use this:
+#
+# resource "spectrocloud_cloudaccount_vsphere" "account" {
+#   name                 = "vsphere-picard-2"
+#   private_cloud_gateway_id      = var.private_cloud_gateway_id
+#   vsphere_vcenter               = "<....>"
+#   vsphere_username              = "<....>"
+#   vsphere_password              = "<....>"
+#   vsphere_ignore_insecure_error = true
+# }

--- a/examples/e2e/ippool/terraform.template.tfvars
+++ b/examples/e2e/ippool/terraform.template.tfvars
@@ -1,0 +1,29 @@
+# Spectro Cloud credentials
+sc_host         = "{enter Spectro Cloud API endpoint}" #e.g: api.spectrocloud.com (for SaaS)
+sc_username     = "{enter Spectro Cloud username}"     #e.g: user1@abc.com
+sc_password     = "{enter Spectro Cloud password}"     #e.g: supereSecure1!
+sc_project_name = "{enter Spectro Cloud project Name}" #e.g: Default
+
+# Cloud Account lookup by name
+# See README.md for instructions how to obtain this name
+shared_vmware_cloud_account_name = "{enter Spectro Cloud VMware Cloud Account name}"
+
+# SSH public key to inject into all K8s nodes
+# Insert your public key between the EOT markers
+# The public key starts with "ssh-rsa ...."
+cluster_ssh_public_key = <<-EOT
+  {enter SSH Public Key}
+EOT
+
+# For DHCP, the search domain
+cluster_network_search = "{enter DHCP Search domain}" #e.g spectrocloud.local
+
+# VMware cluster placement properties
+# All fields except _vsphere\_resource\_pool_ are required fields
+vsphere_datacenter = "{enter vSphere Datacenter}"
+vsphere_folder     = "{enter vSphere Folder}"
+
+vsphere_cluster       = "{enter vSphere ESX Cluster}"
+vsphere_resource_pool = "{enter vSphere Resource Pool}" # Leave "" blank for Cluster Resource pool
+vsphere_datastore     = "{enter vSphere Datastore}"
+vsphere_network       = "{enter vSphere Network}"

--- a/examples/e2e/ippool/variables.tf
+++ b/examples/e2e/ippool/variables.tf
@@ -1,0 +1,12 @@
+variable "shared_vmware_cloud_account_name" {}
+
+variable "cluster_ssh_public_key" {}
+variable "cluster_network_search" {}
+
+variable "vsphere_datacenter" {}
+variable "vsphere_folder" {}
+
+variable "vsphere_cluster" {}
+variable "vsphere_resource_pool" {}
+variable "vsphere_datastore" {}
+variable "vsphere_network" {}

--- a/examples/import/gcp/import_manifest.tf
+++ b/examples/import/gcp/import_manifest.tf
@@ -1,0 +1,6 @@
+resource "local_file" "import_manifest1" {
+  content              = local.cluster_import_manifest
+  filename             = "import_manifest_gcp.yaml"
+  file_permission      = "0644"
+  directory_permission = "0755"
+}

--- a/examples/import/gcp/locals.tf
+++ b/examples/import/gcp/locals.tf
@@ -1,0 +1,4 @@
+locals {
+  cluster_import_manifest_url = spectrocloud_cluster_import.cluster.cluster_import_manifest_apply_command
+  cluster_import_manifest = spectrocloud_cluster_import.cluster.cluster_import_manifest
+}

--- a/examples/import/gcp/outputs.tf
+++ b/examples/import/gcp/outputs.tf
@@ -1,0 +1,11 @@
+output "cluster_id" {
+  value = spectrocloud_cluster_import.cluster.id
+}
+
+output "cluster_import_manifest_url" {
+  value = local.cluster_import_manifest_url
+}
+
+output "cluster_import_manifest" {
+  value = local.cluster_import_manifest
+}

--- a/examples/import/gcp/providers.tf
+++ b/examples/import/gcp/providers.tf
@@ -1,0 +1,34 @@
+terraform {
+  required_providers {
+    spectrocloud = {
+      version = ">= 0.1"
+      source  = "spectrocloud/spectrocloud"
+    }
+  }
+}
+
+variable "sc_host" {
+  description = "Spectro Cloud Endpoint"
+  default     = "api.spectrocloud.com"
+}
+
+variable "sc_username" {
+  description = "Spectro Cloud Username"
+}
+
+variable "sc_password" {
+  description = "Spectro Cloud Password"
+  sensitive   = true
+}
+
+variable "sc_project_name" {
+  description = "Spectro Cloud Project (e.g: Default)"
+  default     = "Default"
+}
+
+provider "spectrocloud" {
+  host         = var.sc_host
+  username     = var.sc_username
+  password     = var.sc_password
+  project_name = var.sc_project_name
+}

--- a/examples/import/gcp/resource_cluster.tf
+++ b/examples/import/gcp/resource_cluster.tf
@@ -1,0 +1,40 @@
+resource "spectrocloud_cluster_import" "cluster" {
+  name = "gke-import-demo"
+  cloud = "gcp"
+  cluster_profile_id = spectrocloud_cluster_profile.profile.id
+
+/*  pack {
+     name   = "k8s-dashboard"
+     tag    = "2.1.x"
+     values = <<-EOT
+        manifests:
+          k8s-dashboard:
+
+            #Namespace to install kubernetes-dashboard
+            namespace: "kubernetes-dashboard"
+
+            #The ClusterRole to assign for kubernetes-dashboard. By default, a ready-only cluster role is provisioned
+            clusterRole: "k8s-dashboard-readonly"
+
+            #Self-Signed Certificate duration in hours
+            certDuration: 9000h
+
+            #Self-Signed Certificate renewal in hours
+            certRenewal: 720h     #30d
+
+            #The service type for dashboard. Supported values are ClusterIP / LoadBalancer / NodePort
+            serviceType: ClusterIP
+
+            #Flag to enable skip login option on the dashboard login page
+            skipLogin: false
+
+            #Ingress config
+            ingress:
+              enabled: false
+     EOT
+  }*/
+
+  provisioner "local-exec" {
+    command = "${spectrocloud_cluster_import.cluster.cluster_import_manifest_apply_command } --kubeconfig ${var.kubeconfig_path}"
+  }
+}

--- a/examples/import/gcp/resource_clusterprofile.tf
+++ b/examples/import/gcp/resource_clusterprofile.tf
@@ -1,0 +1,49 @@
+# If looking up a cluster profile instead of creating a new one
+# data "spectrocloud_cluster_profile" "profile" {
+#   # id = <uid>
+#   name = var.cluster_cluster_profile_name
+# }
+
+data "spectrocloud_pack" "k8s_dashboard" {
+  name = "k8s-dashboard"
+  version  = "2.1.0"
+}
+
+resource "spectrocloud_cluster_profile" "profile" {
+  name        = "cloud-addon-demo"
+  description = "add-on cp"
+  cloud       = "vsphere"
+  type        = "add-on"
+
+  pack {
+    name   = "k8s-dashboard"
+    tag    = "2.1.x"
+    uid    = data.spectrocloud_pack.k8s_dashboard.id
+    values = <<-EOT
+      manifests:
+        k8s-dashboard:
+
+          #Namespace to install kubernetes-dashboard
+          namespace: "kubernetes-dashboard"
+
+          #The ClusterRole to assign for kubernetes-dashboard. By default, a ready-only cluster role is provisioned
+          clusterRole: "k8s-dashboard-readonly"
+
+          #Self-Signed Certificate duration in hours
+          certDuration: 9000h
+
+          #Self-Signed Certificate renewal in hours
+          certRenewal: 720h     #30d
+
+          #The service type for dashboard. Supported values are ClusterIP / LoadBalancer / NodePort
+          serviceType: ClusterIP
+
+          #Flag to enable skip login option on the dashboard login page
+          skipLogin: false
+
+          #Ingress config
+          ingress:
+            enabled: false
+    EOT
+  }
+}

--- a/examples/import/gcp/terraform.template.tfvars
+++ b/examples/import/gcp/terraform.template.tfvars
@@ -1,0 +1,20 @@
+# Spectro Cloud credentials
+sc_host         = "{enter Spectro Cloud API endpoint}" #e.g: api.spectrocloud.com (for SaaS)
+sc_username     = "{enter Spectro Cloud username}"     #e.g: user1@abc.com
+sc_password     = "{enter Spectro Cloud password}"     #e.g: supereSecure1!
+sc_project_name = "{enter Spectro Cloud project Name}" #e.g: Default
+
+# Google Cloud account credentials
+# Create a new GCP service account with the Editor role mapping
+# https://cloud.google.com/iam/docs/creating-managing-service-account-keys
+#
+# Paste the service account JSON key contents inside the yaml heredoc EOT markers.
+gcp_serviceaccount_json = <<-EOT
+  {enter GCP service account json}
+EOT
+
+# GCP Cluster Placement properties
+#
+gcp_network = "{enter GCP network}" #e.g: "" (this one can be blank)
+gcp_project = "{enter GCP project}"
+gcp_region  = "{enter GCP region}" #e.g: us-west3

--- a/examples/import/gcp/variables.tf
+++ b/examples/import/gcp/variables.tf
@@ -1,0 +1,7 @@
+variable "gcp_serviceaccount_json" {}
+
+variable "gcp_network" {}
+variable "gcp_project" {}
+variable "gcp_region" {}
+
+variable "kubeconfig_path" {}

--- a/examples/import/vsphere/apply-manifest.tf
+++ b/examples/import/vsphere/apply-manifest.tf
@@ -1,0 +1,9 @@
+resource "null_resource" "kubectl_apply" {
+//  triggers = {
+//    k8s_yaml_contents = filemd5("/Users/rishi/work/git_clones/terraform-provider-spectrocloud/.local/nginx.yaml")
+//  }
+
+  provisioner "local-exec" {
+    command = spectrocloud_cluster_import.cluster.cluster_import_manifest_url
+  }
+}

--- a/examples/import/vsphere/import_manifest.tf
+++ b/examples/import/vsphere/import_manifest.tf
@@ -1,0 +1,6 @@
+resource "local_file" "import_manifest1" {
+  content              = local.cluster_import_manifest
+  filename             = "import_manifest_aws.yaml"
+  file_permission      = "0644"
+  directory_permission = "0755"
+}

--- a/examples/import/vsphere/locals.tf
+++ b/examples/import/vsphere/locals.tf
@@ -1,0 +1,4 @@
+locals {
+  cluster_import_manifest_url = spectrocloud_cluster_import.cluster.cluster_import_manifest_url
+  cluster_import_manifest = spectrocloud_cluster_import.cluster.cluster_import_manifest
+}

--- a/examples/import/vsphere/outputs.tf
+++ b/examples/import/vsphere/outputs.tf
@@ -1,0 +1,11 @@
+output "cluster_id" {
+  value = spectrocloud_cluster_import.cluster.id
+}
+
+output "cluster_import_manifest_url" {
+  value = local.cluster_import_manifest_url
+}
+
+output "cluster_import_manifest" {
+  value = local.cluster_import_manifest
+}

--- a/examples/import/vsphere/providers.tf
+++ b/examples/import/vsphere/providers.tf
@@ -1,0 +1,34 @@
+terraform {
+  required_providers {
+    spectrocloud = {
+      version = ">= 0.1"
+      source  = "spectrocloud/spectrocloud"
+    }
+  }
+}
+
+variable "sc_host" {
+  description = "Spectro Cloud Endpoint"
+  default     = "api.spectrocloud.com"
+}
+
+variable "sc_username" {
+  description = "Spectro Cloud Username"
+}
+
+variable "sc_password" {
+  description = "Spectro Cloud Password"
+  sensitive   = true
+}
+
+variable "sc_project_name" {
+  description = "Spectro Cloud Project (e.g: Default)"
+  default     = "Default"
+}
+
+provider "spectrocloud" {
+  host         = var.sc_host
+  username     = var.sc_username
+  password     = var.sc_password
+  project_name = var.sc_project_name
+}

--- a/examples/import/vsphere/resource_cluster.tf
+++ b/examples/import/vsphere/resource_cluster.tf
@@ -1,0 +1,36 @@
+resource "spectrocloud_cluster_import" "cluster" {
+  name = "gcp-import-tf-11"
+  cloud = "gcp"
+  cluster_profile_id = spectrocloud_cluster_profile.profile.id
+
+/*  pack {
+     name   = "k8s-dashboard"
+     tag    = "2.1.x"
+     values = <<-EOT
+        manifests:
+          k8s-dashboard:
+
+            #Namespace to install kubernetes-dashboard
+            namespace: "kubernetes-dashboard"
+
+            #The ClusterRole to assign for kubernetes-dashboard. By default, a ready-only cluster role is provisioned
+            clusterRole: "k8s-dashboard-readonly"
+
+            #Self-Signed Certificate duration in hours
+            certDuration: 9000h
+
+            #Self-Signed Certificate renewal in hours
+            certRenewal: 720h     #30d
+
+            #The service type for dashboard. Supported values are ClusterIP / LoadBalancer / NodePort
+            serviceType: ClusterIP
+
+            #Flag to enable skip login option on the dashboard login page
+            skipLogin: false
+
+            #Ingress config
+            ingress:
+              enabled: false
+     EOT
+  }*/
+}

--- a/examples/import/vsphere/resource_clusterprofile.tf
+++ b/examples/import/vsphere/resource_clusterprofile.tf
@@ -1,0 +1,49 @@
+# If looking up a cluster profile instead of creating a new one
+# data "spectrocloud_cluster_profile" "profile" {
+#   # id = <uid>
+#   name = var.cluster_cluster_profile_name
+# }
+
+data "spectrocloud_pack" "k8s_dashboard" {
+  name = "k8s-dashboard"
+  version  = "2.1.0"
+}
+
+resource "spectrocloud_cluster_profile" "profile" {
+  name        = "cloud-addon-12"
+  description = "add-on cp"
+  cloud       = "vsphere"
+  type        = "add-on"
+
+  pack {
+    name   = "k8s-dashboard"
+    tag    = "2.1.x"
+    uid    = data.spectrocloud_pack.k8s_dashboard.id
+    values = <<-EOT
+      manifests:
+        k8s-dashboard:
+
+          #Namespace to install kubernetes-dashboard
+          namespace: "kubernetes-dashboard"
+
+          #The ClusterRole to assign for kubernetes-dashboard. By default, a ready-only cluster role is provisioned
+          clusterRole: "k8s-dashboard-readonly"
+
+          #Self-Signed Certificate duration in hours
+          certDuration: 9000h
+
+          #Self-Signed Certificate renewal in hours
+          certRenewal: 720h     #30d
+
+          #The service type for dashboard. Supported values are ClusterIP / LoadBalancer / NodePort
+          serviceType: ClusterIP
+
+          #Flag to enable skip login option on the dashboard login page
+          skipLogin: false
+
+          #Ingress config
+          ingress:
+            enabled: false
+    EOT
+  }
+}

--- a/examples/import/vsphere/terraform.template.tfvars
+++ b/examples/import/vsphere/terraform.template.tfvars
@@ -1,0 +1,29 @@
+# Spectro Cloud credentials
+sc_host         = "{enter Spectro Cloud API endpoint}" #e.g: api.spectrocloud.com (for SaaS)
+sc_username     = "{enter Spectro Cloud username}"     #e.g: user1@abc.com
+sc_password     = "{enter Spectro Cloud password}"     #e.g: supereSecure1!
+sc_project_name = "{enter Spectro Cloud project Name}" #e.g: Default
+
+# Cloud Account lookup by name
+# See README.md for instructions how to obtain this name
+shared_vmware_cloud_account_name = "{enter Spectro Cloud VMware Cloud Account name}"
+
+# SSH public key to inject into all K8s nodes
+# Insert your public key between the EOT markers
+# The public key starts with "ssh-rsa ...."
+cluster_ssh_public_key = <<-EOT
+  {enter SSH Public Key}
+EOT
+
+# For DHCP, the search domain
+cluster_network_search = "{enter DHCP Search domain}" #e.g spectrocloud.local
+
+# VMware cluster placement properties
+# All fields except _vsphere\_resource\_pool_ are required fields
+vsphere_datacenter = "{enter vSphere Datacenter}"
+vsphere_folder     = "{enter vSphere Folder}"
+
+vsphere_cluster       = "{enter vSphere ESX Cluster}"
+vsphere_resource_pool = "{enter vSphere Resource Pool}" # Leave "" blank for Cluster Resource pool
+vsphere_datastore     = "{enter vSphere Datastore}"
+vsphere_network       = "{enter vSphere Network}"

--- a/examples/import/vsphere/variables.tf
+++ b/examples/import/vsphere/variables.tf
@@ -1,0 +1,12 @@
+variable "shared_vmware_cloud_account_name" {}
+
+variable "cluster_ssh_public_key" {}
+variable "cluster_network_search" {}
+
+variable "vsphere_datacenter" {}
+variable "vsphere_folder" {}
+
+variable "vsphere_cluster" {}
+variable "vsphere_resource_pool" {}
+variable "vsphere_datastore" {}
+variable "vsphere_network" {}

--- a/examples/ippool/providers.tf
+++ b/examples/ippool/providers.tf
@@ -1,0 +1,34 @@
+terraform {
+  required_providers {
+    spectrocloud = {
+      version = ">= 0.1"
+      source  = "spectrocloud/spectrocloud"
+    }
+  }
+}
+
+variable "sc_host" {
+  description = "Spectro Cloud Endpoint"
+  default     = "api.spectrocloud.com"
+}
+
+variable "sc_username" {
+  description = "Spectro Cloud Username"
+}
+
+variable "sc_password" {
+  description = "Spectro Cloud Password"
+  sensitive   = true
+}
+
+variable "sc_project_name" {
+  description = "Spectro Cloud Project (e.g: Default)"
+  default     = "Default"
+}
+
+provider "spectrocloud" {
+  host         = var.sc_host
+  username     = var.sc_username
+  password     = var.sc_password
+  project_name = var.sc_project_name
+}

--- a/examples/ippool/resource_ippool.tf
+++ b/examples/ippool/resource_ippool.tf
@@ -1,0 +1,24 @@
+resource "spectrocloud_privatecloudgateway_ippool" "ippool1" {
+  name                 = "ippool-1"
+  private_cloud_gateway_id = "5fbb9195f4a3d7b95f888211"
+  network_type = "range"
+  ip_start_range = "10.12.10.120"
+  ip_end_range = "10.12.10.125"
+  prefix = 24
+  gateway = "10.12.10.1"
+  nameserver_addresses = "8.8.8.8"
+  nameserver_search_suffix = "test.com"
+  restrict_to_single_cluster = true
+}
+
+resource "spectrocloud_privatecloudgateway_ippool" "ippool2" {
+  name                 = "ippool-2"
+  private_cloud_gateway_id = "5fbb9195f4a3d7b95f888211"
+  network_type = "subnet"
+  subnet_cidr = "100.12.10.120/16"
+  prefix = 30
+  gateway = "100.12.10.1"
+  nameserver_addresses = "8.8.8.8"
+  nameserver_search_suffix = "test.com"
+  restrict_to_single_cluster = true
+}

--- a/examples/ippool/terraform.template.tfvars
+++ b/examples/ippool/terraform.template.tfvars
@@ -1,0 +1,5 @@
+# Spectro Cloud credentials
+sc_host         = "{enter Spectro Cloud API endpoint}" #e.g: api.spectrocloud.com (for SaaS)
+sc_username     = "{enter Spectro Cloud username}"     #e.g: user1@abc.com
+sc_password     = "{enter Spectro Cloud password}"     #e.g: supereSecure1!
+sc_project_name = "{enter Spectro Cloud project Name}" #e.g: Default

--- a/go.mod
+++ b/go.mod
@@ -3,13 +3,16 @@ module github.com/spectrocloud/terraform-provider-spectrocloud
 go 1.15
 
 require (
+	emperror.dev/errors v0.7.0
 	github.com/go-openapi/runtime v0.19.4
 	github.com/go-openapi/strfmt v0.19.3
+	github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320
 	github.com/hashicorp/terraform-plugin-docs v0.3.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.4.0
 	github.com/prometheus/common v0.10.0
+	github.com/robfig/cron v1.2.0
 	github.com/spectrocloud/gomi v0.0.0-20201228182306-1e482c900582
-	github.com/spectrocloud/hapi v1.6.1-0.20201215134830-ba674db801be
+	github.com/spectrocloud/hapi v1.7.0
 )
 
 // replace github.com/spectrocloud/hapi => ../hapi

--- a/go.sum
+++ b/go.sum
@@ -38,6 +38,7 @@ cloud.google.com/go/storage v1.8.0/go.mod h1:Wv1Oy7z6Yz3DshWRJFhqM/UCfaWIRTdp0RX
 cloud.google.com/go/storage v1.10.0 h1:STgFzyU5/8miMl0//zKh2aQeTyeaUH3WN9bSUiJ09bA=
 cloud.google.com/go/storage v1.10.0/go.mod h1:FLPqc6j+Ki4BU591ie1oL6qBQGu2Bl/tZ9ullr3+Kg0=
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
+emperror.dev/errors v0.7.0 h1:vf0gZ0j9BJCXQYm0M21DPKeXy9PUjvX1YHXhNzIsqOY=
 emperror.dev/errors v0.7.0/go.mod h1:X4dljzQehaz3WfBKc6c7bR+ve2ZsRzbBkFBF+HTcW0M=
 github.com/AlecAivazis/survey/v2 v2.0.4/go.mod h1:WYBhg6f0y/fNYUuesWQc0PKbJcEliGcYHB9sNT3Bg74=
 github.com/Azure/azure-sdk-for-go v42.0.0+incompatible/go.mod h1:9XXNKU+eRnpl9moKnB4QOLf1HestfXbmab5FXxiDBjc=
@@ -629,6 +630,8 @@ github.com/prometheus/procfs v0.0.11/go.mod h1:lV6e/gmhEcM9IjHGsFOCxxuZ+z1YqCvr4
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
 github.com/remyoudompheng/bigfft v0.0.0-20170806203942-52369c62f446/go.mod h1:uYEyJGbgTkfkS4+E/PavXkNJcbFIpEtjt2B0KDQ5+9M=
 github.com/rhysd/go-github-selfupdate v1.1.0/go.mod h1:jbfShZ+Nl3IHUgr77kwQjObcWf1z961UAoD6p5LrPBU=
+github.com/robfig/cron v1.2.0 h1:ZjScXvvxeQ63Dbyxy76Fj3AT3Ut0aKsyd2/tl3DTMuQ=
+github.com/robfig/cron v1.2.0/go.mod h1:JGuDeoQd7Z6yL4zQhZ3OPEVHB7fL6Ka6skscFHfmt2k=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/russross/blackfriday v0.0.0-20170610170232-067529f716f4/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR/rfWxYHBV53g=
@@ -654,6 +657,8 @@ github.com/spectrocloud/gomi v0.0.0-20201228182306-1e482c900582 h1:wpKPN/UUaLErQ
 github.com/spectrocloud/gomi v0.0.0-20201228182306-1e482c900582/go.mod h1:rPAwipFWzjYkTfx44KmQazP1NR2cnHe7HSFZkc63mf4=
 github.com/spectrocloud/hapi v1.6.1-0.20201215134830-ba674db801be h1:TJwnUj2rT55w92UOcei6sZgBmwrZlA2/33xt2c1fDK0=
 github.com/spectrocloud/hapi v1.6.1-0.20201215134830-ba674db801be/go.mod h1:+kLhenk25C6rdL+wnC+wH1LLQltYJgrdjKh/Be67mGA=
+github.com/spectrocloud/hapi v1.7.0 h1:/bh456gJIvtyBDNt/v1V7mGe95kAlFSgFBJ4SOXnWE0=
+github.com/spectrocloud/hapi v1.7.0/go.mod h1:+kLhenk25C6rdL+wnC+wH1LLQltYJgrdjKh/Be67mGA=
 github.com/spf13/afero v1.1.2/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=
 github.com/spf13/afero v1.2.2/go.mod h1:9ZxEEn6pIJ8Rxe320qSDBk6AsU0r9pR7Q4OcevTdifk=
 github.com/spf13/cast v1.2.0/go.mod h1:r2rcYCSwa1IExKTDiTfzaxqT2FNHs8hODu4LnUfgKEg=
@@ -739,8 +744,10 @@ go.opencensus.io v0.22.4 h1:LYy1Hy3MJdrCdMwwzxA/dRok4ejH+RwNGbuoD9fCjto=
 go.opencensus.io v0.22.4/go.mod h1:yxeiOL68Rb0Xd1ddK5vPZ/oVn4vY4Ynel7k9FzqtOIw=
 go.uber.org/atomic v1.3.2/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
 go.uber.org/atomic v1.4.0/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
+go.uber.org/atomic v1.5.0 h1:OI5t8sDa1Or+q8AeE+yKeB/SDYioSHAgcVljj9JIETY=
 go.uber.org/atomic v1.5.0/go.mod h1:sABNBOSYdrvTF6hTgEIbc7YasKWGhgEQZyfxyTvoXHQ=
 go.uber.org/multierr v1.1.0/go.mod h1:wR5kodmAFQ0UK8QlbwjlSNy0Z68gJhDJUG5sjR94q/0=
+go.uber.org/multierr v1.4.0 h1:f3WCSC2KzAcBXGATIxAB1E2XuCpNU255wNKZ505qi3E=
 go.uber.org/multierr v1.4.0/go.mod h1:VgVr7evmIr6uPjLBxg28wmKNXyqE9akIJ5XnfpiKl+4=
 go.uber.org/tools v0.0.0-20190618225709-2cfd321de3ee/go.mod h1:vJERXedbb3MVM5f9Ejo0C68/HhF8uaILCdgjnY+goOA=
 go.uber.org/zap v1.10.0/go.mod h1:vwi/ZaCAaUcBkycHslxD9B2zi4UTXhF60s6SWpuDF0Q=

--- a/pkg/client/cluster.go
+++ b/pkg/client/cluster.go
@@ -1,13 +1,13 @@
 package client
 
 import (
+	"strings"
+
 	hapitransport "github.com/spectrocloud/hapi/apiutil/transport"
 	"github.com/spectrocloud/hapi/models"
-	"strings"
 
 	clusterC "github.com/spectrocloud/hapi/spectrocluster/client/v1alpha1"
 )
-
 
 func (h *V1alpha1Client) DeleteCluster(uid string) error {
 	client, err := h.getClusterClient()
@@ -60,3 +60,29 @@ func (h *V1alpha1Client) GetClusterKubeConfig(uid string) (string, error) {
 	return builder.String(), nil
 }
 
+func (h *V1alpha1Client) GetClusterImportManifest(uid string) (string, error) {
+	client, err := h.getClusterClient()
+	if err != nil {
+		return "", err
+	}
+
+	builder := new(strings.Builder)
+	params := clusterC.NewV1alpha1SpectroClustersUIDInstallerManifestParamsWithContext(h.ctx).WithUID(uid)
+	_, err = client.V1alpha1SpectroClustersUIDInstallerManifest(params, builder)
+	if err != nil {
+		return "", err
+	}
+
+	return builder.String(), nil
+}
+
+func (h *V1alpha1Client) UpdateBrownfieldCluster(uid string, profiles *models.V1alpha1SpectroClusterProfiles) error {
+	client, err := h.getClusterClient()
+	if err != nil {
+		return nil
+	}
+
+	params := clusterC.NewV1alpha1SpectroClustersUpdateProfilesParamsWithContext(h.ctx).WithUID(uid).WithBody(profiles)
+	_, err = client.V1alpha1SpectroClustersUpdateProfiles(params)
+	return err
+}

--- a/pkg/client/cluster_aws.go
+++ b/pkg/client/cluster_aws.go
@@ -7,7 +7,6 @@ import (
 	clusterC "github.com/spectrocloud/hapi/spectrocluster/client/v1alpha1"
 )
 
-
 func (h *V1alpha1Client) CreateClusterAws(cluster *models.V1alpha1SpectroAwsClusterEntity) (string, error) {
 	client, err := h.getClusterClient()
 	if err != nil {
@@ -165,4 +164,23 @@ func (h *V1alpha1Client) GetCloudConfigAws(configUID string) (*models.V1alpha1Aw
 	}
 
 	return success.Payload, nil
+}
+
+func (h *V1alpha1Client) ImportClusterAws(meta *models.V1ObjectMetaInputEntity) (string, error) {
+	client, err := h.getClusterClient()
+	if err != nil {
+		return "", err
+	}
+
+	params := clusterC.NewV1alpha1SpectroClustersAwsImportParamsWithContext(h.ctx).WithBody(
+		&models.V1alpha1SpectroAwsClusterImportEntity{
+			Metadata: meta,
+		},
+	)
+	success, err := client.V1alpha1SpectroClustersAwsImport(params)
+	if err != nil {
+		return "", err
+	}
+
+	return *success.Payload.UID, nil
 }

--- a/pkg/client/cluster_azure.go
+++ b/pkg/client/cluster_azure.go
@@ -7,7 +7,6 @@ import (
 	clusterC "github.com/spectrocloud/hapi/spectrocluster/client/v1alpha1"
 )
 
-
 func (h *V1alpha1Client) CreateClusterAzure(cluster *models.V1alpha1SpectroAzureClusterEntity) (string, error) {
 	client, err := h.getClusterClient()
 	if err != nil {
@@ -165,4 +164,23 @@ func (h *V1alpha1Client) GetCloudConfigAzure(configUID string) (*models.V1alpha1
 	}
 
 	return success.Payload, nil
+}
+
+func (h *V1alpha1Client) ImportClusterAzure(meta *models.V1ObjectMetaInputEntity) (string, error) {
+	client, err := h.getClusterClient()
+	if err != nil {
+		return "", err
+	}
+
+	params := clusterC.NewV1alpha1SpectroClustersAzureImportParamsWithContext(h.ctx).WithBody(
+		&models.V1alpha1SpectroAzureClusterImportEntity{
+			Metadata: meta,
+		},
+	)
+	success, err := client.V1alpha1SpectroClustersAzureImport(params)
+	if err != nil {
+		return "", err
+	}
+
+	return *success.Payload.UID, nil
 }

--- a/pkg/client/cluster_gcp.go
+++ b/pkg/client/cluster_gcp.go
@@ -7,7 +7,6 @@ import (
 	clusterC "github.com/spectrocloud/hapi/spectrocluster/client/v1alpha1"
 )
 
-
 func (h *V1alpha1Client) CreateClusterGcp(cluster *models.V1alpha1SpectroGcpClusterEntity) (string, error) {
 	client, err := h.getClusterClient()
 	if err != nil {
@@ -165,4 +164,23 @@ func (h *V1alpha1Client) GetCloudConfigGcp(configUID string) (*models.V1alpha1Gc
 	}
 
 	return success.Payload, nil
+}
+
+func (h *V1alpha1Client) ImportClusterGcp(meta *models.V1ObjectMetaInputEntity) (string, error) {
+	client, err := h.getClusterClient()
+	if err != nil {
+		return "", err
+	}
+
+	params := clusterC.NewV1alpha1SpectroClustersGcpImportParamsWithContext(h.ctx).WithBody(
+		&models.V1alpha1SpectroGcpClusterImportEntity{
+			Metadata: meta,
+		},
+	)
+	success, err := client.V1alpha1SpectroClustersGcpImport(params)
+	if err != nil {
+		return "", err
+	}
+
+	return *success.Payload.UID, nil
 }

--- a/pkg/client/cluster_vsphere.go
+++ b/pkg/client/cluster_vsphere.go
@@ -7,7 +7,6 @@ import (
 	clusterC "github.com/spectrocloud/hapi/spectrocluster/client/v1alpha1"
 )
 
-
 func (h *V1alpha1Client) CreateClusterVsphere(cluster *models.V1alpha1SpectroVsphereClusterEntity) (string, error) {
 	client, err := h.getClusterClient()
 	if err != nil {
@@ -149,7 +148,6 @@ func (h *V1alpha1Client) GetCloudAccountsVsphere() ([]*models.V1alpha1VsphereAcc
 	return accounts, nil
 }
 
-
 func (h *V1alpha1Client) GetCloudConfigVsphere(configUID string) (*models.V1alpha1VsphereCloudConfig, error) {
 	client, err := h.getClusterClient()
 	if err != nil {
@@ -166,4 +164,23 @@ func (h *V1alpha1Client) GetCloudConfigVsphere(configUID string) (*models.V1alph
 	}
 
 	return success.Payload, nil
+}
+
+func (h *V1alpha1Client) ImportClusterVsphere(meta *models.V1ObjectMetaInputEntity) (string, error) {
+	client, err := h.getClusterClient()
+	if err != nil {
+		return "", err
+	}
+
+	params := clusterC.NewV1alpha1SpectroClustersVsphereImportParamsWithContext(h.ctx).WithBody(
+		&models.V1alpha1SpectroVsphereClusterImportEntity{
+			Metadata: meta,
+		},
+	)
+	success, err := client.V1alpha1SpectroClustersVsphereImport(params)
+	if err != nil {
+		return "", err
+	}
+
+	return *success.Payload.UID, nil
 }

--- a/pkg/client/private_cloud_gateway.go
+++ b/pkg/client/private_cloud_gateway.go
@@ -1,0 +1,66 @@
+package client
+
+import (
+	"github.com/spectrocloud/hapi/apiutil"
+	"github.com/spectrocloud/hapi/models"
+
+	clusterC "github.com/spectrocloud/hapi/spectrocluster/client/v1alpha1"
+)
+
+func (h *V1alpha1Client) CreateIpPool(pcgUID string, pool *models.V1alpha1IPPoolInputEntity) (string, error) {
+	client, err := h.getClusterClient()
+	if err != nil {
+		return "", nil
+	}
+
+	params := clusterC.NewV1alpha1OverlordsUIDPoolCreateParams().WithUID(pcgUID).WithBody(pool)
+	if resp, err := client.V1alpha1OverlordsUIDPoolCreate(params); err != nil {
+		return "", err
+	} else {
+		return *resp.Payload.UID, nil
+	}
+}
+
+func (h *V1alpha1Client) GetIpPool(pcgUID, poolUID string) (*models.V1alpha1IPPoolEntity, error) {
+	client, err := h.getClusterClient()
+	if err != nil {
+		return nil, err
+	}
+
+	params := clusterC.NewV1alpha1OverlordsUIDPoolsListParams().WithUID(pcgUID)
+	if listResp, err := client.V1alpha1OverlordsUIDPoolsList(params); err != nil {
+		if v1Err := apiutil.ToV1ErrorObj(err); v1Err.Code != "ResourceNotFound" {
+			return nil, err
+		}
+	} else if listResp.Payload != nil && listResp.Payload.Items != nil {
+		for _, pool := range listResp.Payload.Items {
+			if p := *pool; pool.Metadata.UID == poolUID {
+				return &p, nil
+			}
+		}
+	}
+	return nil, nil
+}
+
+func (h *V1alpha1Client) UpdateIpPool(pcgUID, poolUID string, pool *models.V1alpha1IPPoolInputEntity) error {
+	client, err := h.getClusterClient()
+	if err != nil {
+		return nil
+	}
+
+	params := clusterC.NewV1alpha1OverlordsUIDPoolUpdateParams().WithUID(pcgUID).
+		WithBody(pool).WithPoolUID(poolUID)
+	_, err = client.V1alpha1OverlordsUIDPoolUpdate(params)
+	return err
+}
+
+func (h *V1alpha1Client) DeleteIpPool(pcgUID, poolUID string) error {
+	client, err := h.getClusterClient()
+	if err != nil {
+		return nil
+	}
+
+	params := clusterC.NewV1alpha1OverlordsUIDPoolDeleteParams().WithUID(pcgUID).WithPoolUID(poolUID)
+	_, err = client.V1alpha1OverlordsUIDPoolDelete(params)
+	return err
+}

--- a/spectrocloud/cluster_common.go
+++ b/spectrocloud/cluster_common.go
@@ -4,17 +4,22 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/spectrocloud/gomi/pkg/ptr"
-	"github.com/spectrocloud/hapi/models"
-	"github.com/spectrocloud/terraform-provider-spectrocloud/pkg/client"
 	"hash/fnv"
 	"log"
 	"time"
-)
 
+	"github.com/go-openapi/strfmt"
+
+	"emperror.dev/errors"
+	"github.com/hashicorp/go-cty/cty"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/robfig/cron"
+	"github.com/spectrocloud/gomi/pkg/ptr"
+	"github.com/spectrocloud/hapi/models"
+	"github.com/spectrocloud/terraform-provider-spectrocloud/pkg/client"
+)
 
 var (
 	DefaultDiskType = "Standard_LRS"
@@ -60,8 +65,8 @@ func toPack(pSrc interface{}) *models.V1alpha1PackValuesEntity {
 
 	pack := &models.V1alpha1PackValuesEntity{
 		Name:   ptr.StringPtr(p["name"].(string)),
-		Tag:   ptr.StringPtr(p["tag"].(string)),
-		Values:   p["values"].(string),
+		Tag:    ptr.StringPtr(p["tag"].(string)),
+		Values: p["values"].(string),
 	}
 	return pack
 }
@@ -184,4 +189,66 @@ func hash(s string) uint32 {
 	h := fnv.New32a()
 	h.Write([]byte(s))
 	return h.Sum32()
+}
+
+func toClusterConfig(d *schema.ResourceData) *models.V1alpha1ClusterConfig {
+	return &models.V1alpha1ClusterConfig{
+		MachineManagementConfig: toMachineManagementConfig(d),
+	}
+}
+
+func toMachineManagementConfig(d *schema.ResourceData) *models.V1alpha1MachineManagementConfig {
+	return &models.V1alpha1MachineManagementConfig{
+		OsPatchConfig: toOsPatchConfig(d),
+	}
+}
+
+func toOsPatchConfig(d *schema.ResourceData) *models.V1alpha1OsPatchConfig {
+	osPatchOnBoot := d.Get("os_patch_on_boot").(bool)
+	osPatchOnSchedule := d.Get("os_patch_schedule").(string)
+	osPatchAfter := d.Get("os_patch_after").(string)
+	if osPatchOnBoot || len(osPatchOnSchedule) > 0 || len(osPatchAfter) > 0 {
+		osPatchConfig := &models.V1alpha1OsPatchConfig{}
+		if osPatchOnBoot {
+			osPatchConfig.PatchOnBoot = osPatchOnBoot
+		}
+		if len(osPatchOnSchedule) > 0 {
+			osPatchConfig.Schedule = osPatchOnSchedule
+		}
+		if len(osPatchAfter) > 0 {
+			dateTime, _ := strfmt.ParseDateTime(osPatchAfter)
+			osPatchConfig.OnDemandPatchAfter = dateTime
+		} else {
+			//setting Zero time in request
+			zeroTime, _ := strfmt.ParseDateTime("0001-01-01T00:00:00.000Z")
+			osPatchConfig.OnDemandPatchAfter = zeroTime
+		}
+		return osPatchConfig
+	}
+	return nil
+}
+
+func validateOsPatchSchedule(data interface{}, path cty.Path) diag.Diagnostics {
+	var diags diag.Diagnostics
+	if data != nil {
+		if _, err := cron.ParseStandard(data.(string)); err != nil {
+			return diag.FromErr(errors.Wrap(err, "os patch schedule is invalid. Please see https://en.wikipedia.org/wiki/Cron for valid cron syntax"))
+		}
+	}
+	return diags
+}
+
+func validateOsPatchOnDemandAfter(data interface{}, path cty.Path) diag.Diagnostics {
+	var diags diag.Diagnostics
+	if data != nil {
+		if patchTime, err := time.Parse(time.RFC3339, data.(string)); err != nil {
+			return diag.FromErr(errors.Wrap(err, "time for 'os_patch_after' is invalid. Please follow RFC3339 Date and Time Standards. Eg 2021-01-01T00:00:00.000Z "))
+		} else {
+			if time.Now().After(patchTime.Add(10 * time.Minute)) {
+				return diag.FromErr(fmt.Errorf("valid timestamp is timestamp which is 10 mins ahead of current timestamp. Eg any timestamp ahead of %v", time.Now().Add(10*time.Minute).Format(time.RFC3339)))
+			}
+		}
+	}
+
+	return diags
 }

--- a/spectrocloud/provider.go
+++ b/spectrocloud/provider.go
@@ -3,8 +3,9 @@ package spectrocloud
 import (
 	"context"
 	"crypto/tls"
-	"github.com/spectrocloud/terraform-provider-spectrocloud/pkg/client"
 	"net/http"
+
+	"github.com/spectrocloud/terraform-provider-spectrocloud/pkg/client"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -40,7 +41,7 @@ func New(_ string) func() *schema.Provider {
 				},
 			},
 			ResourcesMap: map[string]*schema.Resource{
-				"spectrocloud_cluster_profile":    resourceClusterProfile(),
+				"spectrocloud_cluster_profile": resourceClusterProfile(),
 
 				"spectrocloud_cloudaccount_aws": resourceCloudAccountAws(),
 				"spectrocloud_cluster_aws":      resourceClusterAws(),
@@ -51,16 +52,20 @@ func New(_ string) func() *schema.Provider {
 				"spectrocloud_cloudaccount_gcp": resourceCloudAccountGcp(),
 				"spectrocloud_cluster_gcp":      resourceClusterGcp(),
 
-				"spectrocloud_cluster_vsphere":    resourceClusterVsphere(),
+				"spectrocloud_cluster_vsphere": resourceClusterVsphere(),
+
+				"spectrocloud_cluster_import": resourceClusterImport(),
+
+				"spectrocloud_privatecloudgateway_ippool": resourcePrivateCloudGatewayIpPool(),
 			},
 			DataSourcesMap: map[string]*schema.Resource{
 				"spectrocloud_pack": dataSourcePack(),
 
 				"spectrocloud_cluster_profile": dataSourceClusterProfile(),
 
-				"spectrocloud_cloudaccount_aws": dataSourceCloudAccountAws(),
-				"spectrocloud_cloudaccount_azure": dataSourceCloudAccountAzure(),
-				"spectrocloud_cloudaccount_gcp": dataSourceCloudAccountGcp(),
+				"spectrocloud_cloudaccount_aws":     dataSourceCloudAccountAws(),
+				"spectrocloud_cloudaccount_azure":   dataSourceCloudAccountAzure(),
+				"spectrocloud_cloudaccount_gcp":     dataSourceCloudAccountGcp(),
 				"spectrocloud_cloudaccount_vsphere": dataSourceCloudAccountVsphere(),
 			},
 			ConfigureContextFunc: providerConfigure,

--- a/spectrocloud/resource_cluster_aws.go
+++ b/spectrocloud/resource_cluster_aws.go
@@ -2,14 +2,15 @@ package spectrocloud
 
 import (
 	"context"
+	"log"
+	"time"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/spectrocloud/gomi/pkg/ptr"
 	"github.com/spectrocloud/hapi/models"
 	"github.com/spectrocloud/terraform-provider-spectrocloud/pkg/client"
-	"log"
-	"time"
 )
 
 func resourceClusterAws() *schema.Resource {
@@ -45,6 +46,20 @@ func resourceClusterAws() *schema.Resource {
 			"cloud_config_id": {
 				Type:     schema.TypeString,
 				Computed: true,
+			},
+			"os_patch_on_boot": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+			"os_patch_schedule": {
+				Type:             schema.TypeString,
+				Optional:         true,
+				ValidateDiagFunc: validateOsPatchSchedule,
+			},
+			"os_patch_after": {
+				Type:             schema.TypeString,
+				Optional:         true,
+				ValidateDiagFunc: validateOsPatchOnDemandAfter,
 			},
 			"kubeconfig": {
 				Type:     schema.TypeString,
@@ -166,7 +181,7 @@ func resourceClusterAwsCreate(ctx context.Context, d *schema.ResourceData, m int
 		Pending:    resourceClusterCreatePendingStates,
 		Target:     []string{"Running"},
 		Refresh:    resourceClusterStateRefreshFunc(c, d.Id()),
-		Timeout:    d.Timeout(schema.TimeoutCreate) - 1 * time.Minute,
+		Timeout:    d.Timeout(schema.TimeoutCreate) - 1*time.Minute,
 		MinTimeout: 10 * time.Second,
 		Delay:      30 * time.Second,
 	}
@@ -207,20 +222,36 @@ func resourceClusterAwsRead(_ context.Context, d *schema.ResourceData, m interfa
 		return diag.FromErr(err)
 	}
 
-	mp := flattenMachinePoolConfigsAws(config.Spec.MachinePoolConfig)
-	if err := d.Set("machine_pool", mp); err != nil {
-		return diag.FromErr(err)
-	}
-
 	// Update the kubeconfig
-	kubeconfig, err := c.GetClusterKubeConfig(uid)
-	if err != nil {
-		return diag.FromErr(err)
-	}
-	if err := d.Set("kubeconfig", kubeconfig); err != nil {
-		return diag.FromErr(err)
+	if cluster.Status != nil && cluster.Status.ClusterImport != nil && cluster.Status.ClusterImport.IsBrownfield {
+		if err := d.Set("cluster_import_manifest_apply_command", cluster.Status.ClusterImport.ImportLink); err != nil {
+			return diag.FromErr(err)
+		}
+
+		importManifest, err := c.GetClusterImportManifest(uid)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+		if err := d.Set("cluster_import_manifest", importManifest); err != nil {
+			return diag.FromErr(err)
+		}
+	} else {
+		kubecfg, err := c.GetClusterKubeConfig(uid)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+		if err := d.Set("kubeconfig", kubecfg); err != nil {
+			return diag.FromErr(err)
+		}
 	}
 
+	//for brownfield, until cluster is not in running state, don't get machine pool
+	if cluster.Status.ClusterImport == nil || cluster.Status.State == "Running" {
+		mp := flattenMachinePoolConfigsAws(config.Spec.MachinePoolConfig)
+		if err := d.Set("machine_pool", mp); err != nil {
+			return diag.FromErr(err)
+		}
+	}
 	return diags
 }
 
@@ -342,10 +373,10 @@ func toAwsCluster(d *schema.ResourceData) *models.V1alpha1SpectroAwsClusterEntit
 		},
 		Spec: &models.V1alpha1SpectroAwsClusterEntitySpec{
 			CloudAccountUID: ptr.StringPtr(d.Get("cloud_account_id").(string)),
-			ProfileUID:      ptr.StringPtr(d.Get("cluster_profile_id").(string)),
+			ProfileUID:      d.Get("cluster_profile_id").(string),
 			CloudConfig: &models.V1alpha1AwsClusterConfig{
 				SSHKeyName: cloudConfig["ssh_key_name"].(string),
-				Region:  ptr.StringPtr(cloudConfig["region"].(string)),
+				Region:     ptr.StringPtr(cloudConfig["region"].(string)),
 			},
 		},
 	}
@@ -365,6 +396,7 @@ func toAwsCluster(d *schema.ResourceData) *models.V1alpha1SpectroAwsClusterEntit
 		packValues = append(packValues, p)
 	}
 	cluster.Spec.PackValues = packValues
+	cluster.Spec.ClusterConfig = toClusterConfig(d)
 
 	return cluster
 }

--- a/spectrocloud/resource_cluster_azure.go
+++ b/spectrocloud/resource_cluster_azure.go
@@ -2,14 +2,15 @@ package spectrocloud
 
 import (
 	"context"
+	"log"
+	"time"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/spectrocloud/gomi/pkg/ptr"
 	"github.com/spectrocloud/hapi/models"
 	"github.com/spectrocloud/terraform-provider-spectrocloud/pkg/client"
-	"log"
-	"time"
 )
 
 func resourceClusterAzure() *schema.Resource {
@@ -45,6 +46,20 @@ func resourceClusterAzure() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"os_patch_on_boot": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+			"os_patch_schedule": {
+				Type:             schema.TypeString,
+				Optional:         true,
+				ValidateDiagFunc: validateOsPatchSchedule,
+			},
+			"os_patch_after": {
+				Type:             schema.TypeString,
+				Optional:         true,
+				ValidateDiagFunc: validateOsPatchOnDemandAfter,
+			},
 			"kubeconfig": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -75,7 +90,7 @@ func resourceClusterAzure() *schema.Resource {
 					},
 				},
 			},
-			"pack" : {
+			"pack": {
 				Type:     schema.TypeSet,
 				Optional: true,
 				Set:      resourcePackHash,
@@ -99,7 +114,7 @@ func resourceClusterAzure() *schema.Resource {
 			"machine_pool": {
 				Type:     schema.TypeSet,
 				Required: true,
-				Set :     resourceMachinePoolAzureHash,
+				Set:      resourceMachinePoolAzureHash,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"control_plane": {
@@ -205,7 +220,7 @@ func resourceClusterAzureCreate(ctx context.Context, d *schema.ResourceData, m i
 		Pending:    resourceClusterCreatePendingStates,
 		Target:     []string{"Running"},
 		Refresh:    resourceClusterStateRefreshFunc(c, d.Id()),
-		Timeout:    d.Timeout(schema.TimeoutCreate) - 1 * time.Minute,
+		Timeout:    d.Timeout(schema.TimeoutCreate) - 1*time.Minute,
 		MinTimeout: 10 * time.Second,
 		Delay:      30 * time.Second,
 	}
@@ -246,21 +261,36 @@ func resourceClusterAzureRead(_ context.Context, d *schema.ResourceData, m inter
 		return diag.FromErr(err)
 	}
 
-
-	mp := flattenMachinePoolConfigsAzure(config.Spec.MachinePoolConfig)
-	if err := d.Set("machine_pool", mp); err != nil {
-		return diag.FromErr(err)
-	}
-
 	// Update the kubeconfig
-	kubeconfig, err := c.GetClusterKubeConfig(uid)
-	if err != nil {
-		return diag.FromErr(err)
-	}
-	if err := d.Set("kubeconfig", kubeconfig); err != nil {
-		return diag.FromErr(err)
+	if cluster.Status != nil && cluster.Status.ClusterImport != nil && cluster.Status.ClusterImport.IsBrownfield {
+		if err := d.Set("cluster_import_manifest_apply_command", cluster.Status.ClusterImport.ImportLink); err != nil {
+			return diag.FromErr(err)
+		}
+
+		importManifest, err := c.GetClusterImportManifest(uid)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+		if err := d.Set("cluster_import_manifest", importManifest); err != nil {
+			return diag.FromErr(err)
+		}
+	} else {
+		kubecfg, err := c.GetClusterKubeConfig(uid)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+		if err := d.Set("kubeconfig", kubecfg); err != nil {
+			return diag.FromErr(err)
+		}
 	}
 
+	//for brownfield, until cluster is not in running state, don't get machine pool
+	if cluster.Status.ClusterImport == nil || cluster.Status.State == "Running" {
+		mp := flattenMachinePoolConfigsAzure(config.Spec.MachinePoolConfig)
+		if err := d.Set("machine_pool", mp); err != nil {
+			return diag.FromErr(err)
+		}
+	}
 	return diags
 }
 
@@ -388,7 +418,7 @@ func toAzureCluster(d *schema.ResourceData) *models.V1alpha1SpectroAzureClusterE
 		},
 		Spec: &models.V1alpha1SpectroAzureClusterEntitySpec{
 			CloudAccountUID: ptr.StringPtr(d.Get("cloud_account_id").(string)),
-			ProfileUID:      ptr.StringPtr(d.Get("cluster_profile_id").(string)),
+			ProfileUID:      d.Get("cluster_profile_id").(string),
 			CloudConfig: &models.V1alpha1AzureClusterConfig{
 				Location:       ptr.StringPtr(cloudConfig["region"].(string)),
 				SSHKey:         ptr.StringPtr(cloudConfig["ssh_key"].(string)),
@@ -413,6 +443,7 @@ func toAzureCluster(d *schema.ResourceData) *models.V1alpha1SpectroAzureClusterE
 		packValues = append(packValues, p)
 	}
 	cluster.Spec.PackValues = packValues
+	cluster.Spec.ClusterConfig = toClusterConfig(d)
 
 	return cluster
 }
@@ -465,4 +496,3 @@ func toMachinePoolAzure(machinePool interface{}) *models.V1alpha1AzureMachinePoo
 	}
 	return mp
 }
-

--- a/spectrocloud/resource_cluster_import.go
+++ b/spectrocloud/resource_cluster_import.go
@@ -1,0 +1,223 @@
+package spectrocloud
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/hashicorp/go-cty/cty"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/spectrocloud/hapi/models"
+	"github.com/spectrocloud/terraform-provider-spectrocloud/pkg/client"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func resourceClusterImport() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceCloudClusterImport,
+		ReadContext:   resourceCloudClusterRead,
+		UpdateContext: resourceCloudClusterUpdate,
+		DeleteContext: resourceClusterDelete,
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(10 * time.Minute),
+			Update: schema.DefaultTimeout(10 * time.Minute),
+			Delete: schema.DefaultTimeout(10 * time.Minute),
+		},
+
+		SchemaVersion: 2,
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"cloud": {
+				Type:             schema.TypeString,
+				ForceNew:         true,
+				Required:         true,
+				ValidateDiagFunc: validateCloudType,
+			},
+			"cloud_config_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"cluster_import_manifest_apply_command": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"cluster_import_manifest": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"cluster_profile_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"pack": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Set:      resourcePackHash,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"tag": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"values": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func resourceCloudClusterImport(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	c := m.(*client.V1alpha1Client)
+	var diags diag.Diagnostics
+	uid, err := cloudClusterImportFunc(c, d)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	d.SetId(uid)
+	stateConf := &resource.StateChangeConf{
+		Target:     []string{"Pending"},
+		Refresh:    resourceClusterStateRefreshFunc(c, d.Id()),
+		Timeout:    d.Timeout(schema.TimeoutCreate) - 1*time.Minute,
+		MinTimeout: 1 * time.Second,
+		Delay:      5 * time.Second,
+	}
+
+	// Wait, catching any errors
+	_, err = stateConf.WaitForStateContext(ctx)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	cloudClusterReadFunc(ctx, d, m)
+
+	if profiles := toCloudClusterProfiles(d); profiles != nil {
+		if err := c.UpdateBrownfieldCluster(uid, profiles); err != nil {
+			return diag.FromErr(err)
+		}
+	}
+	return diags
+}
+
+func resourceCloudClusterRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	cloudType := d.Get("cloud").(string)
+	switch cloudType {
+	case "aws":
+		return resourceClusterAwsRead(ctx, d, m)
+	case "azure":
+		return resourceClusterAzureRead(ctx, d, m)
+	case "gcp":
+		return resourceClusterGcpRead(ctx, d, m)
+	case "vsphere":
+		return resourceClusterVsphereRead(ctx, d, m)
+	}
+	return diag.FromErr(fmt.Errorf("failed to import cluster as cloud type '%s' is invalid", cloudType))
+}
+
+func cloudClusterImportFunc(c *client.V1alpha1Client, d *schema.ResourceData) (string, error) {
+	meta := toClusterMeta(d)
+	cloudType := d.Get("cloud").(string)
+	switch cloudType {
+	case "aws":
+		return c.ImportClusterAws(meta)
+	case "azure":
+		return c.ImportClusterAzure(meta)
+	case "gcp":
+		return c.ImportClusterGcp(meta)
+	case "vsphere":
+		return c.ImportClusterVsphere(meta)
+	}
+	return "", fmt.Errorf("failed to find cloud type %s", cloudType)
+}
+
+func cloudClusterReadFunc(ctx context.Context, d *schema.ResourceData, m interface{}) {
+	cloudType := d.Get("cloud").(string)
+	switch cloudType {
+	case "aws":
+		resourceClusterAwsRead(ctx, d, m)
+	case "azure":
+		resourceClusterAzureRead(ctx, d, m)
+	case "gcp":
+		resourceClusterGcpRead(ctx, d, m)
+	case "vsphere":
+		resourceClusterVsphereRead(ctx, d, m)
+	}
+}
+
+func resourceCloudClusterUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	c := m.(*client.V1alpha1Client)
+	var diags diag.Diagnostics
+
+	clusterProfileId := d.Get("cluster_profile_id").(string)
+	profiles := make([]*models.V1alpha1SpectroClusterProfileEntity, 0)
+	packValues := make([]*models.V1alpha1PackValuesEntity, 0)
+	for _, pack := range d.Get("pack").(*schema.Set).List() {
+		p := toPack(pack)
+		packValues = append(packValues, p)
+	}
+
+	profiles = append(profiles, &models.V1alpha1SpectroClusterProfileEntity{
+		PackValues: packValues,
+		UID:        clusterProfileId,
+	})
+
+	err := c.UpdateBrownfieldCluster("", &models.V1alpha1SpectroClusterProfiles{
+		Profiles: profiles,
+	})
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	return diags
+}
+
+func toCloudClusterProfiles(d *schema.ResourceData) *models.V1alpha1SpectroClusterProfiles {
+	if clusterProfileUid := d.Get("cluster_profile_id"); clusterProfileUid != nil {
+		profileEntities := make([]*models.V1alpha1SpectroClusterProfileEntity, 0)
+		packValues := make([]*models.V1alpha1PackValuesEntity, 0)
+		for _, pack := range d.Get("pack").(*schema.Set).List() {
+			p := toPack(pack)
+			packValues = append(packValues, p)
+		}
+
+		profileEntities = append(profileEntities, &models.V1alpha1SpectroClusterProfileEntity{
+			PackValues: packValues,
+			UID:        clusterProfileUid.(string),
+		})
+		return &models.V1alpha1SpectroClusterProfiles{
+			Profiles: profileEntities,
+		}
+	}
+	return nil
+}
+
+func validateCloudType(data interface{}, path cty.Path) diag.Diagnostics {
+	var diags diag.Diagnostics
+	inCloudType := data.(string)
+	for _, cloudType := range []string{"aws", "azure", "gcp", "vsphere"} {
+		if cloudType == inCloudType {
+			return diags
+		}
+	}
+	return diag.FromErr(fmt.Errorf("cloud type '%s' is invalid. valid cloud types are %v", inCloudType, "cloud_types"))
+}
+
+func toClusterMeta(d *schema.ResourceData) *models.V1ObjectMetaInputEntity {
+	return &models.V1ObjectMetaInputEntity{
+		Name: d.Get("name").(string),
+	}
+}

--- a/spectrocloud/resource_pcg_ippool.go
+++ b/spectrocloud/resource_pcg_ippool.go
@@ -1,0 +1,228 @@
+package spectrocloud
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/go-cty/cty"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/spectrocloud/hapi/models"
+	"github.com/spectrocloud/terraform-provider-spectrocloud/pkg/client"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func resourcePrivateCloudGatewayIpPool() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceIpPoolCreate,
+		ReadContext:   resourceIpPoolRead,
+		UpdateContext: resourceIpPoolUpdate,
+		DeleteContext: resourceIpPoolDelete,
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(10 * time.Minute),
+			Update: schema.DefaultTimeout(10 * time.Minute),
+			Delete: schema.DefaultTimeout(10 * time.Minute),
+		},
+
+		SchemaVersion: 2,
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"private_cloud_gateway_id": {
+				Type:     schema.TypeString,
+				ForceNew: true,
+				Required: true,
+			},
+			"network_type": {
+				Type:             schema.TypeString,
+				Required:         true,
+				ValidateDiagFunc: validateNetworkType,
+			},
+			"ip_start_range": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"ip_end_range": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"subnet_cidr": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"prefix": {
+				Type:     schema.TypeInt,
+				Required: true,
+			},
+			"gateway": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"nameserver_addresses": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"nameserver_search_suffix": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"restrict_to_single_cluster": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
+		},
+	}
+}
+
+func resourceIpPoolCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	c := m.(*client.V1alpha1Client)
+	var diags diag.Diagnostics
+	pcgUID := d.Get("private_cloud_gateway_id").(string)
+
+	pool := toIpPool(d)
+
+	uid, err := c.CreateIpPool(pcgUID, pool)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	d.SetId(uid)
+
+	return diags
+}
+
+func resourceIpPoolRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	c := m.(*client.V1alpha1Client)
+	var diags diag.Diagnostics
+
+	pcgUID := d.Get("private_cloud_gateway_id").(string)
+
+	pool, err := c.GetIpPool(pcgUID, d.Id())
+	if err != nil {
+		return diag.FromErr(err)
+	} else if pool == nil {
+		// Deleted - Terraform will recreate it
+		d.SetId("")
+		return diags
+	}
+
+	if err := d.Set("name", pool.Metadata.Name); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("gateway", pool.Spec.Pool.Gateway); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("prefix", pool.Spec.Pool.Prefix); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("restrict_to_single_cluster", pool.Spec.RestrictToSingleCluster); err != nil {
+		return diag.FromErr(err)
+	}
+
+	if len(pool.Spec.Pool.Subnet) > 0 {
+		if err := d.Set("subnet_cidr", pool.Spec.Pool.Subnet); err != nil {
+			return diag.FromErr(err)
+		}
+	} else {
+		if err := d.Set("ip_start_range", pool.Spec.Pool.Start); err != nil {
+			return diag.FromErr(err)
+		}
+		if err := d.Set("ip_end_range", pool.Spec.Pool.End); err != nil {
+			return diag.FromErr(err)
+		}
+	}
+
+	if pool.Spec.Pool.Nameserver != nil && len(pool.Spec.Pool.Nameserver.Addresses) > 0 {
+		if err := d.Set("nameserver_addresses", strings.Join(pool.Spec.Pool.Nameserver.Addresses, ",")); err != nil {
+			return diag.FromErr(err)
+		}
+	} else if pool.Spec.Pool.Nameserver != nil && len(pool.Spec.Pool.Nameserver.Search) > 0 {
+		if err := d.Set("nameserver_search_suffix", strings.Join(pool.Spec.Pool.Nameserver.Search, ",")); err != nil {
+			return diag.FromErr(err)
+		}
+	}
+
+	return diags
+}
+
+func resourceIpPoolUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	c := m.(*client.V1alpha1Client)
+	var diags diag.Diagnostics
+
+	pcgUID := d.Get("private_cloud_gateway_id").(string)
+
+	pool := toIpPool(d)
+
+	err := c.UpdateIpPool(pcgUID, d.Id(), pool)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	return diags
+}
+
+func resourceIpPoolDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	c := m.(*client.V1alpha1Client)
+	var diags diag.Diagnostics
+
+	pcgUID := d.Get("private_cloud_gateway_id").(string)
+
+	err := c.DeleteIpPool(pcgUID, d.Id())
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	return diags
+}
+
+func toIpPool(d *schema.ResourceData) *models.V1alpha1IPPoolInputEntity {
+	pool := &models.V1alpha1Pool{
+		Gateway:    d.Get("gateway").(string),
+		Nameserver: &models.V1alpha1Nameserver{},
+		Prefix:     int32(d.Get("prefix").(int)),
+	}
+
+	if d.Get("network_type").(string) == "range" {
+		pool.Start = d.Get("ip_start_range").(string)
+		pool.End = d.Get("ip_end_range").(string)
+	} else {
+		pool.Subnet = d.Get("subnet_cidr").(string)
+	}
+
+	if d.Get("nameserver_addresses") != nil {
+		pool.Nameserver.Addresses = strings.Split(d.Get("nameserver_addresses").(string), ",")
+	}
+
+	if d.Get("nameserver_search_suffix") != nil {
+		pool.Nameserver.Search = strings.Split(d.Get("nameserver_search_suffix").(string), ",")
+	}
+
+	return &models.V1alpha1IPPoolInputEntity{
+		Metadata: &models.V1ObjectMeta{
+			Name: d.Get("name").(string),
+			UID:  d.Id(),
+		},
+		Spec: &models.V1alpha1IPPoolInputEntitySpec{
+			Pool:                    pool,
+			RestrictToSingleCluster: d.Get("restrict_to_single_cluster").(bool),
+		},
+	}
+}
+
+func validateNetworkType(data interface{}, path cty.Path) diag.Diagnostics {
+	var diags diag.Diagnostics
+	networkType := data.(string)
+	for _, nwType := range []string{"range", "subnet"} {
+		if nwType == networkType {
+			return diags
+		}
+	}
+	return diag.FromErr(fmt.Errorf("network type '%s' is invalid. valid network types are 'range' and 'subnet'", networkType))
+}


### PR DESCRIPTION
- [x] Added `spectrocloud_cluster_import` resource, example and docs
- [x] Added `spectrocloud_privatecloudgateway_ippool` resource, example and docs
- [x] Added `os_patch_on_boot`, `os_patch_schedule`& `os_patch_after` in cluster for aws, gcp, azure, vsphere and adding validation function for os_patch_schedule & os_patch_after and adding it in docs

Docs:
[spectrocloud_privatecloudgateway_ippool](https://github.com/spectrocloud/terraform-provider-spectrocloud/blob/ipool-import-resource/docs/resources/privatecloudgateway_ippool.md)
[spectrocloud_cluster_import](https://github.com/spectrocloud/terraform-provider-spectrocloud/blob/ipool-import-resource/docs/resources/cluster_import.md)

@saamalik Please Review