### PR TITLE
docs: fixed cluster profile markdown issue

### DIFF
--- a/docs/resources/cluster_profile.md
+++ b/docs/resources/cluster_profile.md
@@ -158,7 +158,7 @@ resource "spectrocloud_cluster_profile" "profile" {
 - `pack` (Block List) For packs of type `spectro`, `helm`, and `manifest`, at least one pack must be specified. (see [below for nested schema](#nestedblock--pack))
 - `tags` (Set of String) A list of tags to be applied to the cluster. Tags must be in the form of `key:value`.
 - `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
-- `type` (String) Specify the cluster profile type to use. Allowed values are `cluster`, infra`, `add-on`, and `system`. These values map to the following User Interface (UI) labels. Use the value ' cluster ' for a **Full** cluster profile.For an Infrastructure cluster profile, use the value `infra`; for an Add-on cluster profile, use the value `add-on`.System cluster profiles can be specified using the value `system`. To learn more about cluster profiles, refer to the [Cluster Profile](https://docs.spectrocloud.com/cluster-profiles) documentation. Default value is `add-on`.
+- `type` (String) Specify the cluster profile type to use. Allowed values are `cluster`, `infra`, `add-on`, and `system`. These values map to the following User Interface (UI) labels. Use the value ' cluster ' for a **Full** cluster profile.For an Infrastructure cluster profile, use the value `infra`; for an Add-on cluster profile, use the value `add-on`.System cluster profiles can be specified using the value `system`. To learn more about cluster profiles, refer to the [Cluster Profile](https://docs.spectrocloud.com/cluster-profiles) documentation. Default value is `add-on`.
 - `version` (String) Version of the cluster profile. Defaults to '1.0.0'.
 
 ### Read-Only

--- a/spectrocloud/resource_cluster_profile.go
+++ b/spectrocloud/resource_cluster_profile.go
@@ -82,7 +82,7 @@ func resourceClusterProfile() *schema.Resource {
 				Optional:     true,
 				Default:      "add-on",
 				ValidateFunc: validation.StringInSlice([]string{"add-on", "cluster", "infra", "system"}, false),
-				Description:  "Specify the cluster profile type to use. Allowed values are `cluster`, infra`, `add-on`, and `system`. These values map to the following User Interface (UI) labels. Use the value ' cluster ' for a **Full** cluster profile." + "For an Infrastructure cluster profile, use the value `infra`; for an Add-on cluster profile, use the value `add-on`." + "System cluster profiles can be specified using the value `system`. To learn more about cluster profiles, refer to the [Cluster Profile](https://docs.spectrocloud.com/cluster-profiles) documentation. Default value is `add-on`.",
+				Description:  "Specify the cluster profile type to use. Allowed values are `cluster`, `infra`, `add-on`, and `system`. These values map to the following User Interface (UI) labels. Use the value ' cluster ' for a **Full** cluster profile." + "For an Infrastructure cluster profile, use the value `infra`; for an Add-on cluster profile, use the value `add-on`." + "System cluster profiles can be specified using the value `system`. To learn more about cluster profiles, refer to the [Cluster Profile](https://docs.spectrocloud.com/cluster-profiles) documentation. Default value is `add-on`.",
 				ForceNew:     true,
 			},
 			"pack": schemas.PackSchema(),


### PR DESCRIPTION
This PR fixes a markdown issue found in the cluster profile resource

![CleanShot 2023-11-17 at 15 35 35](https://github.com/spectrocloud/terraform-provider-spectrocloud/assets/29551334/a527c2f6-21d6-4043-a148-2556d32c9a9d)
