### PR TITLE
PLT-158:Fixed AWS Account day 2 update by setting context/scope

### DIFF
--- a/spectrocloud/resource_cloud_account_aws.go
+++ b/spectrocloud/resource_cloud_account_aws.go
@@ -164,7 +164,7 @@ func toAwsAccount(d *schema.ResourceData) *models.V1AwsAccount {
 			SecretKey: d.Get("aws_secret_key").(string),
 		},
 	}
-	if d.Get("context") != nil || d.Get("context") != "" {
+	if d.Get("context") != nil {
 		ctxAnnotation := map[string]string{
 			"scope": d.Get("context").(string),
 		}

--- a/spectrocloud/resource_cloud_account_aws.go
+++ b/spectrocloud/resource_cloud_account_aws.go
@@ -102,7 +102,9 @@ func resourceCloudAccountAwsRead(_ context.Context, d *schema.ResourceData, m in
 	if err := d.Set("type", string(account.Spec.CredentialType)); err != nil {
 		return diag.FromErr(err)
 	}
-
+	if err := d.Set("context", account.Metadata.Annotations["scope"]); err != nil {
+		return diag.FromErr(err)
+	}
 	if account.Spec.CredentialType == models.V1AwsCloudAccountCredentialTypeSecret {
 		if err := d.Set("aws_access_key", account.Spec.AccessKey); err != nil {
 			return diag.FromErr(err)
@@ -161,6 +163,12 @@ func toAwsAccount(d *schema.ResourceData) *models.V1AwsAccount {
 			AccessKey: d.Get("aws_access_key").(string),
 			SecretKey: d.Get("aws_secret_key").(string),
 		},
+	}
+	if d.Get("context") != nil || d.Get("context") != "" {
+		ctxAnnotation := map[string]string{
+			"scope": d.Get("context").(string),
+		}
+		account.Metadata.Annotations = ctxAnnotation
 	}
 	if len(d.Get("type").(string)) == 0 || d.Get("type").(string) == "secret" {
 		account.Spec.CredentialType = models.V1AwsCloudAccountCredentialTypeSecret

--- a/spectrocloud/resource_cloud_account_aws_test.go
+++ b/spectrocloud/resource_cloud_account_aws_test.go
@@ -1,0 +1,71 @@
+package spectrocloud
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestToAwsAccountCTXProjectSecret(t *testing.T) {
+	rd := resourceCloudAccountAws().TestResourceData()
+	rd.Set("name", "aws_unit_test_acc")
+	rd.Set("aws_access_key", "ABCDEFGHIJKLMNOPQRST")
+	rd.Set("aws_secret_key", "sasf1424aqsfsdf123423SDFs23412sadf@#$@#$")
+	rd.Set("context", "project")
+	rd.Set("type", "secret")
+	acc := toAwsAccount(rd)
+
+	assert.Equal(t, rd.Get("name"), acc.Metadata.Name)
+	assert.Equal(t, rd.Get("aws_access_key"), acc.Spec.AccessKey)
+	assert.Equal(t, rd.Get("aws_secret_key"), acc.Spec.SecretKey)
+	assert.Equal(t, "project", acc.Metadata.Annotations["scope"])
+	assert.Equal(t, rd.Get("type"), string(acc.Spec.CredentialType))
+}
+
+func TestToAwsAccountCTXTenantSecret(t *testing.T) {
+	rd := resourceCloudAccountAws().TestResourceData()
+	rd.Set("name", "aws_unit_test_acc")
+	rd.Set("aws_access_key", "ABCDEFGHIJKLMNOPQRST")
+	rd.Set("aws_secret_key", "sasf1424aqsfsdf123423SDFs23412sadf@#$@#$")
+	rd.Set("context", "tenant")
+	rd.Set("type", "secret")
+	acc := toAwsAccount(rd)
+
+	assert.Equal(t, rd.Get("name"), acc.Metadata.Name)
+	assert.Equal(t, rd.Get("aws_access_key"), acc.Spec.AccessKey)
+	assert.Equal(t, rd.Get("aws_secret_key"), acc.Spec.SecretKey)
+	assert.Equal(t, "tenant", acc.Metadata.Annotations["scope"])
+	assert.Equal(t, rd.Get("type"), string(acc.Spec.CredentialType))
+}
+
+func TestToAwsAccountCTXProjectSTS(t *testing.T) {
+	rd := resourceCloudAccountAws().TestResourceData()
+	rd.Set("name", "aws_unit_test_acc")
+	rd.Set("type", "sts")
+	rd.Set("arn", "ARN::AWSAD:12312sdTEd")
+	rd.Set("external_id", "TEST-External23423ID")
+	rd.Set("context", "project")
+
+	acc := toAwsAccount(rd)
+	assert.Equal(t, rd.Get("name"), acc.Metadata.Name)
+	assert.Equal(t, rd.Get("arn"), acc.Spec.Sts.Arn)
+	assert.Equal(t, rd.Get("external_id"), acc.Spec.Sts.ExternalID)
+	assert.Equal(t, "project", acc.Metadata.Annotations["scope"])
+	assert.Equal(t, rd.Get("type"), string(acc.Spec.CredentialType))
+}
+
+func TestToAwsAccountCTXTenantSTS(t *testing.T) {
+	rd := resourceCloudAccountAws().TestResourceData()
+	rd.Set("name", "aws_unit_test_acc")
+	rd.Set("type", "sts")
+	rd.Set("arn", "ARN::AWSAD:12312sdTEd")
+	rd.Set("external_id", "TEST-External23423ID")
+	rd.Set("context", "tenant")
+
+	acc := toAwsAccount(rd)
+	assert.Equal(t, rd.Get("name"), acc.Metadata.Name)
+	assert.Equal(t, rd.Get("arn"), acc.Spec.Sts.Arn)
+	assert.Equal(t, rd.Get("external_id"), acc.Spec.Sts.ExternalID)
+	assert.Equal(t, "tenant", acc.Metadata.Annotations["scope"])
+	assert.Equal(t, rd.Get("type"), string(acc.Spec.CredentialType))
+	assert.Equal(t, "tenant", acc.Metadata.Annotations["scope"])
+}

--- a/spectrocloud/resource_cloud_account_aws_test.go
+++ b/spectrocloud/resource_cloud_account_aws_test.go
@@ -67,5 +67,4 @@ func TestToAwsAccountCTXTenantSTS(t *testing.T) {
 	assert.Equal(t, rd.Get("external_id"), acc.Spec.Sts.ExternalID)
 	assert.Equal(t, "tenant", acc.Metadata.Annotations["scope"])
 	assert.Equal(t, rd.Get("type"), string(acc.Spec.CredentialType))
-	assert.Equal(t, "tenant", acc.Metadata.Annotations["scope"])
 }


### PR DESCRIPTION
JIRA - https://spectrocloud.atlassian.net/browse/PLT-158

Description -  AWS account day 2 operation update is failed due context is missed in PUT call, Now it fixed and added fee unit cases to cover the same.