### PR TITLE
docs: add extra detail on Azure availability zones DOC-920

### DIFF
--- a/docs/resources/cluster_azure.md
+++ b/docs/resources/cluster_azure.md
@@ -64,7 +64,7 @@ resource "spectrocloud_cluster_azure" "cluster" {
     name                    = "master-pool"
     count                   = 1
     instance_type           = "Standard_D2_v3"
-    azs                     = []
+    azs                     = [""]
     disk {
       size_gb = 65
       type    = "Standard_LRS"
@@ -75,7 +75,7 @@ resource "spectrocloud_cluster_azure" "cluster" {
     name          = "worker-basic"
     count         = 1
     instance_type = "Standard_D2_v3"
-    azs           = []
+    azs           = [""]
   }
 
 }
@@ -173,7 +173,7 @@ Optional:
 
 Required:
 
-- `azs` (Set of String) Availability zones for the machine pool.
+- `azs` (Set of String) Availability zones for the machine pool. Check if your region provides availability zones on [the Azure documentation](https://learn.microsoft.com/en-us/azure/reliability/availability-zones-service-support#azure-regions-with-availability-zone-support).
 - `count` (Number) Number of nodes in the machine pool.
 - `instance_type` (String) Azure instance type from the Azure portal.
 - `name` (String) Name of the machine pool. This must be unique within the cluster.

--- a/docs/resources/cluster_azure.md
+++ b/docs/resources/cluster_azure.md
@@ -173,7 +173,7 @@ Optional:
 
 Required:
 
-- `azs` (Set of String) Availability zones for the machine pool. Check if your region provides availability zones on [the Azure documentation](https://learn.microsoft.com/en-us/azure/reliability/availability-zones-service-support#azure-regions-with-availability-zone-support).
+- `azs` (Set of String) Availability zones for the machine pool. Check if your region provides availability zones on [the Azure documentation](https://learn.microsoft.com/en-us/azure/reliability/availability-zones-service-support#azure-regions-with-availability-zone-support). Default value is `""`.
 - `count` (Number) Number of nodes in the machine pool.
 - `instance_type` (String) Azure instance type from the Azure portal.
 - `name` (String) Name of the machine pool. This must be unique within the cluster.

--- a/spectrocloud/resource_cluster_azure.go
+++ b/spectrocloud/resource_cluster_azure.go
@@ -268,7 +268,7 @@ func resourceClusterAzure() *schema.Resource {
 							Elem: &schema.Schema{
 								Type: schema.TypeString,
 							},
-							Description: "Availability zones for the machine pool.",
+							Description: "Availability zones for the machine pool. Check if your region provides availability zones on [the Azure documentation](https://learn.microsoft.com/en-us/azure/reliability/availability-zones-service-support#azure-regions-with-availability-zone-support).",
 						},
 						"is_system_node_pool": {
 							Type:        schema.TypeBool,

--- a/spectrocloud/resource_cluster_azure.go
+++ b/spectrocloud/resource_cluster_azure.go
@@ -268,7 +268,7 @@ func resourceClusterAzure() *schema.Resource {
 							Elem: &schema.Schema{
 								Type: schema.TypeString,
 							},
-							Description: "Availability zones for the machine pool. Check if your region provides availability zones on [the Azure documentation](https://learn.microsoft.com/en-us/azure/reliability/availability-zones-service-support#azure-regions-with-availability-zone-support). Default value is `""`",
+							Description: "Availability zones for the machine pool. Check if your region provides availability zones on [the Azure documentation](https://learn.microsoft.com/en-us/azure/reliability/availability-zones-service-support#azure-regions-with-availability-zone-support). Default value is `\"\"`.",
 							Default: "",
 						},
 						"is_system_node_pool": {

--- a/spectrocloud/resource_cluster_azure.go
+++ b/spectrocloud/resource_cluster_azure.go
@@ -268,7 +268,8 @@ func resourceClusterAzure() *schema.Resource {
 							Elem: &schema.Schema{
 								Type: schema.TypeString,
 							},
-							Description: "Availability zones for the machine pool. Check if your region provides availability zones on [the Azure documentation](https://learn.microsoft.com/en-us/azure/reliability/availability-zones-service-support#azure-regions-with-availability-zone-support).",
+							Description: "Availability zones for the machine pool. Check if your region provides availability zones on [the Azure documentation](https://learn.microsoft.com/en-us/azure/reliability/availability-zones-service-support#azure-regions-with-availability-zone-support). Default value is `""`",
+							Default: "",
 						},
 						"is_system_node_pool": {
 							Type:        schema.TypeBool,

--- a/templates/resources/cluster_azure.md.tmpl
+++ b/templates/resources/cluster_azure.md.tmpl
@@ -64,7 +64,7 @@ resource "spectrocloud_cluster_azure" "cluster" {
     name                    = "master-pool"
     count                   = 1
     instance_type           = "Standard_D2_v3"
-    azs                     = []
+    azs                     = [""]
     disk {
       size_gb = 65
       type    = "Standard_LRS"
@@ -75,7 +75,7 @@ resource "spectrocloud_cluster_azure" "cluster" {
     name          = "worker-basic"
     count         = 1
     instance_type = "Standard_D2_v3"
-    azs           = []
+    azs           = [""]
   }
 
 }


### PR DESCRIPTION
This patch adds extra detail on availability zones in Azure regions, as not all Azure regions provide AZs.