### PR TITLE
fix: propagate insecureSkipTLSVerify to Palette client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,7 @@
 .DS_Store
 
 bin
-__debug_bin
+__debug_bin*
 profile.cov
 
 terraform.tfplan

--- a/spectrocloud/resource_cluster_tke.go
+++ b/spectrocloud/resource_cluster_tke.go
@@ -3,6 +3,7 @@ package spectrocloud
 import (
 	"context"
 	"log"
+	"slices"
 	"time"
 
 	"github.com/spectrocloud/terraform-provider-spectrocloud/spectrocloud/schemas"
@@ -593,6 +594,7 @@ func toMachinePoolTke(machinePool interface{}) *models.V1TencentMachinePoolConfi
 	for k := range m["az_subnets"].(map[string]interface{}) {
 		azs = append(azs, k)
 	}
+	slices.Sort(azs)
 
 	min := int32(m["count"].(int))
 	max := int32(m["count"].(int))

--- a/spectrocloud/resource_cluster_tke_test.go
+++ b/spectrocloud/resource_cluster_tke_test.go
@@ -1,12 +1,14 @@
 package spectrocloud
 
 import (
-	"github.com/google/go-cmp/cmp"
-	"github.com/spectrocloud/terraform-provider-spectrocloud/types"
-	"github.com/stretchr/testify/assert"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/assert"
+
 	"github.com/spectrocloud/palette-api-go/models"
+
+	"github.com/spectrocloud/terraform-provider-spectrocloud/types"
 )
 
 func TestFlattenMachinePoolConfigsTke(t *testing.T) {


### PR DESCRIPTION
Properly configure the Palette client's `WithInsecureSkipVerify` functional option.

This was not an issue in the past because the Palette client was utilizing `http.DefaultTransport`, which the TF provider overrides. However, at some point the SDK behaviour was updated and the override stopped working.