### PR TITLE
docs: update account signup text

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -19,7 +19,7 @@ infrastructure stacks.
 
 ## Palette Account
 
-Sign up for a free trial account [here](https://www.spectrocloud.com/free-trial/).
+To get starteed with Palette, sign up for an account [here](https://www.spectrocloud.com/get-started).
 Use your Palette [API key](https://docs.spectrocloud.com/user-management/authentication/api-key/create-api-key) to authenticate. For more details on the authentication, navigate to the [authentication](#authentication) section.
 
 ## Example Usage

--- a/docs/index.md
+++ b/docs/index.md
@@ -19,7 +19,7 @@ infrastructure stacks.
 
 ## Palette Account
 
-To get starteed with Palette, sign up for an account [here](https://www.spectrocloud.com/get-started).
+To get started with Palette, sign up for an account [here](https://www.spectrocloud.com/get-started).
 Use your Palette [API key](https://docs.spectrocloud.com/user-management/authentication/api-key/create-api-key) to authenticate. For more details on the authentication, navigate to the [authentication](#authentication) section.
 
 ## Example Usage

--- a/templates/index.md.tmpl
+++ b/templates/index.md.tmpl
@@ -19,7 +19,7 @@ infrastructure stacks.
 
 ## Palette Account
 
-Sign up for a free trial account [here](https://www.spectrocloud.com/free-trial/).
+To get starteed with Palette, sign up for an account [here](https://www.spectrocloud.com/get-started).
 Use your Palette [API key](https://docs.spectrocloud.com/user-management/authentication/api-key/create-api-key) to authenticate. For more details on the authentication, navigate to the [authentication](#authentication) section.
 
 ## Example Usage

--- a/templates/index.md.tmpl
+++ b/templates/index.md.tmpl
@@ -19,7 +19,7 @@ infrastructure stacks.
 
 ## Palette Account
 
-To get starteed with Palette, sign up for an account [here](https://www.spectrocloud.com/get-started).
+To get started with Palette, sign up for an account [here](https://www.spectrocloud.com/get-started).
 Use your Palette [API key](https://docs.spectrocloud.com/user-management/authentication/api-key/create-api-key) to authenticate. For more details on the authentication, navigate to the [authentication](#authentication) section.
 
 ## Example Usage


### PR DESCRIPTION
This PR fixes the language on the main provider page regarding account signup. The mention of the free tier is removed, and the signup URL is updated.  