### PR TITLE
PLT-33: ClusterHealth alert support

### DIFF
--- a/docs/resources/alert.md
+++ b/docs/resources/alert.md
@@ -22,24 +22,35 @@ description: Provisioning Cluster Health alerts (email | http).|-
 
 
 ```terraform
-resource "spectrocloud_alert" "alert_dev" {
-  project = "dev"
+Type : HTTP
+-----------------------------------------------------------
+resource "spectrocloud_alert" "alert_http" {
+  project = "Default"
   is_active = true
   component = "ClusterHealth"
   http {
-    method = "POST"
-    url = "https://openhook.com/put/dev0"
-    body = "{ \"text\": \"{{message}}\" }"
+    method  = "POST"
+    url     = "https://openhook.com/put/edit2"
+    body    = "{ \"text\": \"{{message}}\" }"
     headers = {
-      ApiKey = "test--key--dev"
-      tag = "test"
-      source = "spectro"
+      type = "test--key--dev0"
+      tag    = "Health"
+      source = "spectrocloud"
     }
   }
-  email {
-    alert_all_users = false
-    identifiers = ["abc@spectrocloud.com"]
-  }
+  type = "http"
+  alert_all_users = false
+}
+
+Type : EMAIL
+-----------------------------------------------------------
+resource "spectrocloud_alert" "alert_email" {
+  project = "Default"
+  is_active = true
+  component = "ClusterHealth"
+  type = "email"
+  identifiers = ["siva@spectrocloud.com", "anand@spectrocloud.com"]
+  alert_all_users = false
 }
 ```
 

--- a/docs/resources/alert.md
+++ b/docs/resources/alert.md
@@ -1,0 +1,70 @@
+---
+page_title: "spectrocloud_alert Resource - terraform-provider-spectrocloud"
+subcategory: ""
+description: Provisioning Cluster Health alerts (email | http).|-
+  
+---
+
+# Resource `spectrocloud_alert`
+
+
+
+## Example Usage
+#### Note
+- Spectrocloud allow to create upto 2 alert in below combinations
+    - 1 email alert (can add any number of email recipient) & 1 http webhook alert.
+    - 2 http webhook alert configuration.
+    - Any one alert type Email/http.
+
+  (Documentation [Cluster Health Alerts](#https://docs.spectrocloud.com/clusters/cluster-management/health-alerts#overview))
+
+
+
+
+```terraform
+resource "spectrocloud_alert" "alert_dev" {
+  project = "dev"
+  is_active = true
+  component = "ClusterHealth"
+  http {
+    method = "POST"
+    url = "https://openhook.com/put/dev0"
+    body = "{ \"text\": \"{{message}}\" }"
+    headers = {
+      ApiKey = "test--key--dev"
+      tag = "test"
+      source = "spectro"
+    }
+  }
+  email {
+    alert_all_users = false
+    identifiers = ["abc@spectrocloud.com"]
+  }
+}
+```
+
+## Schema
+
+### Required
+
+- **project (name)** (String)
+- **is_active** (Bool)
+- **component** (Bool)
+- **alert (http/email)** (Map)
+
+
+### Optional
+
+- **identifiers** (String)
+- **body** (String)
+- **headers** ([]Map)
+- **timeouts** (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
+
+<a id="nestedblock--timeouts"></a>
+### Nested Schema for `timeouts`
+
+Optional:
+
+- **create** (String)
+- **delete** (String)
+- **update** (String)

--- a/docs/resources/alert.md
+++ b/docs/resources/alert.md
@@ -11,7 +11,7 @@ description: Provisioning Cluster Health alerts (email | http).|-
 
 ## Example Usage
 #### Note
-- Spectrocloud allow to create upto 2 alert in below combinations
+- Spectro Cloud creates up to two alerts from the below combinations:
     - 1 email alert (can add any number of email recipient) & 1 http webhook alert.
     - 2 http webhook alert configuration.
     - Any one alert type Email/http.

--- a/examples/resources/spectrocloud_alert/providers.tf
+++ b/examples/resources/spectrocloud_alert/providers.tf
@@ -1,0 +1,15 @@
+terraform {
+  required_providers {
+    spectrocloud = {
+      version = ">= 0.1"
+      source  = "spectrocloud/spectrocloud"
+    }
+  }
+}
+
+provider "spectrocloud" {
+  host         = var.sc_host
+  username     = var.sc_username
+  password     = var.sc_password
+  project_name = var.sc_project_name
+}

--- a/examples/resources/spectrocloud_alert/providers.tf
+++ b/examples/resources/spectrocloud_alert/providers.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     spectrocloud = {
-      version = ">= 0.1"
+      version = ">= 0.10.4"
       source  = "spectrocloud/spectrocloud"
     }
   }

--- a/examples/resources/spectrocloud_alert/resource.tf
+++ b/examples/resources/spectrocloud_alert/resource.tf
@@ -3,78 +3,29 @@
 and for email, we can add a target email recipient or enable alerts for all users in the corresponding project
 */
 
-# Sample with one email & one webhook alert configuration.
-resource "spectrocloud_alert" "alert_dev0" {
-  project = "dev0"
+resource "spectrocloud_alert" "alert_email" {
+  project = "Default"
   is_active = true
   component = "ClusterHealth"
-  http {
-    method = "POST"
-    url = "https://openhook.com/put/dev0"
-    body = "{ \"text\": \"{{message}}\" }"
-    headers = {
-      ApiKey = "test--key--dev0"
-      tag = "Health"
-      source = "spectrocloud"
-    }
-  }
-  email {
-    alert_all_users = false
-    identifiers = ["abc@spectrocloud.com"]
-  }
+  type = "email"
+  identifiers = ["siva@spectrocloud.com", "anand@spectrocloud.com"]
+  alert_all_users = false
 }
 
-# Sample with only email alert configuration.
-resource "spectrocloud_alert" "alert_dev1" {
-  project = "dev1"
-  is_active = true
-  component = "ClusterHealth"
-  email {
-    alert_all_users = false
-    identifiers = ["abc@spectrocloud.com", "cba@spectrocloud.com"]
-  }
-}
-
-# Sample with 2 webhook alert configuration
-resource "spectrocloud_alert" "alert_dev2" {
-  project = "dev2"
+resource "spectrocloud_alert" "alert_http" {
+  project = "Default"
   is_active = true
   component = "ClusterHealth"
   http {
-    method = "POST"
-    url = "https://openhook.com/put/dev2"
-    body = "{ \"text\": \"{{message}}\" }"
+    method  = "POST"
+    url     = "https://openhook.com/put/edit2"
+    body    = "{ \"text\": \"{{message}}\" }"
     headers = {
-      ApiKey = "test--key--dev0"
-      tag = "Health"
+      type = "test--key--dev0"
+      tag    = "Health"
       source = "spectrocloud"
     }
   }
-  http {
-    method = "POST"
-    url = "https://openhook.com/post/dev2"
-    body = "{ \"text\": \"{{message}}\" }"
-    headers = {
-      ApiKey = "test--key--dev0"
-      tag = "Health"
-      source = "spectrocloud"
-    }
-  }
-}
-
-# Sample with only webhook alert configuration.
-resource "spectrocloud_alert" "alert_dev3" {
-  project = "dev3"
-  is_active = true
-  component = "ClusterHealth"
-  http {
-    method = "POST"
-    url = "https://openhook.com/put/dev3"
-    body = "{ \"text\": \"{{message}}\" }"
-    headers = {
-      ApiKey = "test--key--dev0"
-      tag = "Health"
-      source = "spectrocloud"
-    }
-  }
+  type = "http"
+  alert_all_users = false
 }

--- a/examples/resources/spectrocloud_alert/resource.tf
+++ b/examples/resources/spectrocloud_alert/resource.tf
@@ -1,0 +1,81 @@
+/*
+Note - Spectocloud allow upto 2 alert configurations for cluster health per project, which can be provisioned under one
+resource. Below are example for provisioning alert. we cannot have multiple email component under same resource in single
+project context, Instead we can add n' recipient in 'identifiers' or set alert_all_users to true.
+*/
+
+# Sample with one email & one webhook alert configuration.
+resource "spectrocloud_alert" "alert_dev0" {
+  project = "dev0"
+  is_active = true
+  component = "ClusterHealth"
+  http {
+    method = "POST"
+    url = "https://openhook.com/put/dev0"
+    body = "{ \"text\": \"{{message}}\" }"
+    headers = {
+      ApiKey = "test--key--dev0"
+      tag = "Health"
+      source = "spectrocloud"
+    }
+  }
+  email {
+    alert_all_users = false
+    identifiers = ["abc@spectrocloud.com"]
+  }
+}
+
+# Sample with only email alert configuration.
+resource "spectrocloud_alert" "alert_dev1" {
+  project = "dev1"
+  is_active = true
+  component = "ClusterHealth"
+  email {
+    alert_all_users = false
+    identifiers = ["abc@spectrocloud.com", "cba@spectrocloud.com"]
+  }
+}
+
+# Sample with 2 webhook alert configuration
+resource "spectrocloud_alert" "alert_dev2" {
+  project = "dev2"
+  is_active = true
+  component = "ClusterHealth"
+  http {
+    method = "POST"
+    url = "https://openhook.com/put/dev2"
+    body = "{ \"text\": \"{{message}}\" }"
+    headers = {
+      ApiKey = "test--key--dev0"
+      tag = "Health"
+      source = "spectrocloud"
+    }
+  }
+  http {
+    method = "POST"
+    url = "https://openhook.com/post/dev2"
+    body = "{ \"text\": \"{{message}}\" }"
+    headers = {
+      ApiKey = "test--key--dev0"
+      tag = "Health"
+      source = "spectrocloud"
+    }
+  }
+}
+
+# Sample with only webhook alert configuration.
+resource "spectrocloud_alert" "alert_dev3" {
+  project = "dev3"
+  is_active = true
+  component = "ClusterHealth"
+  http {
+    method = "POST"
+    url = "https://openhook.com/put/dev3"
+    body = "{ \"text\": \"{{message}}\" }"
+    headers = {
+      ApiKey = "test--key--dev0"
+      tag = "Health"
+      source = "spectrocloud"
+    }
+  }
+}

--- a/examples/resources/spectrocloud_alert/resource.tf
+++ b/examples/resources/spectrocloud_alert/resource.tf
@@ -1,6 +1,6 @@
 /*
-Note - We can set up to two alerts for cluster health per project. Web-hook can be configured in HTTP component and for
-email, we can add a target email recipients or enable alerts for all users in the corresponding project
+**Note** - We can set up a maximum of two alerts for cluster health per project. Webhook can be configured in the HTTP component,
+and for email, we can add a target email recipient or enable alerts for all users in the corresponding project
 */
 
 # Sample with one email & one webhook alert configuration.

--- a/examples/resources/spectrocloud_alert/resource.tf
+++ b/examples/resources/spectrocloud_alert/resource.tf
@@ -1,7 +1,6 @@
 /*
-Note - Spectocloud allow upto 2 alert configurations for cluster health per project, which can be provisioned under one
-resource. Below are example for provisioning alert. we cannot have multiple email component under same resource in single
-project context, Instead we can add n' recipient in 'identifiers' or set alert_all_users to true.
+Note - We can set up to two alerts for cluster health per project. Web-hook can be configured in HTTP component and for
+email, we can add a target email recipients or enable alerts for all users in the corresponding project
 */
 
 # Sample with one email & one webhook alert configuration.

--- a/examples/resources/spectrocloud_alert/terraform.template.tfvars
+++ b/examples/resources/spectrocloud_alert/terraform.template.tfvars
@@ -1,0 +1,4 @@
+sc_host         = "{enter host}"
+sc_username     = "{enter username}"
+sc_password     = "{enter password}"
+sc_project_name = "{enter Project}"

--- a/examples/resources/spectrocloud_alert/variables.tf
+++ b/examples/resources/spectrocloud_alert/variables.tf
@@ -1,0 +1,4 @@
+variable "sc_host" {}
+variable "sc_username" {}
+variable "sc_password" {}
+variable "sc_project_name" {}

--- a/pkg/client/alert.go
+++ b/pkg/client/alert.go
@@ -5,64 +5,57 @@ import (
 	userC "github.com/spectrocloud/hapi/user/client/v1"
 )
 
-func (h *V1Client) CreateAlert(body *models.V1AlertEntity, projectUID string, component string) (string, error) {
+func (h *V1Client) CreateAlert(body *models.V1Channel, projectUID string, component string) (string, error) {
 	client, err := h.GetUserClient()
 
 	if err != nil {
 		return "", err
 	}
 
-	params := userC.NewV1ProjectsUIDAlertUpdateParams().WithBody(body).WithUID(projectUID).WithComponent(component)
-	_, err = client.V1ProjectsUIDAlertUpdate(params)
+	params := userC.NewV1ProjectsUIDAlertCreateParams().WithBody(body).WithUID(projectUID).WithComponent(component)
+	success, err := client.V1ProjectsUIDAlertCreate(params)
 	if err != nil {
 		return "", err
 	}
-	return "nil", err
-
+	return *success.Payload.UID, nil
 }
 
-func (h *V1Client) UpdateAlert(body *models.V1AlertEntity, projectUID string, component string) (string, error) {
+func (h *V1Client) UpdateAlert(body *models.V1Channel, projectUID string, component string, alertUID string) (string, error) {
 	client, err := h.GetUserClient()
-
 	if err != nil {
 		return "", err
 	}
-
-	params := userC.NewV1ProjectsUIDAlertUpdateParams().WithBody(body).WithUID(projectUID).WithComponent(component)
-	_, err = client.V1ProjectsUIDAlertUpdate(params)
+	params := userC.NewV1ProjectsUIDAlertsUIDUpdateParams().WithBody(body).WithUID(projectUID).WithComponent(component).WithAlertUID(alertUID)
+	_, err = client.V1ProjectsUIDAlertsUIDUpdate(params)
 	if err != nil {
 		return "", err
 	}
-	return "nill", err
+	return "success", nil
 
 }
 
-func (h *V1Client) ReadAlert(body []*models.V1Channel, projectUID string, component string) ([]*models.V1Channel, error) {
+func (h *V1Client) ReadAlert(projectUID string, component string, alertUID string) (*models.V1Channel, error) {
 	client, err := h.GetUserClient()
-	channels := make([]*models.V1Channel, 0)
+	channel := &models.V1Channel{}
 	if err != nil {
-		return channels, err
+		return channel, err
 	}
-
-	for _, ch := range body {
-		params := userC.NewV1ProjectsUIDAlertsUIDGetParams().WithUID(projectUID).WithComponent(component).WithAlertUID(ch.UID)
-		resp, err := client.V1ProjectsUIDAlertsUIDGet(params)
-		if err != nil {
-			return channels, err
-		}
-		channels = append(channels, resp.Payload)
+	params := userC.NewV1ProjectsUIDAlertsUIDGetParams().WithUID(projectUID).WithComponent(component).WithAlertUID(alertUID)
+	success, err := client.V1ProjectsUIDAlertsUIDGet(params)
+	if err != nil {
+		return nil, err
 	}
-	return channels, err
+	return success.Payload, nil
 
 }
 
-func (h *V1Client) DeleteAlerts(projectUID string, component string) error {
+func (h *V1Client) DeleteAlerts(projectUID string, component string, alertUID string) error {
 	client, err := h.GetUserClient()
 	if err != nil {
 		return err
 	}
-	params := userC.NewV1ProjectsUIDAlertDeleteParams().WithUID(projectUID).WithComponent(component)
-	_, err = client.V1ProjectsUIDAlertDelete(params)
+	params := userC.NewV1ProjectsUIDAlertsUIDDeleteParams().WithUID(projectUID).WithComponent(component).WithAlertUID(alertUID)
+	_, err = client.V1ProjectsUIDAlertsUIDDelete(params)
 	if err != nil {
 		return err
 	}

--- a/pkg/client/alert.go
+++ b/pkg/client/alert.go
@@ -1,0 +1,71 @@
+package client
+
+import (
+	"github.com/spectrocloud/hapi/models"
+	userC "github.com/spectrocloud/hapi/user/client/v1"
+)
+
+func (h *V1Client) CreateAlert(body *models.V1AlertEntity, projectUID string, component string) (string, error) {
+	client, err := h.GetUserClient()
+
+	if err != nil {
+		return "", err
+	}
+
+	params := userC.NewV1ProjectsUIDAlertUpdateParams().WithBody(body).WithUID(projectUID).WithComponent(component)
+	_, err = client.V1ProjectsUIDAlertUpdate(params)
+	if err != nil {
+		return "", err
+	}
+	return "nil", err
+
+}
+
+func (h *V1Client) UpdateAlert(body *models.V1AlertEntity, projectUID string, component string) (string, error) {
+	client, err := h.GetUserClient()
+
+	if err != nil {
+		return "", err
+	}
+
+	params := userC.NewV1ProjectsUIDAlertUpdateParams().WithBody(body).WithUID(projectUID).WithComponent(component)
+	_, err = client.V1ProjectsUIDAlertUpdate(params)
+	if err != nil {
+		return "", err
+	}
+	return "nill", err
+
+}
+
+func (h *V1Client) ReadAlert(body []*models.V1Channel, projectUID string, component string) ([]*models.V1Channel, error) {
+	client, err := h.GetUserClient()
+	channels := make([]*models.V1Channel, 0)
+	if err != nil {
+		return channels, err
+	}
+
+	for _, ch := range body {
+		params := userC.NewV1ProjectsUIDAlertsUIDGetParams().WithUID(projectUID).WithComponent(component).WithAlertUID(ch.UID)
+		resp, err := client.V1ProjectsUIDAlertsUIDGet(params)
+		if err != nil {
+			return channels, err
+		}
+		channels = append(channels, resp.Payload)
+	}
+	return channels, err
+
+}
+
+func (h *V1Client) DeleteAlerts(projectUID string, component string) error {
+	client, err := h.GetUserClient()
+	if err != nil {
+		return err
+	}
+	params := userC.NewV1ProjectsUIDAlertDeleteParams().WithUID(projectUID).WithComponent(component)
+	_, err = client.V1ProjectsUIDAlertDelete(params)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/spectrocloud/provider.go
+++ b/spectrocloud/provider.go
@@ -116,6 +116,7 @@ func New(_ string) func() *schema.Provider {
 				"spectrocloud_appliance": resourceAppliance(),
 
 				"spectrocloud_workspace": resourceWorkspace(),
+				"spectrocloud_alert":     resourceAlert(),
 			},
 			DataSourcesMap: map[string]*schema.Resource{
 				"spectrocloud_user":    dataSourceUser(),

--- a/spectrocloud/resource_alert.go
+++ b/spectrocloud/resource_alert.go
@@ -1,0 +1,228 @@
+package spectrocloud
+
+import (
+	"context"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/spectrocloud/hapi/models"
+	"github.com/spectrocloud/terraform-provider-spectrocloud/pkg/client"
+	"time"
+)
+
+func resourceAlert() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceAlertCreate,
+		ReadContext:   resourceAlertRead,
+		UpdateContext: resourceAlertUpdate,
+		DeleteContext: resourceAlertDelete,
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(10 * time.Minute),
+			Update: schema.DefaultTimeout(10 * time.Minute),
+			Delete: schema.DefaultTimeout(10 * time.Minute),
+		},
+		SchemaVersion: 2,
+		Schema: map[string]*schema.Schema{
+			"project": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"is_active": {
+				Type:     schema.TypeBool,
+				Required: true,
+			},
+			"component": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validation.StringInSlice([]string{"ClusterHealth"}, false),
+			},
+			"email": {
+				Type:     schema.TypeList,
+				Optional: true,
+				ForceNew: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"alert_all_users": {
+							Type:     schema.TypeBool,
+							Required: true,
+						},
+						"identifiers": {
+							Type:     schema.TypeSet,
+							Optional: true,
+							Set:      schema.HashString,
+							Elem: &schema.Schema{
+								Type: schema.TypeString,
+							},
+						},
+					},
+				},
+			},
+			"http": {
+				Type:     schema.TypeList,
+				Optional: true,
+				ForceNew: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"method": {
+							Type:         schema.TypeString,
+							Required:     true,
+							ValidateFunc: validation.StringInSlice([]string{"POST", "GET", "PUT"}, false),
+						},
+						"url": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"body": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"headers": {
+							Type:     schema.TypeMap,
+							Optional: true,
+							Elem: &schema.Schema{
+								Type: schema.TypeString,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func resourceAlertCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	c := m.(*client.V1Client)
+	var err error
+	projectUid := ""
+	var diags diag.Diagnostics
+	alertObj := toAlert(d)
+	if v, ok := d.GetOk("project"); ok && v.(string) != "" { //if project name is set it's a project scope
+		projectUid, err = c.GetProjectUID(v.(string))
+		if err != nil {
+			return diag.FromErr(err)
+		}
+	}
+	uid, err := c.CreateAlert(alertObj, projectUid, d.Get("component").(string))
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	d.SetId(uid)
+
+	return diags
+}
+
+func resourceAlertUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	c := m.(*client.V1Client)
+	var err error
+	projectUid := ""
+	var diags diag.Diagnostics
+	alertObj := toAlert(d)
+	if v, ok := d.GetOk("project"); ok && v.(string) != "" { //if project name is set it's a project scope
+		projectUid, err = c.GetProjectUID(v.(string))
+		if err != nil {
+			return diag.FromErr(err)
+		}
+	}
+	uid, err := c.UpdateAlert(alertObj, projectUid, d.Get("component").(string))
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	d.SetId(uid)
+
+	return diags
+}
+
+func toAlert(d *schema.ResourceData) (alertEntity *models.V1AlertEntity) {
+	channels := make([]*models.V1Channel, 0)
+	isEmail, isHttp := getAlertTypes(d)
+	if isEmail == true {
+		emailInfo := d.Get("email").([]interface{})[0].(map[string]interface{})
+		emailIDs := make([]string, 0)
+		for _, email := range emailInfo["identifiers"].(*schema.Set).List() {
+			emailIDs = append(emailIDs, email.(string))
+		}
+		emailAlert := &models.V1Channel{
+			IsActive:      d.Get("is_active").(bool),
+			AlertAllUsers: emailInfo["alert_all_users"].(bool),
+			Identifiers:   emailIDs,
+			Type:          "email",
+		}
+		channels = append(channels, emailAlert)
+	}
+	if isHttp == true {
+		for _, val := range d.Get("http").([]interface{}) {
+			http := val.(map[string]interface{})
+			headersMap := make(map[string]string)
+			for key, element := range http["headers"].(map[string]interface{}) {
+				headersMap[key] = element.(string)
+			}
+			channelHttp := &models.V1ChannelHTTP{
+				Body:    http["body"].(string),
+				Headers: headersMap,
+				Method:  http["method"].(string),
+				URL:     http["url"].(string),
+			}
+			httpAlert := &models.V1Channel{
+				IsActive: d.Get("is_active").(bool),
+				Type:     "http",
+				HTTP:     channelHttp,
+			}
+			channels = append(channels, httpAlert)
+		}
+	}
+	alertEntity = &models.V1AlertEntity{
+		Channels: channels,
+	}
+	return alertEntity
+}
+
+func resourceAlertDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	projectUid := ""
+	var err error
+	c := m.(*client.V1Client)
+	var diags diag.Diagnostics
+	if v, ok := d.GetOk("project"); ok && v.(string) != "" { //if project name is set it's a project scope
+		projectUid, err = c.GetProjectUID(v.(string))
+		if err != nil {
+			return diag.FromErr(err)
+		}
+	}
+	err = c.DeleteAlerts(projectUid, d.Get("component").(string))
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	return diags
+}
+
+func resourceAlertRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	projectUid := ""
+	var err error
+	c := m.(*client.V1Client)
+	var diags diag.Diagnostics
+	if v, ok := d.GetOk("project"); ok && v.(string) != "" { //if project name is set it's a project scope
+		projectUid, err = c.GetProjectUID(v.(string))
+		if err != nil {
+			return diag.FromErr(err)
+		}
+	}
+	projectDetails, _ := c.GetProjectByUID(projectUid)
+	channels := projectDetails.Spec.Alerts[0].Channels
+	_, err = c.ReadAlert(channels, projectUid, d.Get("component").(string))
+	return diags
+}
+
+func getAlertTypes(d *schema.ResourceData) (hasEmail bool, hasHttp bool) {
+	email := false
+	http := false
+	for range d.Get("email").([]interface{}) {
+		email = true
+		break
+	}
+	for range d.Get("http").([]interface{}) {
+		http = true
+		break
+	}
+	return email, http
+}


### PR DESCRIPTION
## Jira 
https://spectrocloud.atlassian.net/browse/PLT-33

## Change Description
Terrafrom - Enable project level cluster health alerts ( email | http ).

## Type of change
- [*] New feature (non-breaking change which adds functionality)

## Documentation
https://docs.spectrocloud.com/clusters/cluster-management/health-alerts#overview

### Validation

- Tried to create alert resources with below combinations 
      - With one email & one web-hook alert configuration.
      - with only email alert configuration.
      - With 2 web-hook alert configuration.
      - With only web-hook alert configuration.
-  Validated with all CRUD operations with resources.

### Support

1. Added documentation for `spectrocloud_alert`
2. Included examples for alert creation, few combinations

