### PR TITLE
PE-1608: Terraform - Go lang version update to 1.19.8

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,7 @@ jobs:
         name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.18
+          go-version: 1.19.8
       -
         name: Import GPG key
         id: import_gpg


### PR DESCRIPTION
Terraform - Go lang version update to 1.19.8