### PR TITLE
Revert "PLT-896: Make registry_uid attribute mandatory in spectrocloud_packs and spectrocloud_packs_simple"

### DIFF
--- a/docs/data-sources/pack.md
+++ b/docs/data-sources/pack.md
@@ -11,7 +11,7 @@ description: |-
 
 
 
-~> Starting with Palette version 4.5 (and the corresponding provider release), the `registry_uid` attribute will become required. The existing `filters` attribute will be deprecated, and a new `pack_filters` attribute will be introduced for advanced search functionality.
+~> The existing `filters` attribute will be deprecated, and a new `pack_filters` attribute will be introduced for advanced search functionality.
 
 ## Example Usage
 
@@ -59,7 +59,7 @@ data "spectrocloud_pack" "cni" {
 - `filters` (String) Filters to apply when searching for a pack. This is a string of the form 'key1=value1' with 'AND', 'OR` operators. Refer to the Palette API [pack search API endpoint documentation](https://docs.spectrocloud.com/api/v1/v-1-packs-search/) for filter examples..
 - `id` (String) The UID of the pack returned.
 - `name` (String) The name of the pack to search for.
-- `registry_uid` (String) The UID of the registry to search for the pack in. This is a required parameter starting from version 0.21.0.
+- `registry_uid` (String) The unique identifier (UID) of the registry where the pack is located. Specify `registry_uid` to search within a specific registry.
 - `type` (String) The type of pack to search for. Supported values are `helm`, `manifest`, `container`, `operator-instance`.
 - `version` (String) The version of the pack to search for.
 

--- a/docs/data-sources/pack.md
+++ b/docs/data-sources/pack.md
@@ -59,7 +59,7 @@ data "spectrocloud_pack" "cni" {
 - `filters` (String) Filters to apply when searching for a pack. This is a string of the form 'key1=value1' with 'AND', 'OR` operators. Refer to the Palette API [pack search API endpoint documentation](https://docs.spectrocloud.com/api/v1/v-1-packs-search/) for filter examples..
 - `id` (String) The UID of the pack returned.
 - `name` (String) The name of the pack to search for.
-- `registry_uid` (String) The unique identifier (UID) of the specific registry where the pack is located. Required if searching within a specific registry. Only one of `filters`, `id`, or `registry_uid` can be provided.
+- `registry_uid` (String) The UID of the registry to search for the pack in. This is a required parameter starting from version 0.21.0.
 - `type` (String) The type of pack to search for. Supported values are `helm`, `manifest`, `container`, `operator-instance`.
 - `version` (String) The version of the pack to search for.
 

--- a/docs/data-sources/pack_simple.md
+++ b/docs/data-sources/pack_simple.md
@@ -33,12 +33,12 @@ data "spectrocloud_pack_simple" "pack" {
 ### Required
 
 - `name` (String) The name of the pack.
-- `registry_uid` (String) The unique identifier (UID) of the registry that the pack belongs to. This is mandatory for identifying the specific registry in which the pack resides.
 - `type` (String) The type of Pack. Allowed values are `helm`, `manifest`, `container` or `operator-instance`.
 
 ### Optional
 
 - `context` (String) Indicates in which context registry should be searched for the pack values. Allowed values are `system`, `project` or `tenant`. Defaults to `project`.If  the `project` context is specified, the project name will sourced from the provider configuration parameter [`project_name`](https://registry.terraform.io/providers/spectrocloud/spectrocloud/latest/docs#schema).
+- `registry_uid` (String) The unique identifier of the registry the pack belongs to. This is a required parameter starting from version 0.21.0
 - `version` (String) The version of the pack.
 
 ### Read-Only

--- a/docs/data-sources/pack_simple.md
+++ b/docs/data-sources/pack_simple.md
@@ -11,8 +11,6 @@ description: |-
 
 ## Example Usage
 
-~> Starting with version 0.21.0 the attribute `registry_uid` is required.
-
 ```hcl
 data "spectrocloud_registry" "registry" {
   name = "Public Repo"
@@ -38,7 +36,7 @@ data "spectrocloud_pack_simple" "pack" {
 ### Optional
 
 - `context` (String) Indicates in which context registry should be searched for the pack values. Allowed values are `system`, `project` or `tenant`. Defaults to `project`.If  the `project` context is specified, the project name will sourced from the provider configuration parameter [`project_name`](https://registry.terraform.io/providers/spectrocloud/spectrocloud/latest/docs#schema).
-- `registry_uid` (String) The unique identifier of the registry the pack belongs to. This is a required parameter starting from version 0.21.0
+- `registry_uid` (String) The unique identifier (UID) of the registry where the pack is located. Specify `registry_uid` to search within a specific registry.
 - `version` (String) The version of the pack.
 
 ### Read-Only

--- a/spectrocloud/data_source_pack.go
+++ b/spectrocloud/data_source_pack.go
@@ -51,10 +51,10 @@ func dataSourcePack() *schema.Resource {
 				Optional:    true,
 			},
 			"registry_uid": {
-				Type:         schema.TypeString,
-				Description:  "The unique identifier (UID) of the specific registry where the pack is located. Required if searching within a specific registry. Only one of `filters`, `id`, or `registry_uid` can be provided.",
-				Optional:     true,
-				ExactlyOneOf: []string{"filters", "id", "registry_uid"},
+				Type:        schema.TypeString,
+				Description: "The UID of the registry to search for the pack in. This is a required parameter starting from version 0.21.0.",
+				Computed:    true,
+				Optional:    true,
 			},
 			"type": {
 				Type:        schema.TypeString,

--- a/spectrocloud/data_source_pack.go
+++ b/spectrocloud/data_source_pack.go
@@ -52,7 +52,7 @@ func dataSourcePack() *schema.Resource {
 			},
 			"registry_uid": {
 				Type:        schema.TypeString,
-				Description: "The UID of the registry to search for the pack in. This is a required parameter starting from version 0.21.0.",
+				Description: "The unique identifier (UID) of the registry where the pack is located. Specify `registry_uid` to search within a specific registry.",
 				Computed:    true,
 				Optional:    true,
 			},

--- a/spectrocloud/data_source_pack_simple.go
+++ b/spectrocloud/data_source_pack_simple.go
@@ -38,7 +38,7 @@ func dataSourcePackSimple() *schema.Resource {
 			"registry_uid": {
 				Type:        schema.TypeString,
 				Optional:    true,
-				Description: "The unique identifier of the registry the pack belongs to. This is a required parameter starting from version 0.21.0",
+				Description: "The unique identifier (UID) of the registry where the pack is located. Specify `registry_uid` to search within a specific registry.",
 			},
 			"type": {
 				Type:         schema.TypeString,

--- a/spectrocloud/data_source_pack_simple.go
+++ b/spectrocloud/data_source_pack_simple.go
@@ -37,8 +37,8 @@ func dataSourcePackSimple() *schema.Resource {
 			},
 			"registry_uid": {
 				Type:        schema.TypeString,
-				Required:    true,
-				Description: "The unique identifier (UID) of the registry that the pack belongs to. This is mandatory for identifying the specific registry in which the pack resides.",
+				Optional:    true,
+				Description: "The unique identifier of the registry the pack belongs to. This is a required parameter starting from version 0.21.0",
 			},
 			"type": {
 				Type:         schema.TypeString,

--- a/templates/data-sources/pack.md.tmpl
+++ b/templates/data-sources/pack.md.tmpl
@@ -11,7 +11,7 @@ description: |-
 
 
 
-~> Starting with Palette version 4.5 (and the corresponding provider release), the `registry_uid` attribute will become required. The existing `filters` attribute will be deprecated, and a new `pack_filters` attribute will be introduced for advanced search functionality.
+~> The existing `filters` attribute will be deprecated, and a new `pack_filters` attribute will be introduced for advanced search functionality.
 
 ## Example Usage
 

--- a/templates/data-sources/pack_simple.md.tmpl
+++ b/templates/data-sources/pack_simple.md.tmpl
@@ -11,8 +11,6 @@ description: |-
 
 ## Example Usage
 
-~> Starting with version 0.21.0 the attribute `registry_uid` is required.
-
 ```hcl
 data "spectrocloud_registry" "registry" {
   name = "Public Repo"


### PR DESCRIPTION
PLT-896: Make registry_uid attribute mandatory in spectrocloud_packs and spectrocloud_packs_simple (#517)"

This reverts commit 852f58eea847af833aa7836e5f91f68d4ae394ed.