### PR TITLE
backup_storage_location & backup and scan policy changes

### DIFF
--- a/docs/data-sources/backup_storage_location.md
+++ b/docs/data-sources/backup_storage_location.md
@@ -1,0 +1,21 @@
+---
+page_title: "spectrocloud_backup_storage_location Data Source - terraform-provider-spectrocloud"
+subcategory: ""
+description: |-
+  
+---
+
+# Data Source `spectrocloud_backup_storage_location`
+
+
+
+
+
+## Schema
+
+### Optional
+
+- **id** (String) The ID of this resource.
+- **name** (String)
+
+

--- a/docs/index.md
+++ b/docs/index.md
@@ -46,11 +46,11 @@ provider "spectrocloud" {
 Create or append to a `terraform.tfvars` file:
 
 ```terraform
-# Credentials
-host         = "console.spectrocloud.com"
-username     = "user1@abc.com" # Username of the user (or specify with SPECTROCLOUD_USERNAME env var)
-password     = "superSecure1!" # Password of the user (or specify with SPECTROCLOUD_PASSWORD env var)
-project_name = "Default"       # Project name (e.g: Default)
+# Spectro Cloud credentials
+sc_host         = "{enter Spectro Cloud API endpoint}" #e.g: api.spectrocloud.com (for SaaS)
+sc_username     = "{enter Spectro Cloud username}"     #e.g: user1@abc.com
+sc_password     = "{enter Spectro Cloud password}"     #e.g: supereSecure1!
+sc_project_name = "{enter Spectro Cloud project Name}" #e.g: Default
 ```
 
 ->

--- a/docs/resources/backup_storage_location.md
+++ b/docs/resources/backup_storage_location.md
@@ -1,0 +1,87 @@
+---
+page_title: "spectrocloud_backup_storage_location Resource - terraform-provider-spectrocloud"
+subcategory: ""
+description: |-
+  
+---
+
+# Resource `spectrocloud_backup_storage_location`
+
+
+
+## Example Usage
+
+```terraform
+resource "spectrocloud_backup_storage_location" "bsl1" {
+  name        = "dev-backup-s3"
+  is_default  = false
+  region      = "us-east-2"
+  bucket_name = "dev-backup"
+  s3 {
+    credential_type     = var.credential_type
+    access_key          = var.aws_access_key
+    secret_key          = var.aws_secret_key
+    s3_force_path_style = false
+
+    #s3_url             = "http://10.90.78.23"
+  }
+}
+
+resource "spectrocloud_backup_storage_location" "bsl2" {
+  name        = "prod-backup-s3"
+  is_default  = false
+  region      = "us-east-2"
+  bucket_name = "prod-backup"
+  s3 {
+    credential_type     = var.credential_type
+    arn                 = var.arn
+    external_id         = var.external_id
+    s3_force_path_style = false
+    #s3_url             = "http://10.90.78.23"
+  }
+}
+```
+
+## Schema
+
+### Required
+
+- **bucket_name** (String)
+- **is_default** (Boolean)
+- **name** (String)
+- **region** (String)
+- **s3** (Block List, Min: 1, Max: 1) (see [below for nested schema](#nestedblock--s3))
+
+### Optional
+
+- **ca_cert** (String)
+- **id** (String) The ID of this resource.
+- **timeouts** (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
+
+<a id="nestedblock--s3"></a>
+### Nested Schema for `s3`
+
+Required:
+
+- **credential_type** (String)
+
+Optional:
+
+- **access_key** (String)
+- **arn** (String)
+- **external_id** (String)
+- **s3_force_path_style** (Boolean)
+- **s3_url** (String)
+- **secret_key** (String)
+
+
+<a id="nestedblock--timeouts"></a>
+### Nested Schema for `timeouts`
+
+Optional:
+
+- **create** (String)
+- **delete** (String)
+- **update** (String)
+
+

--- a/docs/resources/cluster_aws.md
+++ b/docs/resources/cluster_aws.md
@@ -23,6 +23,10 @@ data "spectrocloud_cluster_profile" "profile" {
 }
 
 
+data "spectrocloud_backup_storage_location" "bsl" {
+  name = var.backup_storage_location_name
+}
+
 resource "spectrocloud_cluster_aws" "cluster" {
   name             = var.cluster_name
   cloud_account_id = data.spectrocloud_cloudaccount_aws.account.id
@@ -56,6 +60,21 @@ resource "spectrocloud_cluster_aws" "cluster" {
     # }
   }
 
+  backup_policy {
+    schedule                  = "0 0 * * SUN"
+    backup_location_id        = data.spectrocloud_backup_storage_location.bsl.id
+    prefix                    = "prod-backup"
+    expiry_in_hour            = 7200
+    include_disks             = true
+    include_cluster_resources = true
+  }
+
+  scan_policy {
+    configuration_scan_schedule = "0 0 * * SUN"
+    penetration_scan_schedule   = "0 0 * * SUN"
+    conformance_scan_schedule   = "0 0 1 * *"
+  }
+
   machine_pool {
     control_plane           = true
     control_plane_as_worker = true
@@ -86,6 +105,7 @@ resource "spectrocloud_cluster_aws" "cluster" {
 
 ### Optional
 
+- **backup_policy** (Block List, Max: 1) (see [below for nested schema](#nestedblock--backup_policy))
 - **cloud_account_id** (String)
 - **cluster_profile** (Block List) (see [below for nested schema](#nestedblock--cluster_profile))
 - **cluster_profile_id** (String, Deprecated)
@@ -94,6 +114,7 @@ resource "spectrocloud_cluster_aws" "cluster" {
 - **os_patch_on_boot** (Boolean)
 - **os_patch_schedule** (String)
 - **pack** (Block List) (see [below for nested schema](#nestedblock--pack))
+- **scan_policy** (Block List, Max: 1) (see [below for nested schema](#nestedblock--scan_policy))
 - **timeouts** (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
 
 ### Read-only
@@ -128,6 +149,23 @@ Optional:
 - **update_strategy** (String)
 
 
+<a id="nestedblock--backup_policy"></a>
+### Nested Schema for `backup_policy`
+
+Required:
+
+- **backup_location_id** (String)
+- **expiry_in_hour** (Number)
+- **prefix** (String)
+- **schedule** (String)
+
+Optional:
+
+- **include_cluster_resources** (Boolean)
+- **include_disks** (Boolean)
+- **namespaces** (Set of String)
+
+
 <a id="nestedblock--cluster_profile"></a>
 ### Nested Schema for `cluster_profile`
 
@@ -158,6 +196,16 @@ Required:
 - **name** (String)
 - **tag** (String)
 - **values** (String)
+
+
+<a id="nestedblock--scan_policy"></a>
+### Nested Schema for `scan_policy`
+
+Required:
+
+- **configuration_scan_schedule** (String)
+- **conformance_scan_schedule** (String)
+- **penetration_scan_schedule** (String)
 
 
 <a id="nestedblock--timeouts"></a>

--- a/docs/resources/cluster_azure.md
+++ b/docs/resources/cluster_azure.md
@@ -91,6 +91,7 @@ resource "spectrocloud_cluster_azure" "cluster" {
 
 ### Optional
 
+- **backup_policy** (Block List, Max: 1) (see [below for nested schema](#nestedblock--backup_policy))
 - **cluster_profile** (Block List) (see [below for nested schema](#nestedblock--cluster_profile))
 - **cluster_profile_id** (String, Deprecated)
 - **id** (String) The ID of this resource.
@@ -98,6 +99,7 @@ resource "spectrocloud_cluster_azure" "cluster" {
 - **os_patch_on_boot** (Boolean)
 - **os_patch_schedule** (String)
 - **pack** (Block List) (see [below for nested schema](#nestedblock--pack))
+- **scan_policy** (Block List, Max: 1) (see [below for nested schema](#nestedblock--scan_policy))
 - **timeouts** (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
 
 ### Read-only
@@ -143,6 +145,23 @@ Required:
 
 
 
+<a id="nestedblock--backup_policy"></a>
+### Nested Schema for `backup_policy`
+
+Required:
+
+- **backup_location_id** (String)
+- **expiry_in_hour** (Number)
+- **prefix** (String)
+- **schedule** (String)
+
+Optional:
+
+- **include_cluster_resources** (Boolean)
+- **include_disks** (Boolean)
+- **namespaces** (Set of String)
+
+
 <a id="nestedblock--cluster_profile"></a>
 ### Nested Schema for `cluster_profile`
 
@@ -173,6 +192,16 @@ Required:
 - **name** (String)
 - **tag** (String)
 - **values** (String)
+
+
+<a id="nestedblock--scan_policy"></a>
+### Nested Schema for `scan_policy`
+
+Required:
+
+- **configuration_scan_schedule** (String)
+- **conformance_scan_schedule** (String)
+- **penetration_scan_schedule** (String)
 
 
 <a id="nestedblock--timeouts"></a>

--- a/docs/resources/cluster_eks.md
+++ b/docs/resources/cluster_eks.md
@@ -22,6 +22,9 @@ data "spectrocloud_cluster_profile" "profile" {
   name = var.cluster_cluster_profile_name
 }
 
+data "spectrocloud_backup_storage_location" "bsl" {
+  name = var.backup_storage_location_name
+}
 
 resource "spectrocloud_cluster_eks" "cluster" {
   name             = var.cluster_name
@@ -56,6 +59,21 @@ resource "spectrocloud_cluster_eks" "cluster" {
     # }
   }
 
+  backup_policy {
+    schedule                  = "0 0 * * SUN"
+    backup_location_id        = data.spectrocloud_backup_storage_location.bsl.id
+    prefix                    = "prod-backup"
+    expiry_in_hour            = 7200
+    include_disks             = true
+    include_cluster_resources = true
+  }
+
+  scan_policy {
+    configuration_scan_schedule = "0 0 * * SUN"
+    penetration_scan_schedule   = "0 0 * * SUN"
+    conformance_scan_schedule   = "0 0 1 * *"
+  }
+
   machine_pool {
     control_plane           = true
     control_plane_as_worker = true
@@ -86,16 +104,18 @@ resource "spectrocloud_cluster_eks" "cluster" {
 
 - **cloud_account_id** (String)
 - **cloud_config** (Block List, Min: 1, Max: 1) (see [below for nested schema](#nestedblock--cloud_config))
-- **fargate_profile** (Block List, Min: 1) (see [below for nested schema](#nestedblock--fargate_profile))
 - **machine_pool** (Block List, Min: 1) (see [below for nested schema](#nestedblock--machine_pool))
 - **name** (String)
 
 ### Optional
 
+- **backup_policy** (Block List, Max: 1) (see [below for nested schema](#nestedblock--backup_policy))
 - **cluster_profile** (Block List) (see [below for nested schema](#nestedblock--cluster_profile))
 - **cluster_profile_id** (String, Deprecated)
+- **fargate_profile** (Block List) (see [below for nested schema](#nestedblock--fargate_profile))
 - **id** (String) The ID of this resource.
 - **pack** (Block List) (see [below for nested schema](#nestedblock--pack))
+- **scan_policy** (Block List, Max: 1) (see [below for nested schema](#nestedblock--scan_policy))
 - **timeouts** (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
 
 ### Read-only
@@ -118,6 +138,61 @@ Optional:
 - **public_access_cidrs** (Set of String)
 - **ssh_key_name** (String)
 - **vpc_id** (String)
+
+
+<a id="nestedblock--machine_pool"></a>
+### Nested Schema for `machine_pool`
+
+Required:
+
+- **count** (Number)
+- **disk_size_gb** (Number)
+- **instance_type** (String)
+- **name** (String)
+
+Optional:
+
+- **az_subnets** (Map of String)
+- **azs** (List of String)
+
+
+<a id="nestedblock--backup_policy"></a>
+### Nested Schema for `backup_policy`
+
+Required:
+
+- **backup_location_id** (String)
+- **expiry_in_hour** (Number)
+- **prefix** (String)
+- **schedule** (String)
+
+Optional:
+
+- **include_cluster_resources** (Boolean)
+- **include_disks** (Boolean)
+- **namespaces** (Set of String)
+
+
+<a id="nestedblock--cluster_profile"></a>
+### Nested Schema for `cluster_profile`
+
+Required:
+
+- **id** (String) The ID of this resource.
+
+Optional:
+
+- **pack** (Block List) (see [below for nested schema](#nestedblock--cluster_profile--pack))
+
+<a id="nestedblock--cluster_profile--pack"></a>
+### Nested Schema for `cluster_profile.pack`
+
+Required:
+
+- **name** (String)
+- **tag** (String)
+- **values** (String)
+
 
 
 <a id="nestedblock--fargate_profile"></a>
@@ -146,44 +221,6 @@ Optional:
 
 
 
-<a id="nestedblock--machine_pool"></a>
-### Nested Schema for `machine_pool`
-
-Required:
-
-- **count** (Number)
-- **disk_size_gb** (Number)
-- **instance_type** (String)
-- **name** (String)
-
-Optional:
-
-- **az_subnets** (Map of String)
-- **azs** (List of String)
-
-
-<a id="nestedblock--cluster_profile"></a>
-### Nested Schema for `cluster_profile`
-
-Required:
-
-- **id** (String) The ID of this resource.
-
-Optional:
-
-- **pack** (Block List) (see [below for nested schema](#nestedblock--cluster_profile--pack))
-
-<a id="nestedblock--cluster_profile--pack"></a>
-### Nested Schema for `cluster_profile.pack`
-
-Required:
-
-- **name** (String)
-- **tag** (String)
-- **values** (String)
-
-
-
 <a id="nestedblock--pack"></a>
 ### Nested Schema for `pack`
 
@@ -192,6 +229,16 @@ Required:
 - **name** (String)
 - **tag** (String)
 - **values** (String)
+
+
+<a id="nestedblock--scan_policy"></a>
+### Nested Schema for `scan_policy`
+
+Required:
+
+- **configuration_scan_schedule** (String)
+- **conformance_scan_schedule** (String)
+- **penetration_scan_schedule** (String)
 
 
 <a id="nestedblock--timeouts"></a>

--- a/docs/resources/cluster_gcp.md
+++ b/docs/resources/cluster_gcp.md
@@ -88,6 +88,7 @@ resource "spectrocloud_cluster_gcp" "cluster" {
 
 ### Optional
 
+- **backup_policy** (Block List, Max: 1) (see [below for nested schema](#nestedblock--backup_policy))
 - **cluster_profile** (Block List) (see [below for nested schema](#nestedblock--cluster_profile))
 - **cluster_profile_id** (String, Deprecated)
 - **id** (String) The ID of this resource.
@@ -95,6 +96,7 @@ resource "spectrocloud_cluster_gcp" "cluster" {
 - **os_patch_on_boot** (Boolean)
 - **os_patch_schedule** (String)
 - **pack** (Block List) (see [below for nested schema](#nestedblock--pack))
+- **scan_policy** (Block List, Max: 1) (see [below for nested schema](#nestedblock--scan_policy))
 - **timeouts** (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
 
 ### Read-only
@@ -133,6 +135,23 @@ Optional:
 - **update_strategy** (String)
 
 
+<a id="nestedblock--backup_policy"></a>
+### Nested Schema for `backup_policy`
+
+Required:
+
+- **backup_location_id** (String)
+- **expiry_in_hour** (Number)
+- **prefix** (String)
+- **schedule** (String)
+
+Optional:
+
+- **include_cluster_resources** (Boolean)
+- **include_disks** (Boolean)
+- **namespaces** (Set of String)
+
+
 <a id="nestedblock--cluster_profile"></a>
 ### Nested Schema for `cluster_profile`
 
@@ -163,6 +182,16 @@ Required:
 - **name** (String)
 - **tag** (String)
 - **values** (String)
+
+
+<a id="nestedblock--scan_policy"></a>
+### Nested Schema for `scan_policy`
+
+Required:
+
+- **configuration_scan_schedule** (String)
+- **conformance_scan_schedule** (String)
+- **penetration_scan_schedule** (String)
 
 
 <a id="nestedblock--timeouts"></a>

--- a/docs/resources/cluster_vsphere.md
+++ b/docs/resources/cluster_vsphere.md
@@ -22,6 +22,7 @@ description: |-
 
 ### Optional
 
+- **backup_policy** (Block List, Max: 1) (see [below for nested schema](#nestedblock--backup_policy))
 - **cluster_profile** (Block List) (see [below for nested schema](#nestedblock--cluster_profile))
 - **cluster_profile_id** (String, Deprecated)
 - **id** (String) The ID of this resource.
@@ -29,6 +30,7 @@ description: |-
 - **os_patch_on_boot** (Boolean)
 - **os_patch_schedule** (String)
 - **pack** (Block List) (see [below for nested schema](#nestedblock--pack))
+- **scan_policy** (Block List, Max: 1) (see [below for nested schema](#nestedblock--scan_policy))
 - **timeouts** (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
 
 ### Read-only
@@ -98,6 +100,23 @@ Read-only:
 
 
 
+<a id="nestedblock--backup_policy"></a>
+### Nested Schema for `backup_policy`
+
+Required:
+
+- **backup_location_id** (String)
+- **expiry_in_hour** (Number)
+- **prefix** (String)
+- **schedule** (String)
+
+Optional:
+
+- **include_cluster_resources** (Boolean)
+- **include_disks** (Boolean)
+- **namespaces** (Set of String)
+
+
 <a id="nestedblock--cluster_profile"></a>
 ### Nested Schema for `cluster_profile`
 
@@ -128,6 +147,16 @@ Required:
 - **name** (String)
 - **tag** (String)
 - **values** (String)
+
+
+<a id="nestedblock--scan_policy"></a>
+### Nested Schema for `scan_policy`
+
+Required:
+
+- **configuration_scan_schedule** (String)
+- **conformance_scan_schedule** (String)
+- **penetration_scan_schedule** (String)
 
 
 <a id="nestedblock--timeouts"></a>

--- a/examples/backupstoragelocation/providers.tf
+++ b/examples/backupstoragelocation/providers.tf
@@ -1,0 +1,34 @@
+terraform {
+  required_providers {
+    spectrocloud = {
+      version = ">= 0.1"
+      source  = "spectrocloud/spectrocloud"
+    }
+  }
+}
+
+variable "sc_host" {
+  description = "Spectro Cloud Endpoint"
+  default     = "api.spectrocloud.com"
+}
+
+variable "sc_username" {
+  description = "Spectro Cloud Username"
+}
+
+variable "sc_password" {
+  description = "Spectro Cloud Password"
+  sensitive   = true
+}
+
+variable "sc_project_name" {
+  description = "Spectro Cloud Project (e.g: Default)"
+  default     = "Default"
+}
+
+provider "spectrocloud" {
+  host         = var.sc_host
+  username     = var.sc_username
+  password     = var.sc_password
+  project_name = var.sc_project_name
+}

--- a/examples/backupstoragelocation/resource_ippool.tf
+++ b/examples/backupstoragelocation/resource_ippool.tf
@@ -1,0 +1,28 @@
+resource "spectrocloud_backup_storage_location" "bsl1" {
+  name        = "dev-backup-s3"
+  is_default  = false
+  region      = "us-east-2"
+  bucket_name = "dev-backup"
+  s3 {
+    credential_type     = "secret"
+    access_key          = "access_key"
+    secret_key          = "secret_key"
+    s3_force_path_style = false
+
+    #s3_url             = "http://10.90.78.23"
+  }
+}
+
+resource "spectrocloud_backup_storage_location" "bsl2" {
+  name        = "prod-backup-s3"
+  is_default  = false
+  region      = "us-east-2"
+  bucket_name = "prod-backup"
+  s3 {
+    credential_type     = "sts"
+    arn                 = "arn_role"
+    external_id         = "external_id"
+    s3_force_path_style = false
+    #s3_url             = "http://10.90.78.23"
+  }
+}

--- a/examples/backupstoragelocation/terraform.template.tfvars
+++ b/examples/backupstoragelocation/terraform.template.tfvars
@@ -1,0 +1,5 @@
+# Spectro Cloud credentials
+sc_host         = "{enter Spectro Cloud API endpoint}" #e.g: api.spectrocloud.com (for SaaS)
+sc_username     = "{enter Spectro Cloud username}"     #e.g: user1@abc.com
+sc_password     = "{enter Spectro Cloud password}"     #e.g: supereSecure1!
+sc_project_name = "{enter Spectro Cloud project Name}" #e.g: Default

--- a/examples/resources/spectrocloud_backup_storage_location/providers.tf
+++ b/examples/resources/spectrocloud_backup_storage_location/providers.tf
@@ -1,0 +1,15 @@
+terraform {
+  required_providers {
+    spectrocloud = {
+      version = ">= 0.1"
+      source  = "spectrocloud/spectrocloud"
+    }
+  }
+}
+
+provider "spectrocloud" {
+  host         = var.sc_host
+  username     = var.sc_username
+  password     = var.sc_password
+  project_name = var.sc_project_name
+}

--- a/examples/resources/spectrocloud_backup_storage_location/resource.tf
+++ b/examples/resources/spectrocloud_backup_storage_location/resource.tf
@@ -1,0 +1,28 @@
+resource "spectrocloud_backup_storage_location" "bsl1" {
+  name        = "dev-backup-s3"
+  is_default  = false
+  region      = "us-east-2"
+  bucket_name = "dev-backup"
+  s3 {
+    credential_type     = var.credential_type
+    access_key          = var.aws_access_key
+    secret_key          = var.aws_secret_key
+    s3_force_path_style = false
+
+    #s3_url             = "http://10.90.78.23"
+  }
+}
+
+resource "spectrocloud_backup_storage_location" "bsl2" {
+  name        = "prod-backup-s3"
+  is_default  = false
+  region      = "us-east-2"
+  bucket_name = "prod-backup"
+  s3 {
+    credential_type     = var.credential_type
+    arn                 = var.arn
+    external_id         = var.external_id
+    s3_force_path_style = false
+    #s3_url             = "http://10.90.78.23"
+  }
+}

--- a/examples/resources/spectrocloud_backup_storage_location/terraform.template.tfvars
+++ b/examples/resources/spectrocloud_backup_storage_location/terraform.template.tfvars
@@ -1,0 +1,2 @@
+aws_access_key = "<...>"
+aws_secret_key = "<...>"

--- a/examples/resources/spectrocloud_backup_storage_location/variables.tf
+++ b/examples/resources/spectrocloud_backup_storage_location/variables.tf
@@ -1,0 +1,12 @@
+variable "sc_host" {}
+variable "sc_username" {}
+variable "sc_password" {}
+variable "sc_project_name" {}
+
+variable "credential_type" {}
+
+variable "aws_access_key" {}
+variable "aws_secret_key" {}
+
+variable "arn" {}
+variable "external_id" {}

--- a/examples/resources/spectrocloud_cluster_aws/resource.tf
+++ b/examples/resources/spectrocloud_cluster_aws/resource.tf
@@ -9,6 +9,10 @@ data "spectrocloud_cluster_profile" "profile" {
 }
 
 
+data "spectrocloud_backup_storage_location" "bsl" {
+  name = var.backup_storage_location_name
+}
+
 resource "spectrocloud_cluster_aws" "cluster" {
   name             = var.cluster_name
   cloud_account_id = data.spectrocloud_cloudaccount_aws.account.id
@@ -40,6 +44,21 @@ resource "spectrocloud_cluster_aws" "cluster" {
     #             name: wordpress
     #   EOT
     # }
+  }
+
+  backup_policy {
+    schedule                  = "0 0 * * SUN"
+    backup_location_id        = data.spectrocloud_backup_storage_location.bsl.id
+    prefix                    = "prod-backup"
+    expiry_in_hour            = 7200
+    include_disks             = true
+    include_cluster_resources = true
+  }
+
+  scan_policy {
+    configuration_scan_schedule = "0 0 * * SUN"
+    penetration_scan_schedule   = "0 0 * * SUN"
+    conformance_scan_schedule   = "0 0 1 * *"
   }
 
   machine_pool {

--- a/examples/resources/spectrocloud_cluster_aws/terraform.template.tfvars
+++ b/examples/resources/spectrocloud_cluster_aws/terraform.template.tfvars
@@ -1,4 +1,5 @@
 cluster_cloud_account_name   = "aws-1"
 cluster_cluster_profile_name = "ProdAWS"
+backup_storage_location_name = "prod-backup-s3"
 
 cluster_name = "aws-2"

--- a/examples/resources/spectrocloud_cluster_aws/variables.tf
+++ b/examples/resources/spectrocloud_cluster_aws/variables.tf
@@ -5,5 +5,6 @@ variable "sc_project_name" {}
 
 variable "cluster_cloud_account_name" {}
 variable "cluster_cluster_profile_name" {}
+variable "backup_storage_location_name" {}
 
 variable "cluster_name" {}

--- a/examples/resources/spectrocloud_cluster_eks/resource.tf
+++ b/examples/resources/spectrocloud_cluster_eks/resource.tf
@@ -8,6 +8,9 @@ data "spectrocloud_cluster_profile" "profile" {
   name = var.cluster_cluster_profile_name
 }
 
+data "spectrocloud_backup_storage_location" "bsl" {
+  name = var.backup_storage_location_name
+}
 
 resource "spectrocloud_cluster_eks" "cluster" {
   name             = var.cluster_name
@@ -40,6 +43,21 @@ resource "spectrocloud_cluster_eks" "cluster" {
     #             name: wordpress
     #   EOT
     # }
+  }
+
+  backup_policy {
+    schedule                  = "0 0 * * SUN"
+    backup_location_id        = data.spectrocloud_backup_storage_location.bsl.id
+    prefix                    = "prod-backup"
+    expiry_in_hour            = 7200
+    include_disks             = true
+    include_cluster_resources = true
+  }
+
+  scan_policy {
+    configuration_scan_schedule = "0 0 * * SUN"
+    penetration_scan_schedule   = "0 0 * * SUN"
+    conformance_scan_schedule   = "0 0 1 * *"
   }
 
   machine_pool {

--- a/examples/resources/spectrocloud_cluster_eks/terraform.template.tfvars
+++ b/examples/resources/spectrocloud_cluster_eks/terraform.template.tfvars
@@ -1,4 +1,5 @@
 cluster_cloud_account_name   = "aws-1"
 cluster_cluster_profile_name = "ProdEKS"
+backup_storage_location_name = "prod-backup-s3"
 
 cluster_name = "eks-1"

--- a/examples/resources/spectrocloud_cluster_eks/variables.tf
+++ b/examples/resources/spectrocloud_cluster_eks/variables.tf
@@ -5,5 +5,6 @@ variable "sc_project_name" {}
 
 variable "cluster_cloud_account_name" {}
 variable "cluster_cluster_profile_name" {}
+variable "backup_storage_location_name" {}
 
 variable "cluster_name" {}

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/prometheus/common v0.23.0
 	github.com/robfig/cron v1.2.0
 	github.com/spectrocloud/gomi v1.9.1-0.20210519044035-5333c9359877
-	github.com/spectrocloud/hapi v1.9.1-0.20210528122259-78e01fb3877e
+	github.com/spectrocloud/hapi v1.10.1-0.20210603080539-609a48b967df
 )
 
 // replace github.com/spectrocloud/hapi => ../hapi

--- a/go.sum
+++ b/go.sum
@@ -855,8 +855,8 @@ github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasO
 github.com/spectrocloud/gomi v0.0.0-20201113051324-08a1179400db/go.mod h1:rPAwipFWzjYkTfx44KmQazP1NR2cnHe7HSFZkc63mf4=
 github.com/spectrocloud/gomi v1.9.1-0.20210519044035-5333c9359877 h1:rbfwoaCqN862q0LVra0UistoS+QRhM3D/e+pNnwy7zw=
 github.com/spectrocloud/gomi v1.9.1-0.20210519044035-5333c9359877/go.mod h1:rPAwipFWzjYkTfx44KmQazP1NR2cnHe7HSFZkc63mf4=
-github.com/spectrocloud/hapi v1.9.1-0.20210528122259-78e01fb3877e h1:CgYVNQBq4WQotEqMjR93/91GCOrwDzwaklKDCWAVj4Q=
-github.com/spectrocloud/hapi v1.9.1-0.20210528122259-78e01fb3877e/go.mod h1:PY/aOnWz7w1hZE9RIEKeSYhuHJDpaeKHfsQ97pQ/yZk=
+github.com/spectrocloud/hapi v1.10.1-0.20210603080539-609a48b967df h1:nmSn2ky4SsFTrj6B9r2jaj+2/wn2rni2lt9OPpgiKTY=
+github.com/spectrocloud/hapi v1.10.1-0.20210603080539-609a48b967df/go.mod h1:PY/aOnWz7w1hZE9RIEKeSYhuHJDpaeKHfsQ97pQ/yZk=
 github.com/spf13/afero v1.1.2/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=
 github.com/spf13/afero v1.2.2/go.mod h1:9ZxEEn6pIJ8Rxe320qSDBk6AsU0r9pR7Q4OcevTdifk=
 github.com/spf13/cast v1.2.0/go.mod h1:r2rcYCSwa1IExKTDiTfzaxqT2FNHs8hODu4LnUfgKEg=

--- a/pkg/client/backup_storage_location.go
+++ b/pkg/client/backup_storage_location.go
@@ -1,0 +1,104 @@
+package client
+
+import (
+	"github.com/spectrocloud/hapi/models"
+	userC "github.com/spectrocloud/hapi/user/client/v1alpha1"
+)
+
+func (h *V1alpha1Client) ListBackupStorageLocation(projectScope bool) ([]*models.V1alpha1UserAssetsLocation, error) {
+	client, err := h.getUserClient()
+	if err != nil {
+		return nil, err
+	}
+
+	params := userC.NewV1alpha1UsersAssetsLocationGetParams()
+	if projectScope {
+		params.WithContext(h.ctx)
+	}
+	response, err := client.V1alpha1UsersAssetsLocationGet(params)
+	if err != nil {
+		return nil, err
+	}
+
+	bsls := make([]*models.V1alpha1UserAssetsLocation, len(response.Payload.Items))
+	for i, account := range response.Payload.Items {
+		bsls[i] = account
+	}
+
+	return bsls, nil
+}
+
+func (h *V1alpha1Client) GetBackupStorageLocation(uid string) (*models.V1alpha1UserAssetsLocation, error) {
+	client, err := h.getUserClient()
+	if err != nil {
+		return nil, err
+	}
+
+	params := userC.NewV1alpha1UsersAssetsLocationGetParamsWithContext(h.ctx)
+	response, err := client.V1alpha1UsersAssetsLocationGet(params)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, account := range response.Payload.Items {
+		if account.Metadata.UID == uid {
+			return account, nil
+		}
+	}
+
+	return nil, nil
+}
+
+func (h *V1alpha1Client) GetS3BackupStorageLocation(uid string) (*models.V1alpha1UserAssetsLocationS3, error) {
+	client, err := h.getUserClient()
+	if err != nil {
+		return nil, err
+	}
+
+	params := userC.NewV1alpha1UsersAssetsLocationS3GetParamsWithContext(h.ctx).WithUID(uid)
+	if response, err := client.V1alpha1UsersAssetsLocationS3Get(params); err != nil {
+		return nil, err
+	} else {
+		return response.Payload, nil
+	}
+}
+
+func (h *V1alpha1Client) CreateS3BackupStorageLocation(bsl *models.V1alpha1UserAssetsLocationS3) (string, error) {
+	client, err := h.getUserClient()
+	if err != nil {
+		return "", err
+	}
+
+	params := userC.NewV1alpha1UsersAssetsLocationS3CreateParamsWithContext(h.ctx).WithBody(bsl)
+	if resp, err := client.V1alpha1UsersAssetsLocationS3Create(params); err != nil {
+		return "", err
+	} else {
+		return *resp.Payload.UID, nil
+	}
+}
+
+func (h *V1alpha1Client) UpdateS3BackupStorageLocation(uid string, bsl *models.V1alpha1UserAssetsLocationS3) error {
+	client, err := h.getUserClient()
+	if err != nil {
+		return err
+	}
+
+	params := userC.NewV1alpha1UsersAssetsLocationS3UpdateParamsWithContext(h.ctx).WithUID(uid).WithBody(bsl)
+	if _, err := client.V1alpha1UsersAssetsLocationS3Update(params); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (h *V1alpha1Client) DeleteS3BackupStorageLocation(uid string) error {
+	client, err := h.getUserClient()
+	if err != nil {
+		return err
+	}
+
+	params := userC.NewV1alpha1UsersAssetsLocationS3DeleteParamsWithContext(h.ctx).WithUID(uid)
+	if _, err := client.V1alpha1UsersAssetsLocationS3Delete(params); err != nil {
+		return err
+	}
+	return nil
+}

--- a/pkg/client/cluster.go
+++ b/pkg/client/cluster.go
@@ -3,6 +3,8 @@ package client
 import (
 	"strings"
 
+	"github.com/spectrocloud/terraform-provider-spectrocloud/pkg/client/herr"
+
 	hapitransport "github.com/spectrocloud/hapi/apiutil/transport"
 	"github.com/spectrocloud/hapi/models"
 
@@ -86,4 +88,104 @@ func (h *V1alpha1Client) UpdateClusterProfileValues(uid string, profiles *models
 		WithBody(profiles)
 	_, err = client.V1alpha1SpectroClustersUpdateProfiles(params)
 	return err
+}
+
+func (h *V1alpha1Client) GetClusterBackupConfig(uid string) (*models.V1alpha1ClusterBackup, error) {
+	client, err := h.getClusterClient()
+	if err != nil {
+		return nil, err
+	}
+
+	params := clusterC.NewV1alpha1ClusterFeatureBackupGetParamsWithContext(h.ctx).WithUID(uid)
+	success, err := client.V1alpha1ClusterFeatureBackupGet(params)
+	if err != nil {
+		if herr.IsNotFound(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	return success.Payload, nil
+}
+
+func (h *V1alpha1Client) CreateClusterBackupConfig(uid string, config *models.V1alpha1ClusterBackupConfig) error {
+	client, err := h.getClusterClient()
+	if err != nil {
+		return err
+	}
+
+	params := clusterC.NewV1alpha1ClusterFeatureBackupCreateParamsWithContext(h.ctx).WithUID(uid).WithBody(config)
+	_, err = client.V1alpha1ClusterFeatureBackupCreate(params)
+	return err
+}
+
+func (h *V1alpha1Client) UpdateClusterBackupConfig(uid string, config *models.V1alpha1ClusterBackupConfig) error {
+	client, err := h.getClusterClient()
+	if err != nil {
+		return err
+	}
+
+	params := clusterC.NewV1alpha1ClusterFeatureBackupUpdateParamsWithContext(h.ctx).WithUID(uid).WithBody(config)
+	_, err = client.V1alpha1ClusterFeatureBackupUpdate(params)
+	return err
+}
+
+func (h *V1alpha1Client) ApplyClusterBackupConfig(uid string, config *models.V1alpha1ClusterBackupConfig) error {
+	if policy, err := h.GetClusterBackupConfig(uid); err != nil {
+		return err
+	} else if policy == nil {
+		return h.CreateClusterBackupConfig(uid, config)
+	} else {
+		return h.UpdateClusterBackupConfig(uid, config)
+	}
+}
+
+func (h *V1alpha1Client) GetClusterScanConfig(uid string) (*models.V1alpha1ClusterComplianceScan, error) {
+	client, err := h.getClusterClient()
+	if err != nil {
+		return nil, err
+	}
+
+	params := clusterC.NewV1alpha1ClusterFeatureComplianceScanGetParamsWithContext(h.ctx).WithUID(uid)
+	success, err := client.V1alpha1ClusterFeatureComplianceScanGet(params)
+	if err != nil {
+		if herr.IsNotFound(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	return success.Payload, nil
+}
+
+func (h *V1alpha1Client) CreateClusterScanConfig(uid string, config *models.V1alpha1ClusterComplianceScheduleConfig) error {
+	client, err := h.getClusterClient()
+	if err != nil {
+		return err
+	}
+
+	params := clusterC.NewV1alpha1ClusterFeatureComplianceScanCreateParamsWithContext(h.ctx).WithUID(uid).WithBody(config)
+	_, err = client.V1alpha1ClusterFeatureComplianceScanCreate(params)
+	return err
+}
+
+func (h *V1alpha1Client) UpdateClusterScanConfig(uid string, config *models.V1alpha1ClusterComplianceScheduleConfig) error {
+	client, err := h.getClusterClient()
+	if err != nil {
+		return err
+	}
+
+	params := clusterC.NewV1alpha1ClusterFeatureComplianceScanUpdateParamsWithContext(h.ctx).WithUID(uid).WithBody(config)
+	_, err = client.V1alpha1ClusterFeatureComplianceScanUpdate(params)
+	return err
+}
+
+func (h *V1alpha1Client) ApplyClusterScanConfig(uid string, config *models.V1alpha1ClusterComplianceScheduleConfig) error {
+	if policy, err := h.GetClusterScanConfig(uid); err != nil {
+		return err
+	} else if policy == nil {
+		return h.CreateClusterScanConfig(uid, config)
+	} else {
+		return h.UpdateClusterScanConfig(uid, config)
+	}
 }

--- a/pkg/client/herr/errors.go
+++ b/pkg/client/herr/errors.go
@@ -1,0 +1,7 @@
+package herr
+
+import "github.com/spectrocloud/hapi/apiutil"
+
+func IsNotFound(err error) bool {
+	return apiutil.ToV1ErrorObj(err).Code == "ResourceNotFound"
+}

--- a/spectrocloud/data_source_backup_storage_location.go
+++ b/spectrocloud/data_source_backup_storage_location.go
@@ -1,0 +1,72 @@
+package spectrocloud
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/spectrocloud/hapi/models"
+	"github.com/spectrocloud/terraform-provider-spectrocloud/pkg/client"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func dataSourceBackupStorageLocation() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceBackupStorageLocationRead,
+
+		Schema: map[string]*schema.Schema{
+			"id": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Computed:     true,
+				ExactlyOneOf: []string{"id", "name"},
+			},
+			"name": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Computed:     true,
+				ExactlyOneOf: []string{"id", "name"},
+			},
+		},
+	}
+}
+
+func dataSourceBackupStorageLocationRead(_ context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	c := m.(*client.V1alpha1Client)
+
+	// Warning or errors can be collected in a slice type
+	var diags diag.Diagnostics
+
+	projectScope := true
+
+	bsls, err := c.ListBackupStorageLocation(projectScope)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	var bsl *models.V1alpha1UserAssetsLocation
+	for _, a := range bsls {
+
+		if v, ok := d.GetOk("id"); ok && v.(string) == a.Metadata.UID {
+			bsl = a
+			break
+		} else if v, ok := d.GetOk("name"); ok && v.(string) == a.Metadata.Name {
+			bsl = a
+			break
+		}
+	}
+
+	if bsl == nil {
+		diags = append(diags, diag.Diagnostic{
+			Severity: diag.Error,
+			Summary:  "Unable to find backup storage location",
+			Detail:   "Unable to find the specified backup storage location",
+		})
+		return diags
+	}
+
+	d.SetId(bsl.Metadata.UID)
+	d.Set("name", bsl.Metadata.Name)
+
+	return diags
+}

--- a/spectrocloud/provider.go
+++ b/spectrocloud/provider.go
@@ -59,6 +59,8 @@ func New(_ string) func() *schema.Provider {
 				"spectrocloud_cluster_import": resourceClusterImport(),
 
 				"spectrocloud_privatecloudgateway_ippool": resourcePrivateCloudGatewayIpPool(),
+
+				"spectrocloud_backup_storage_location": resourceBackupStorageLocation(),
 			},
 			DataSourcesMap: map[string]*schema.Resource{
 				"spectrocloud_pack": dataSourcePack(),
@@ -69,6 +71,8 @@ func New(_ string) func() *schema.Provider {
 				"spectrocloud_cloudaccount_azure":   dataSourceCloudAccountAzure(),
 				"spectrocloud_cloudaccount_gcp":     dataSourceCloudAccountGcp(),
 				"spectrocloud_cloudaccount_vsphere": dataSourceCloudAccountVsphere(),
+
+				"spectrocloud_backup_storage_location": dataSourceBackupStorageLocation(),
 			},
 			ConfigureContextFunc: providerConfigure,
 		}

--- a/spectrocloud/resource_backup_storage_location.go
+++ b/spectrocloud/resource_backup_storage_location.go
@@ -1,0 +1,238 @@
+package spectrocloud
+
+import (
+	"context"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/spectrocloud/hapi/models"
+	"github.com/spectrocloud/terraform-provider-spectrocloud/pkg/client"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func resourceBackupStorageLocation() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceBackupStorageLocationCreate,
+		ReadContext:   resourceBackupStorageLocationRead,
+		UpdateContext: resourceBackupStorageLocationUpdate,
+		DeleteContext: resourceBackupStorageLocationDelete,
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(10 * time.Minute),
+			Update: schema.DefaultTimeout(10 * time.Minute),
+			Delete: schema.DefaultTimeout(10 * time.Minute),
+		},
+
+		SchemaVersion: 2,
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"is_default": {
+				Type:     schema.TypeBool,
+				Required: true,
+			},
+			"region": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"bucket_name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"ca_cert": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"s3": {
+				Type:     schema.TypeList,
+				Required: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"s3_url": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"s3_force_path_style": {
+							Type:     schema.TypeBool,
+							Optional: true,
+						},
+						"credential_type": {
+							Type:         schema.TypeString,
+							Required:     true,
+							ValidateFunc: validation.StringInSlice([]string{"secret", "sts"}, false),
+						},
+						"access_key": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"secret_key": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"arn": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"external_id": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func resourceBackupStorageLocationCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	c := m.(*client.V1alpha1Client)
+	var diags diag.Diagnostics
+
+	bsl := toBackupStorageLocation(d)
+	uid, err := c.CreateS3BackupStorageLocation(bsl)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	d.SetId(uid)
+
+	return diags
+}
+
+func resourceBackupStorageLocationRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	c := m.(*client.V1alpha1Client)
+	var diags diag.Diagnostics
+
+	bsl, err := c.GetBackupStorageLocation(d.Id())
+	if err != nil {
+		return diag.FromErr(err)
+	} else if bsl == nil {
+		// Deleted - Terraform will recreate it
+		d.SetId("")
+		return diags
+	}
+
+	if err := d.Set("name", bsl.Metadata.Name); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("is_default", bsl.Spec.IsDefault); err != nil {
+		return diag.FromErr(err)
+	}
+
+	if *bsl.Spec.Storage == "s3" {
+		s3Bsl, err := c.GetS3BackupStorageLocation(d.Id())
+		if err != nil {
+			return diag.FromErr(err)
+		} else if s3Bsl == nil {
+			// Deleted - Terraform will recreate it
+			d.SetId("")
+			return diags
+		}
+		if len(s3Bsl.Spec.Config.CaCert) > 0 {
+			if err := d.Set("ca_cert", s3Bsl.Spec.Config.CaCert); err != nil {
+				return diag.FromErr(err)
+			}
+		}
+		if err := d.Set("region", *s3Bsl.Spec.Config.Region); err != nil {
+			return diag.FromErr(err)
+		}
+		if err := d.Set("bucket_name", *s3Bsl.Spec.Config.BucketName); err != nil {
+			return diag.FromErr(err)
+		}
+
+		s3 := make(map[string]interface{})
+		if len(s3Bsl.Spec.Config.S3URL) > 0 {
+			s3["s3_url"] = s3Bsl.Spec.Config.S3URL
+		}
+
+		if s3Bsl.Spec.Config.S3ForcePathStyle != nil {
+			s3["s3_force_path_style"] = *s3Bsl.Spec.Config.S3ForcePathStyle
+		}
+		s3["credential_type"] = string(s3Bsl.Spec.Config.Credentials.CredentialType)
+		if s3Bsl.Spec.Config.Credentials.CredentialType == models.V1alpha1AwsCloudAccountCredentialTypeSecret {
+			s3["access_key"] = s3Bsl.Spec.Config.Credentials.AccessKey
+			s3["secret_key"] = s3Bsl.Spec.Config.Credentials.SecretKey
+		} else {
+			s3["arn"] = s3Bsl.Spec.Config.Credentials.Sts.Arn
+			if len(s3Bsl.Spec.Config.Credentials.Sts.ExternalID) > 0 {
+				s3["external_id"] = s3Bsl.Spec.Config.Credentials.Sts.ExternalID
+			}
+		}
+		s3Config := make([]interface{}, 0, 1)
+		s3Config = append(s3Config, s3)
+		if err := d.Set("s3", s3Config); err != nil {
+			return diag.FromErr(err)
+		}
+	}
+
+	return diags
+}
+
+func resourceBackupStorageLocationUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	c := m.(*client.V1alpha1Client)
+	var diags diag.Diagnostics
+
+	bsl := toBackupStorageLocation(d)
+	err := c.UpdateS3BackupStorageLocation(d.Id(), bsl)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	return diags
+}
+
+func resourceBackupStorageLocationDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	c := m.(*client.V1alpha1Client)
+	var diags diag.Diagnostics
+	err := c.DeleteS3BackupStorageLocation(d.Id())
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	return diags
+}
+
+func toBackupStorageLocation(d *schema.ResourceData) *models.V1alpha1UserAssetsLocationS3 {
+	bucketName := d.Get("bucket_name").(string)
+	region := d.Get("region").(string)
+	s3config := d.Get("s3").([]interface{})[0].(map[string]interface{})
+	s3ForcePathStyle := s3config["s3_force_path_style"].(bool)
+	return &models.V1alpha1UserAssetsLocationS3{
+		Metadata: &models.V1ObjectMetaInputEntity{
+			Name: d.Get("name").(string),
+		},
+		Spec: &models.V1alpha1UserAssetsLocationS3Spec{
+			Config: &models.V1alpha1S3Credentials{
+				BucketName:       &bucketName,
+				CaCert:           d.Get("ca_cert").(string),
+				Credentials:      toAwsAccountCredential(s3config),
+				Region:           &region,
+				S3ForcePathStyle: &s3ForcePathStyle,
+				S3URL:            s3config["s3_url"].(string),
+			},
+			IsDefault: d.Get("is_default").(bool),
+		},
+	}
+}
+
+func toAwsAccountCredential(s3cred map[string]interface{}) *models.V1alpha1AwsCloudAccount {
+	account := &models.V1alpha1AwsCloudAccount{}
+	if len(s3cred["credential_type"].(string)) == 0 || s3cred["credential_type"].(string) == "secret" {
+		account.CredentialType = models.V1alpha1AwsCloudAccountCredentialTypeSecret
+		account.AccessKey = s3cred["access_key"].(string)
+		account.SecretKey = s3cred["secret_key"].(string)
+	} else if s3cred["credential_type"].(string) == "sts" {
+		account.CredentialType = models.V1alpha1AwsCloudAccountCredentialTypeSts
+		account.Sts = &models.V1alpha1AwsStsCredentials{
+			Arn:        s3cred["arn"].(string),
+			ExternalID: s3cred["external_id"].(string),
+		}
+	}
+	return account
+}

--- a/spectrocloud/resource_cluster_aws.go
+++ b/spectrocloud/resource_cluster_aws.go
@@ -34,8 +34,8 @@ func resourceClusterAws() *schema.Resource {
 				ForceNew: true,
 			},
 			"cluster_profile_id": {
-				Type:     schema.TypeString,
-				Optional: true,
+				Type:       schema.TypeString,
+				Optional:   true,
 				Deprecated: "Switch to cluster_profile",
 			},
 			"cluster_profile": {
@@ -190,6 +190,70 @@ func resourceClusterAws() *schema.Resource {
 					},
 				},
 			},
+			"backup_policy": {
+				Type:     schema.TypeList,
+				Optional: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"prefix": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"backup_location_id": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"schedule": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"expiry_in_hour": {
+							Type:     schema.TypeInt,
+							Required: true,
+						},
+						"include_disks": {
+							Type:     schema.TypeBool,
+							Optional: true,
+							Default:  true,
+						},
+						"include_cluster_resources": {
+							Type:     schema.TypeBool,
+							Optional: true,
+							Default:  true,
+						},
+						"namespaces": {
+							Type:     schema.TypeSet,
+							Optional: true,
+							Set:      schema.HashString,
+							Elem: &schema.Schema{
+								Type: schema.TypeString,
+							},
+						},
+					},
+				},
+			},
+			"scan_policy": {
+				Type:     schema.TypeList,
+				Optional: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"configuration_scan_schedule": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"penetration_scan_schedule": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"conformance_scan_schedule": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+					},
+				},
+			},
 		},
 	}
 }
@@ -254,6 +318,22 @@ func resourceClusterAwsRead(_ context.Context, d *schema.ResourceData, m interfa
 
 	if err := d.Set("kubeconfig", kubeconfig); err != nil {
 		return diag.FromErr(err)
+	}
+
+	if policy, err := c.GetClusterBackupConfig(d.Id()); err != nil {
+		return diag.FromErr(err)
+	} else if policy != nil && policy.Spec.Config != nil {
+		if err := d.Set("backup_policy", flattenBackupPolicy(policy.Spec.Config)); err != nil {
+			return diag.FromErr(err)
+		}
+	}
+
+	if policy, err := c.GetClusterScanConfig(d.Id()); err != nil {
+		return diag.FromErr(err)
+	} else if policy != nil && policy.Spec.DriverSpec != nil {
+		if err := d.Set("scan_policy", flattenScanPolicy(policy.Spec.DriverSpec)); err != nil {
+			return diag.FromErr(err)
+		}
 	}
 
 	return flattenCloudConfigAws(cluster.Spec.CloudConfigRef.UID, d, c)
@@ -372,6 +452,18 @@ func resourceClusterAwsUpdate(ctx context.Context, d *schema.ResourceData, m int
 		}
 	}
 
+	if d.HasChange("backup_policy") {
+		if err := updateBackupPolicy(c, d); err != nil {
+			return diag.FromErr(err)
+		}
+	}
+
+	if d.HasChange("scan_policy") {
+		if err := updateScanPolicy(c, d); err != nil {
+			return diag.FromErr(err)
+		}
+	}
+
 	resourceClusterAwsRead(ctx, d, m)
 
 	return diags
@@ -389,6 +481,7 @@ func toAwsCluster(d *schema.ResourceData) *models.V1alpha1SpectroAwsClusterEntit
 		Spec: &models.V1alpha1SpectroAwsClusterEntitySpec{
 			CloudAccountUID: ptr.StringPtr(d.Get("cloud_account_id").(string)),
 			Profiles:        toProfiles(d),
+			Policies:        toPolicies(d),
 			CloudConfig: &models.V1alpha1AwsClusterConfig{
 				SSHKeyName: cloudConfig["ssh_key_name"].(string),
 				Region:     ptr.StringPtr(cloudConfig["region"].(string)),


### PR DESCRIPTION
- [x] Adding `backup_storage_location` as `data` & `resource`
- [x] Adding `backup_policy` & `scan_policy` support for `aws, azure, gcp, vsphere, eks` cluster
- [x] Added examples for `backup_storage_location` and modified examples of few clouds to have `backup_policy` and `scan_policy` in `spectrocloud_cluster` resource

@jzhoucliqr, @prathabk, @jgautam Please Review