### PR TITLE
PPD-270: clean up nested cluster config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
-/.idea/
+.idea/
 .vscode/
 .DS_Store
+
+__debug_bin
 
 terraform.tfplan
 terraform.tfstate

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.6.1
 	github.com/robfig/cron v1.2.0
 	github.com/spectrocloud/gomi v1.14.1-0.20220727130240-fc64f32e394d
-	github.com/spectrocloud/hapi v1.14.1-0.20220908174410-e370e189783c
+	github.com/spectrocloud/hapi v1.14.1-0.20221005223137-f9ce5552a400
 )
 
 //replace github.com/spectrocloud/hapi => ../hapi

--- a/go.sum
+++ b/go.sum
@@ -584,8 +584,8 @@ github.com/sirupsen/logrus v1.4.2 h1:SPIRibHv4MatM3XXNO2BJeFLZwZ2LvZgfQ5+UNI2im4
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
 github.com/spectrocloud/gomi v1.14.1-0.20220727130240-fc64f32e394d h1:ICP3awSALxQrtubNm79v1t/hUEoXi+YUzW26Pwtam0M=
 github.com/spectrocloud/gomi v1.14.1-0.20220727130240-fc64f32e394d/go.mod h1:HviEHWZZkcU+iQOxCeSr+IIRypm3HY/XsL1wkte/2SI=
-github.com/spectrocloud/hapi v1.14.1-0.20220908174410-e370e189783c h1:L6PhP6sdV16oGc2H+HBYMUx7f3H4FwBW63YO8XX0guc=
-github.com/spectrocloud/hapi v1.14.1-0.20220908174410-e370e189783c/go.mod h1:mHd7t0RTGnNBysMD9abHK88RN+dL5NWX9LsJ4iOqffo=
+github.com/spectrocloud/hapi v1.14.1-0.20221005223137-f9ce5552a400 h1:8GsyDKQGvb6Rhz8R3Tigiadl3D3NzfnvJ3iE6/AZDSI=
+github.com/spectrocloud/hapi v1.14.1-0.20221005223137-f9ce5552a400/go.mod h1:mHd7t0RTGnNBysMD9abHK88RN+dL5NWX9LsJ4iOqffo=
 github.com/spf13/afero v1.1.2/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=
 github.com/spf13/afero v1.2.2/go.mod h1:9ZxEEn6pIJ8Rxe320qSDBk6AsU0r9pR7Q4OcevTdifk=
 github.com/spf13/cast v1.2.0/go.mod h1:r2rcYCSwa1IExKTDiTfzaxqT2FNHs8hODu4LnUfgKEg=

--- a/pkg/client/cluster_nested.go
+++ b/pkg/client/cluster_nested.go
@@ -23,16 +23,14 @@ func (h *V1Client) CreateClusterNested(cluster *models.V1SpectroNestedClusterEnt
 }
 
 func (h *V1Client) CreateMachinePoolNested(cloudConfigId string, machinePool *models.V1NestedMachinePoolConfigEntity) error {
-	/*client, err := h.GetClusterClient()
+	client, err := h.GetClusterClient()
 	if err != nil {
 		return nil
 	}
 
 	params := clusterC.NewV1CloudConfigsNestedMachinePoolCreateParamsWithContext(h.Ctx).WithConfigUID(cloudConfigId).WithBody(machinePool)
 	_, err = client.V1CloudConfigsNestedMachinePoolCreate(params)
-	return err*/
-
-	return nil // TODO: not implemented.
+	return err
 }
 
 func (h *V1Client) UpdateMachinePoolNested(cloudConfigId string, machinePool *models.V1NestedMachinePoolConfigEntity) error {
@@ -43,23 +41,20 @@ func (h *V1Client) UpdateMachinePoolNested(cloudConfigId string, machinePool *mo
 
 	params := clusterC.NewV1CloudConfigsNestedMachinePoolUpdateParamsWithContext(h.Ctx).
 		WithConfigUID(cloudConfigId).
-		WithMachinePoolName(*machinePool.PoolConfig.Name).
 		WithBody(machinePool)
 	_, err = client.V1CloudConfigsNestedMachinePoolUpdate(params)
 	return err
 }
 
 func (h *V1Client) DeleteMachinePoolNested(cloudConfigId string, machinePoolName string) error {
-	/*client, err := h.GetClusterClient()
+	client, err := h.GetClusterClient()
 	if err != nil {
 		return nil
 	}
 
 	params := clusterC.NewV1CloudConfigsNestedMachinePoolDeleteParamsWithContext(h.Ctx).WithConfigUID(cloudConfigId).WithMachinePoolName(machinePoolName)
 	_, err = client.V1CloudConfigsNestedMachinePoolDelete(params)
-	return err*/
-
-	return nil //TODO: not implemented.
+	return err
 }
 
 func (h *V1Client) GetCloudConfigNested(configUID string) (*models.V1NestedCloudConfig, error) {


### PR DESCRIPTION
Changes:
- implemented create/delete for nested machinepools
- simplified/updated nested cluster configuration:
  ```terraform
  resource "spectrocloud_cluster_nested" "cluster" {
    name = "nested-cluster-demo"
  
    cluster_config {
      host_cluster_config {
        # one of [ host_cluster, cluster_group ] is required
        host_cluster {
          uid = var.host_cluster_uid
        }
        # cluster_group {
        #   uid = var.cluster_group_uid
        # }
      }
      resources {
        max_cpu = 2
        max_mem_in_mb = 6
        min_cpu = 0
        min_mem_in_mb = 0
      }
    }
  
    # (optional)
    # cluster_profile {
    #   id = spectrocloud_cluster_profile.profile.id
    # }
  
    # (optional)
    # cloud_config {
    #   chart_name = var.chart_name
    #   chart_repo = var.chart_repo
    #   chart_version = var.chart_version
    #   chart_values = var.chart_values
    #   k8s_version = var.k8s_version
    # }
  
  }
  ```

Requires:
- https://github.com/spectrocloud/hubble/pull/4919
- https://github.com/spectrocloud/hapi/pull/1170