### PR TITLE
Simplify nested cluster configuration

### DIFF
--- a/pkg/client/cluster.go
+++ b/pkg/client/cluster.go
@@ -23,22 +23,22 @@ func (h *V1Client) DeleteCluster(uid string) error {
 }
 
 func (h *V1Client) GetCluster(uid string) (*models.V1SpectroCluster, error) {
-	err, cluster := h.GetClusterWithoutStatus(uid)
+	cluster, err := h.GetClusterWithoutStatus(uid)
 	if err != nil {
 		return nil, err
 	}
 
-	if cluster.Status.State == "Deleted" {
+	if cluster == nil || cluster.Status.State == "Deleted" {
 		return nil, nil
 	}
 
 	return cluster, nil
 }
 
-func (h *V1Client) GetClusterWithoutStatus(uid string) (error, *models.V1SpectroCluster) {
+func (h *V1Client) GetClusterWithoutStatus(uid string) (*models.V1SpectroCluster, error) {
 	client, err := h.GetClusterClient()
 	if err != nil {
-		return err, nil
+		return nil, err
 	}
 
 	params := clusterC.NewV1SpectroClustersGetParamsWithContext(h.Ctx).WithUID(uid)
@@ -47,12 +47,12 @@ func (h *V1Client) GetClusterWithoutStatus(uid string) (error, *models.V1Spectro
 		// TODO(saamalik) check with team if this is proper?
 		return nil, nil
 	} else if err != nil {
-		return err, nil
+		return nil, err
 	}
 
 	// special check if the cluster is marked deleted
 	cluster := success.Payload
-	return nil, cluster
+	return cluster, nil
 }
 
 func (h *V1Client) GetClusterByName(name string) (*models.V1SpectroCluster, error) {

--- a/spectrocloud/cluster_common_crud.go
+++ b/spectrocloud/cluster_common_crud.go
@@ -2,12 +2,13 @@ package spectrocloud
 
 import (
 	"context"
+	"log"
+	"time"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/spectrocloud/terraform-provider-spectrocloud/pkg/client"
-	"log"
-	"time"
 )
 
 var resourceClusterReadyPendingStates = []string{
@@ -50,13 +51,12 @@ func waitForClusterReady(ctx context.Context, d *schema.ResourceData, uid string
 
 func resourceClusterReadyRefreshFunc(c *client.V1Client, id string) resource.StateRefreshFunc {
 	return func() (interface{}, string, error) {
-		err, cluster := c.GetClusterWithoutStatus(id)
+		cluster, err := c.GetClusterWithoutStatus(id)
 		if err != nil {
 			return nil, "", err
 		} else if cluster == nil || cluster.Status == nil {
 			return nil, "NotReady", nil
 		}
-
 		return cluster, "Ready", nil
 	}
 }

--- a/spectrocloud/cluster_common_profiles.go
+++ b/spectrocloud/cluster_common_profiles.go
@@ -14,7 +14,7 @@ func toProfiles(c *client.V1Client, d *schema.ResourceData) []*models.V1SpectroC
 	var cluster *models.V1SpectroCluster
 	var err error
 	if d.Id() != "" {
-		err, cluster = c.GetClusterWithoutStatus(d.Id())
+		cluster, err = c.GetClusterWithoutStatus(d.Id())
 		if err != nil {
 			return nil
 		}


### PR DESCRIPTION
Changes
- make `cloud_config` and `machine_pool` blocks optional
- now `resource_cluster.tf` can be as simple as:
  ```bash
  resource "spectrocloud_cluster_nested" "cluster" {
    name = "nested-example"
    host_cluster_uid = "6329db035b2e5c1600054035"
  }
  ```

Regarding bug fix, here's the stack trace:
```bash
GET /v1/spectroclusters/632cec645b2e5d7858fe8a4b?includeNonSpectroLabels=false&resolvePackValues=false HTTP/1.1
Host: tyler.dev.spectrocloud.com
User-Agent: Go-http-client/1.1
Accept: application/json
Apikey: 8guu5acCY5yQIJiTJMwYEE21sJv3mv3J
Projectuid: 63181acdbf5c8abda11db9c3
Accept-Encoding: gzip


HTTP/2.0 404 Not Found
Content-Length: 167
Content-Type: application/json
Date: Fri, 23 Sep 2022 17:01:38 GMT
Requester: 63181ababf5c8abd983cac44
Requestuid: r-1663952498306-get-1ab65bc8d512
Via: 1.1 f85d379725bf31eb2428acfa2b9da6e6.cloudfront.net (CloudFront)
X-Amz-Cf-Id: XO7Va2JXMfDFTLYmW857b8cUN4oU8tRY6ce3WNh8NuCQCmMPUAcZXg==
X-Amz-Cf-Pop: SFO5-P1
X-Cache: Error from cloudfront

{"code":"ResourceNotFound","details":null,"message":"Cluster '632cec645b2e5d7858fe8a4b' is not found in the project Default","ref":"7401493d52f3e4039a780a2aac9534cf"}

panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x30 pc=0x10508cd14]

goroutine 2254 [running]:
github.com/spectrocloud/terraform-provider-spectrocloud/pkg/client.(*V1Client).GetCluster(0x140007c5808?, {0x140007e49d8?, 0x1057ba028?})
        /Users/tylergillson/spectrocloud/repos/terraform-provider-spectrocloud/pkg/client/cluster.go:31 +0x24
github.com/spectrocloud/terraform-provider-spectrocloud/spectrocloud.resourceClusterNestedRead({0x1057ba028?, 0x14000899c40?}, 0x140009c7580, {0x105798f20?, 0x140005d0690})
        /Users/tylergillson/spectrocloud/repos/terraform-provider-spectrocloud/spectrocloud/resource_cluster_nested.go:417 +0xd8
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*Resource).read(0x14000754b60, {0x1057ba028, 0x14000899c40}, 0x24?, {0x105798f20, 0x140005d0690})
        /Users/tylergillson/go/pkg/mod/github.com/hashicorp/terraform-plugin-sdk/v2@v2.6.1/helper/schema/resource.go:347 +0xe8
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*Resource).RefreshWithoutUpgrade(0x14000754b60, {0x1057ba028, 0x14000899c40}, 0x140001762a0, {0x105798f20, 0x140005d0690})
        /Users/tylergillson/go/pkg/mod/github.com/hashicorp/terraform-plugin-sdk/v2@v2.6.1/helper/schema/resource.go:624 +0x30c
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*GRPCProviderServer).ReadResource(0x140001aa180, {0x1057ba028, 0x14000899c40}, 0x14000899c80)
        /Users/tylergillson/go/pkg/mod/github.com/hashicorp/terraform-plugin-sdk/v2@v2.6.1/helper/schema/grpc_provider.go:575 +0x380
github.com/hashicorp/terraform-plugin-go/tfprotov5/server.(*server).ReadResource(0x140004e4460, {0x1057ba0d0?, 0x1400071a780?}, 0x1400041ad20)
        /Users/tylergillson/go/pkg/mod/github.com/hashicorp/terraform-plugin-go@v0.3.0/tfprotov5/server/server.go:298 +0x240
github.com/hashicorp/terraform-plugin-go/tfprotov5/internal/tfplugin5._Provider_ReadResource_Handler({0x10574f840?, 0x140004e4460}, {0x1057ba0d0, 0x1400071a780}, 0x1400041acc0, 0x0)
        /Users/tylergillson/go/pkg/mod/github.com/hashicorp/terraform-plugin-go@v0.3.0/tfprotov5/internal/tfplugin5/tfplugin5_grpc.pb.go:344 +0x170
google.golang.org/grpc.(*Server).processUnaryRPC(0x140002addc0, {0x1057be7e0, 0x140005ac480}, 0x140005a4500, 0x1400009e690, 0x1061f4650, 0x0)
        /Users/tylergillson/go/pkg/mod/google.golang.org/grpc@v1.32.0/server.go:1194 +0xadc
google.golang.org/grpc.(*Server).handleStream(0x140002addc0, {0x1057be7e0, 0x140005ac480}, 0x140005a4500, 0x0)
        /Users/tylergillson/go/pkg/mod/google.golang.org/grpc@v1.32.0/server.go:1517 +0x82c
google.golang.org/grpc.(*Server).serveStreams.func1.2()
        /Users/tylergillson/go/pkg/mod/google.golang.org/grpc@v1.32.0/server.go:859 +0x84
created by google.golang.org/grpc.(*Server).serveStreams.func1
        /Users/tylergillson/go/pkg/mod/google.golang.org/grpc@v1.32.0/server.go:857 +0x290
exit status 2

```