### PR TITLE
Use `strings.Replacer` and a single type to represent patch operations

### DIFF
--- a/spectrocloud/addon_deployment.go
+++ b/spectrocloud/addon_deployment.go
@@ -8,7 +8,7 @@ import (
 	"github.com/spectrocloud/palette-sdk-go/api/models"
 	"github.com/spectrocloud/palette-sdk-go/client"
 
-	"github.com/spectrocloud/terraform-provider-spectrocloud/types"
+	"github.com/spectrocloud/terraform-provider-spectrocloud/util/ptr"
 )
 
 func readAddonDeployment(c *client.V1Client, d *schema.ResourceData, cluster *models.V1SpectroCluster) (diag.Diagnostics, bool) {
@@ -104,7 +104,7 @@ func toAddonDeploymentPackCreate(pSrc interface{}) (*models.V1PackManifestEntity
 	pType := models.V1PackType(p["type"].(string))
 
 	pack := &models.V1PackManifestEntity{
-		Name:        types.Ptr(pName),
+		Name:        ptr.To(pName),
 		Tag:         pTag,
 		RegistryUID: pRegistryUID,
 		Type:        pType,

--- a/spectrocloud/addon_deployment_test.go
+++ b/spectrocloud/addon_deployment_test.go
@@ -1,12 +1,14 @@
 package spectrocloud
 
 import (
+	"testing"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/spectrocloud/palette-sdk-go/api/models"
-	"github.com/spectrocloud/terraform-provider-spectrocloud/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"testing"
+
+	"github.com/spectrocloud/terraform-provider-spectrocloud/util/ptr"
 )
 
 func TestToAddonDeploymentPackCreate(t *testing.T) {
@@ -36,7 +38,7 @@ func TestToAddonDeploymentPackCreate(t *testing.T) {
 				},
 			},
 			expected: &models.V1PackManifestEntity{
-				Name:        types.Ptr("test-pack"),
+				Name:        ptr.To("test-pack"),
 				Tag:         "v1.0.0",
 				RegistryUID: "registry-123",
 				Type:        "Addon",
@@ -70,7 +72,7 @@ func TestToAddonDeploymentPackCreate(t *testing.T) {
 				},
 			},
 			expected: &models.V1PackManifestEntity{
-				Name:        types.Ptr("test-pack"),
+				Name:        ptr.To("test-pack"),
 				Tag:         "v1.0.0",
 				RegistryUID: "",
 				Type:        "Addon",
@@ -95,7 +97,7 @@ func TestToAddonDeploymentPackCreate(t *testing.T) {
 				"manifest":     []interface{}{},
 			},
 			expected: &models.V1PackManifestEntity{
-				Name:        types.Ptr("test-pack"),
+				Name:        ptr.To("test-pack"),
 				Tag:         "v1.0.0",
 				RegistryUID: "registry-123",
 				Type:        "Addon",

--- a/spectrocloud/application_create_common.go
+++ b/spectrocloud/application_create_common.go
@@ -4,7 +4,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
 	"github.com/spectrocloud/palette-sdk-go/api/models"
-	"github.com/spectrocloud/terraform-provider-spectrocloud/types"
+
+	"github.com/spectrocloud/terraform-provider-spectrocloud/util/ptr"
 )
 
 // New Sandbox cluster.
@@ -36,9 +37,9 @@ func toAppDeploymentClusterGroupTargetSpec(d *schema.ResourceData) *models.V1App
 	config := configList.([]interface{})[0].(map[string]interface{})
 
 	return &models.V1AppDeploymentClusterGroupTargetSpec{
-		ClusterGroupUID: types.Ptr(config["cluster_group_uid"].(string)),
+		ClusterGroupUID: ptr.To(config["cluster_group_uid"].(string)),
 		ClusterLimits:   toAppDeploymentTargetClusterLimits(d),
-		ClusterName:     types.Ptr(config["cluster_name"].(string)),
+		ClusterName:     ptr.To(config["cluster_name"].(string)),
 	}
 }
 
@@ -65,7 +66,7 @@ func toAppDeploymentTargetClusterLimits(d *schema.ResourceData) *models.V1AppDep
 
 func toV1AppDeploymentProfileEntity(d *schema.ResourceData) *models.V1AppDeploymentProfileEntity {
 	return &models.V1AppDeploymentProfileEntity{
-		AppProfileUID: types.Ptr(d.Get("application_profile_uid").(string)),
+		AppProfileUID: ptr.To(d.Get("application_profile_uid").(string)),
 	}
 }
 
@@ -98,6 +99,6 @@ func toAppDeploymentVirtualClusterTargetSpec(d *schema.ResourceData) *models.V1A
 	config := configList.([]interface{})[0].(map[string]interface{})
 
 	return &models.V1AppDeploymentVirtualClusterTargetSpec{
-		ClusterUID: types.Ptr(config["cluster_uid"].(string)),
+		ClusterUID: ptr.To(config["cluster_uid"].(string)),
 	}
 }

--- a/spectrocloud/cluster_common_profiles.go
+++ b/spectrocloud/cluster_common_profiles.go
@@ -10,7 +10,7 @@ import (
 	"github.com/spectrocloud/palette-sdk-go/api/models"
 	"github.com/spectrocloud/palette-sdk-go/client"
 
-	"github.com/spectrocloud/terraform-provider-spectrocloud/types"
+	"github.com/spectrocloud/terraform-provider-spectrocloud/util/ptr"
 )
 
 func toProfiles(c *client.V1Client, d *schema.ResourceData, clusterContext string) ([]*models.V1SpectroClusterProfileEntity, error) {
@@ -86,7 +86,7 @@ func toPack(cluster *models.V1SpectroCluster, pSrc interface{}) *models.V1PackVa
 	p := pSrc.(map[string]interface{})
 
 	pack := &models.V1PackValuesEntity{
-		Name: types.Ptr(p["name"].(string)),
+		Name: ptr.To(p["name"].(string)),
 	}
 
 	setPackValues(pack, p)
@@ -130,7 +130,7 @@ func setPackManifests(pack *models.V1PackValuesEntity, p map[string]interface{},
 				uid = getManifestUID(data["name"].(string), packs)
 			}
 			manifests[i] = &models.V1ManifestRefUpdateEntity{
-				Name:    types.Ptr(data["name"].(string)),
+				Name:    ptr.To(data["name"].(string)),
 				Content: data["content"].(string),
 				UID:     uid,
 			}

--- a/spectrocloud/cluster_common_profiles_test.go
+++ b/spectrocloud/cluster_common_profiles_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/spectrocloud/palette-sdk-go/api/models"
 	"github.com/stretchr/testify/assert"
 
-	"github.com/spectrocloud/terraform-provider-spectrocloud/types"
+	"github.com/spectrocloud/terraform-provider-spectrocloud/util/ptr"
 )
 
 func TestToPack_PacksMerging(t *testing.T) {
@@ -16,13 +16,13 @@ func TestToPack_PacksMerging(t *testing.T) {
 				{
 					Packs: []*models.V1PackRef{
 						{
-							Name: types.Ptr("pack1"),
+							Name: ptr.To("pack1"),
 							Manifests: []*models.V1ObjectReference{
 								{Name: "pack1", UID: "uid1"},
 							},
 						},
 						{
-							Name: types.Ptr("pack2"),
+							Name: ptr.To("pack2"),
 							Manifests: []*models.V1ObjectReference{
 								{Name: "pack2", UID: "uid2"},
 							},
@@ -32,13 +32,13 @@ func TestToPack_PacksMerging(t *testing.T) {
 				{
 					Packs: []*models.V1PackRef{
 						{
-							Name: types.Ptr("pack3"),
+							Name: ptr.To("pack3"),
 							Manifests: []*models.V1ObjectReference{
 								{Name: "pack3", UID: "uid3"},
 							},
 						},
 						{
-							Name: types.Ptr("pack4"),
+							Name: ptr.To("pack4"),
 							Manifests: []*models.V1ObjectReference{
 								{Name: "pack4", UID: "uid4"},
 							},
@@ -67,18 +67,18 @@ func TestToPack_PacksMerging(t *testing.T) {
 	}
 
 	expectedPack := &models.V1PackValuesEntity{
-		Name:   types.Ptr("testPack"),
+		Name:   ptr.To("testPack"),
 		Values: "someValues",
 		Tag:    "v1",
 		Type:   models.V1PackType("testType"),
 		Manifests: []*models.V1ManifestRefUpdateEntity{
 			{
-				Name:    types.Ptr("pack1"),
+				Name:    ptr.To("pack1"),
 				Content: "content1",
 				UID:     "uid1",
 			},
 			{
-				Name:    types.Ptr("pack2"),
+				Name:    ptr.To("pack2"),
 				Content: "content2",
 				UID:     "uid2",
 			},

--- a/spectrocloud/cluster_common_test.go
+++ b/spectrocloud/cluster_common_test.go
@@ -2,16 +2,18 @@ package spectrocloud
 
 import (
 	"fmt"
-	"github.com/hashicorp/go-cty/cty"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/spectrocloud/gomi/pkg/ptr"
-	"github.com/spectrocloud/palette-sdk-go/client"
-	"github.com/stretchr/testify/require"
 	"reflect"
 	"sort"
 	"testing"
 	"time"
+
+	"github.com/hashicorp/go-cty/cty"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/spectrocloud/palette-sdk-go/client"
+	"github.com/stretchr/testify/require"
+
+	"github.com/spectrocloud/terraform-provider-spectrocloud/util/ptr"
 
 	"github.com/spectrocloud/palette-sdk-go/api/models"
 	"github.com/stretchr/testify/assert"
@@ -373,10 +375,10 @@ func prepareSpectroClusterModel() *models.V1SpectroCluster {
 						Name: "",
 						UID:  "test-host-cluster-uid",
 					},
-					IsHostCluster: ptr.BoolPtr(false),
+					IsHostCluster: ptr.To((false),,
 				},
 				LifecycleConfig: &models.V1LifecycleConfig{
-					Pause: ptr.BoolPtr(false),
+					Pause: ptr.To((false),,
 				},
 				MachineHealthConfig: &models.V1MachineHealthCheckConfig{
 					HealthCheckMaxUnhealthy:         "",
@@ -693,7 +695,7 @@ func TestToClusterHostConfigs(t *testing.T) {
 				},
 			},
 		},
-		IsHostCluster: ptr.BoolPtr(true),
+		IsHostCluster: ptr.To((true),,
 	}
 
 	assert.Equal(t, expected, result)
@@ -731,7 +733,7 @@ func TestToClusterHostConfigsNoHostConfig(t *testing.T) {
 
 	expected := &models.V1HostClusterConfig{
 		ClusterEndpoint: nil,
-		IsHostCluster:   ptr.BoolPtr(false),
+		IsHostCluster:   ptr.To((false),,
 	}
 
 	assert.Equal(t, expected, result)

--- a/spectrocloud/cluster_common_virtual_machine.go
+++ b/spectrocloud/cluster_common_virtual_machine.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
-	"github.com/spectrocloud/hapi/apiutil/transport"
+	"github.com/spectrocloud/palette-sdk-go/api/apiutil/transport"
 	"github.com/spectrocloud/palette-sdk-go/api/models"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"

--- a/spectrocloud/convert/hapi_to_kubevirt_status.go
+++ b/spectrocloud/convert/hapi_to_kubevirt_status.go
@@ -3,10 +3,12 @@ package convert
 import (
 	"encoding/json"
 	"fmt"
+
 	"github.com/spectrocloud/palette-sdk-go/api/models"
-	"github.com/spectrocloud/terraform-provider-spectrocloud/types"
 	k8sv1 "k8s.io/api/core/v1"
 	kubevirtapiv1 "kubevirt.io/api/core/v1"
+
+	"github.com/spectrocloud/terraform-provider-spectrocloud/util/ptr"
 )
 
 func ToKubevirtVMStatusM(status *models.V1ClusterVirtualMachineStatus) (kubevirtapiv1.VirtualMachineStatus, error) {
@@ -35,8 +37,8 @@ func ToKubevirtVMStatus(status *models.V1ClusterVirtualMachineStatus) kubevirtap
 	}
 
 	return kubevirtapiv1.VirtualMachineStatus{
-		SnapshotInProgress:     types.Ptr(status.SnapshotInProgress),
-		RestoreInProgress:      types.Ptr(status.RestoreInProgress),
+		SnapshotInProgress:     ptr.To(status.SnapshotInProgress),
+		RestoreInProgress:      ptr.To(status.RestoreInProgress),
 		Created:                status.Created,
 		Ready:                  status.Ready,
 		PrintableStatus:        PrintableStatus,

--- a/spectrocloud/convert/kubevirt_to_hapi_common.go
+++ b/spectrocloud/convert/kubevirt_to_hapi_common.go
@@ -9,7 +9,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kubevirtapiv1 "kubevirt.io/api/core/v1"
 
-	"github.com/spectrocloud/terraform-provider-spectrocloud/types"
+	"github.com/spectrocloud/terraform-provider-spectrocloud/util/ptr"
 )
 
 func ToHapiVm(vm *kubevirtapiv1.VirtualMachine) (*models.V1ClusterVirtualMachine, error) {
@@ -52,12 +52,12 @@ func ToHapiVmOwnerReferences(references []metav1.OwnerReference) []*models.V1VMO
 	ret := make([]*models.V1VMOwnerReference, len(references))
 	for i, reference := range references {
 		ret[i] = &models.V1VMOwnerReference{
-			APIVersion:         types.Ptr(reference.APIVersion),
+			APIVersion:         ptr.To(reference.APIVersion),
 			BlockOwnerDeletion: *reference.BlockOwnerDeletion,
 			Controller:         *reference.Controller,
-			Kind:               types.Ptr(reference.Kind),
-			Name:               types.Ptr(reference.Name),
-			UID:                types.Ptr(string(reference.UID)),
+			Kind:               ptr.To(reference.Kind),
+			Name:               ptr.To(reference.Name),
+			UID:                ptr.To(string(reference.UID)),
 		}
 	}
 

--- a/spectrocloud/convert/volume_kubevirt_to_hapi_common_test.go
+++ b/spectrocloud/convert/volume_kubevirt_to_hapi_common_test.go
@@ -3,15 +3,17 @@ package convert
 import (
 	"encoding/json"
 	"errors"
+	"testing"
+
 	"github.com/go-openapi/strfmt"
 	"github.com/spectrocloud/palette-sdk-go/api/models"
-	"github.com/spectrocloud/terraform-provider-spectrocloud/types"
 	"github.com/stretchr/testify/assert"
 	k8sv1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kubevirtapiv1 "kubevirt.io/api/core/v1"
 	cdiv1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
-	"testing"
+
+	"github.com/spectrocloud/terraform-provider-spectrocloud/util/ptr"
 )
 
 func TestToHapiVolume(t *testing.T) {
@@ -204,8 +206,8 @@ func TestToKubevirtVMStatus(t *testing.T) {
 		PrintableStatus:    "Running",
 		Conditions: []*models.V1VMVirtualMachineCondition{
 			{
-				Type:    types.Ptr("Ready"),
-				Status:  types.Ptr("True"),
+				Type:    ptr.To("Ready"),
+				Status:  ptr.To("True"),
 				Reason:  "Ready",
 				Message: "VM is ready",
 			},
@@ -305,12 +307,12 @@ func TestToKubevirtVM(t *testing.T) {
 			UID:       "123456",
 			OwnerReferences: []*models.V1VMOwnerReference{
 				{
-					APIVersion:         types.Ptr("v1"),
+					APIVersion:         ptr.To("v1"),
 					BlockOwnerDeletion: true,
 					Controller:         true,
-					Kind:               types.Ptr("ReplicaSet"),
-					Name:               types.Ptr("test-owner"),
-					UID:                types.Ptr("654321"),
+					Kind:               ptr.To("ReplicaSet"),
+					Name:               ptr.To("test-owner"),
+					UID:                ptr.To("654321"),
 				},
 			},
 			ManagedFields: []*models.V1VMManagedFieldsEntry{

--- a/spectrocloud/data_volume_schema_test.go
+++ b/spectrocloud/data_volume_schema_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/spectrocloud/terraform-provider-spectrocloud/spectrocloud/kubevirt/utils"
-	"github.com/spectrocloud/terraform-provider-spectrocloud/types"
+	"github.com/spectrocloud/terraform-provider-spectrocloud/util/ptr"
 )
 
 func prepareDataVolumeTestData() *schema.ResourceData {
@@ -115,16 +115,16 @@ func TestExpandAddVolumeOptions(t *testing.T) {
 	}
 
 	expected := &models.V1VMAddVolumeOptions{
-		Name: types.Ptr("test-volume"),
+		Name: ptr.To("test-volume"),
 		Disk: &models.V1VMDisk{
-			Name: types.Ptr("test-disk"),
+			Name: ptr.To("test-disk"),
 			Disk: &models.V1VMDiskTarget{
 				Bus: "scsi",
 			},
 		},
 		VolumeSource: &models.V1VMHotplugVolumeSource{
 			DataVolume: &models.V1VMCoreDataVolumeSource{
-				Name:         types.Ptr("test-data-volume"),
+				Name:         ptr.To("test-data-volume"),
 				Hotpluggable: true,
 			},
 		},

--- a/spectrocloud/kubevirt/schema/datavolume/source.go
+++ b/spectrocloud/kubevirt/schema/datavolume/source.go
@@ -4,7 +4,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	cdiv1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
 
-	"github.com/spectrocloud/terraform-provider-spectrocloud/types"
+	"github.com/spectrocloud/terraform-provider-spectrocloud/util/ptr"
 )
 
 func dataVolumeSourceFields() map[string]*schema.Schema {
@@ -212,7 +212,7 @@ func expandDataVolumeSourceRegistry(dataVolumeSourceRegistry []interface{}) *cdi
 	in := dataVolumeSourceRegistry[0].(map[string]interface{})
 
 	if v, ok := in["image_url"].(string); ok {
-		result.URL = types.Ptr(v)
+		result.URL = ptr.To(v)
 	}
 
 	return result

--- a/spectrocloud/kubevirt/schema/k8s/persistent_volume_claim.go
+++ b/spectrocloud/kubevirt/schema/k8s/persistent_volume_claim.go
@@ -9,7 +9,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 
 	"github.com/spectrocloud/terraform-provider-spectrocloud/spectrocloud/kubevirt/utils"
-	"github.com/spectrocloud/terraform-provider-spectrocloud/types"
+	"github.com/spectrocloud/terraform-provider-spectrocloud/util/ptr"
 )
 
 func persistentVolumeClaimSpecFields() map[string]*schema.Schema {
@@ -155,9 +155,9 @@ func ExpandPersistentVolumeClaimSpec(l []interface{}) (*v1.PersistentVolumeClaim
 	if v, ok := in["volume_mode"].(string); ok && v != "" {
 		switch v {
 		case string(v1.PersistentVolumeBlock):
-			obj.VolumeMode = types.Ptr(v1.PersistentVolumeBlock)
+			obj.VolumeMode = ptr.To(v1.PersistentVolumeBlock)
 		case string(v1.PersistentVolumeFilesystem):
-			obj.VolumeMode = types.Ptr(v1.PersistentVolumeFilesystem)
+			obj.VolumeMode = ptr.To(v1.PersistentVolumeFilesystem)
 		default:
 			return nil, fmt.Errorf("invalid volume mode: %s", v)
 		}

--- a/spectrocloud/kubevirt/test_utils/flatten_utils/flatten_utils.go
+++ b/spectrocloud/kubevirt/test_utils/flatten_utils/flatten_utils.go
@@ -4,7 +4,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
 	test_entities "github.com/spectrocloud/terraform-provider-spectrocloud/spectrocloud/kubevirt/test_utils/entities"
-	"github.com/spectrocloud/terraform-provider-spectrocloud/types"
+	"github.com/spectrocloud/terraform-provider-spectrocloud/util/ptr"
 
 	"github.com/spectrocloud/terraform-provider-spectrocloud/spectrocloud/kubevirt/utils"
 
@@ -30,7 +30,7 @@ func getDataVolumeSpec() cdiv1.DataVolumeSpec {
 				Name:      "name",
 			},
 			Registry: &cdiv1.DataVolumeSourceRegistry{
-				URL: types.Ptr("docker://gcr.io/spectro-images-public/daily/os/ubuntu-container-disk:22.04"),
+				URL: ptr.To("docker://gcr.io/spectro-images-public/daily/os/ubuntu-container-disk:22.04"),
 			},
 		},
 		PVC: &k8sv1.PersistentVolumeClaimSpec{
@@ -131,7 +131,7 @@ func GetBaseOutputForDataVolume() interface{} {
 						},
 						"registry": []interface{}{
 							map[string]interface{}{
-								"image_url": types.Ptr("docker://gcr.io/spectro-images-public/daily/os/ubuntu-container-disk:22.04"),
+								"image_url": ptr.To("docker://gcr.io/spectro-images-public/daily/os/ubuntu-container-disk:22.04"),
 							},
 						},
 					},
@@ -354,7 +354,7 @@ func GetBaseOutputForVirtualMachine() interface{} {
 								},
 								"registry": []interface{}{
 									map[string]interface{}{
-										"image_url": types.Ptr("docker://gcr.io/spectro-images-public/daily/os/ubuntu-container-disk:22.04"),
+										"image_url": ptr.To("docker://gcr.io/spectro-images-public/daily/os/ubuntu-container-disk:22.04"),
 									},
 								},
 							},

--- a/spectrocloud/resource_application_profile.go
+++ b/spectrocloud/resource_application_profile.go
@@ -2,15 +2,14 @@ package spectrocloud
 
 import (
 	"context"
+	"log"
+	"strings"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
 	"github.com/spectrocloud/terraform-provider-spectrocloud/spectrocloud/schemas"
-	"github.com/spectrocloud/terraform-provider-spectrocloud/types"
-
-	"log"
-	"strings"
-	"time"
+	"github.com/spectrocloud/terraform-provider-spectrocloud/util/ptr"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -341,7 +340,7 @@ func toApplicationProfilePackCreate(pSrc interface{}) (*models.V1AppTierEntity, 
 	pType := models.V1AppTierType(p["type"].(string))
 
 	tier := &models.V1AppTierEntity{
-		Name:             types.Ptr(pName),
+		Name:             ptr.To(pName),
 		Version:          pVersion,
 		SourceAppTierUID: source_app_tier,
 		RegistryUID:      pRegistryUID,
@@ -462,7 +461,7 @@ func toApplicationProfilePackUpdate(pSrc interface{}) *models.V1AppTierUpdateEnt
 		m := manifest.(map[string]interface{})
 		manifests = append(manifests, &models.V1ManifestRefUpdateEntity{
 			Content: strings.TrimSpace(m["content"].(string)),
-			Name:    types.Ptr(m["name"].(string)),
+			Name:    ptr.To(m["name"].(string)),
 			//UID:     getManifestUID(m["name"].(string), packs),
 		})
 	}

--- a/spectrocloud/resource_cloud_account_aws.go
+++ b/spectrocloud/resource_cloud_account_aws.go
@@ -8,7 +8,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
 	"github.com/spectrocloud/palette-sdk-go/api/models"
-	"github.com/spectrocloud/terraform-provider-spectrocloud/types"
+
+	"github.com/spectrocloud/terraform-provider-spectrocloud/util/ptr"
 )
 
 func resourceCloudAccountAws() *schema.Resource {
@@ -206,7 +207,7 @@ func toAwsAccount(d *schema.ResourceData) (*models.V1AwsAccount, error) {
 
 	// add partition to account
 	if d.Get("partition") != nil {
-		account.Spec.Partition = types.Ptr(d.Get("partition").(string))
+		account.Spec.Partition = ptr.To(d.Get("partition").(string))
 	}
 
 	// add policy arns to account

--- a/spectrocloud/resource_cloud_account_aws_test.go
+++ b/spectrocloud/resource_cloud_account_aws_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/spectrocloud/palette-sdk-go/api/models"
 	"github.com/stretchr/testify/assert"
 
-	"github.com/spectrocloud/terraform-provider-spectrocloud/types"
+	"github.com/spectrocloud/terraform-provider-spectrocloud/util/ptr"
 )
 
 func TestToAwsAccountCTXProjectSecret(t *testing.T) {
@@ -96,7 +96,7 @@ func TestFlattenCloudAccountAwsSTS(t *testing.T) {
 		Spec: &models.V1AwsCloudAccount{
 			CredentialType: models.V1AwsCloudAccountCredentialTypeSts,
 			Sts:            &models.V1AwsStsCredentials{Arn: "test_arn"},
-			Partition:      types.Ptr("test_partition"),
+			Partition:      ptr.To("test_partition"),
 			PolicyARNs:     []string{"arn:aws:test_policy1", "arn:aws:test_policy2"},
 		},
 	}
@@ -141,7 +141,7 @@ func TestFlattenCloudAccountAws_NonStsType(t *testing.T) {
 		Spec: &models.V1AwsCloudAccount{
 			CredentialType: models.V1AwsCloudAccountCredentialTypeSecret,
 			AccessKey:      "test_access_key_secret",
-			Partition:      types.Ptr("test_partition_secret"),
+			Partition:      ptr.To("test_partition_secret"),
 			PolicyARNs:     []string{"arn:aws:test_policy_secret1", "arn:aws:test_policy_secret2"},
 		},
 	}

--- a/spectrocloud/resource_cloud_account_azure.go
+++ b/spectrocloud/resource_cloud_account_azure.go
@@ -8,7 +8,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/spectrocloud/palette-sdk-go/api/models"
-	"github.com/spectrocloud/terraform-provider-spectrocloud/types"
+
+	"github.com/spectrocloud/terraform-provider-spectrocloud/util/ptr"
 )
 
 func resourceCloudAccountAzure() *schema.Resource {
@@ -207,9 +208,9 @@ func toAzureAccount(d *schema.ResourceData) *models.V1AzureAccount {
 			UID: d.Id(),
 		},
 		Spec: &models.V1AzureCloudAccount{
-			ClientID:     types.Ptr(d.Get("azure_client_id").(string)),
+			ClientID:     ptr.To(d.Get("azure_client_id").(string)),
 			ClientSecret: &clientSecret,
-			TenantID:     types.Ptr(d.Get("azure_tenant_id").(string)),
+			TenantID:     ptr.To(d.Get("azure_tenant_id").(string)),
 			TenantName:   d.Get("tenant_name").(string),
 			Settings: &models.V1CloudAccountSettings{
 				DisablePropertiesRequest: d.Get("disable_properties_request").(bool),
@@ -219,7 +220,7 @@ func toAzureAccount(d *schema.ResourceData) *models.V1AzureAccount {
 
 	// add partition to account
 	if d.Get("cloud") != nil {
-		account.Spec.AzureEnvironment = types.Ptr(d.Get("cloud").(string))
+		account.Spec.AzureEnvironment = ptr.To(d.Get("cloud").(string))
 	}
 	return account
 }

--- a/spectrocloud/resource_cloud_account_azure_test.go
+++ b/spectrocloud/resource_cloud_account_azure_test.go
@@ -2,13 +2,14 @@ package spectrocloud
 
 import (
 	"context"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
 	"github.com/spectrocloud/palette-sdk-go/api/models"
 	"github.com/stretchr/testify/assert"
 
-	"github.com/spectrocloud/terraform-provider-spectrocloud/types"
+	"github.com/spectrocloud/terraform-provider-spectrocloud/util/ptr"
 )
 
 // Test for toAzureAccount
@@ -47,14 +48,14 @@ func TestFlattenCloudAccountAzure(t *testing.T) {
 			UID:         "abcdef",
 		},
 		Spec: &models.V1AzureCloudAccount{
-			ClientID:     types.Ptr("test_client_id"),
-			ClientSecret: types.Ptr("test_client_secret"),
-			TenantID:     types.Ptr("test_tenant_id"),
+			ClientID:     ptr.To("test_client_id"),
+			ClientSecret: ptr.To("test_client_secret"),
+			TenantID:     ptr.To("test_tenant_id"),
 			TenantName:   "test_tenant_name",
 			Settings: &models.V1CloudAccountSettings{
 				DisablePropertiesRequest: true,
 			},
-			AzureEnvironment: types.Ptr("AzureUSGovernmentCloud"),
+			AzureEnvironment: ptr.To("AzureUSGovernmentCloud"),
 		},
 	}
 

--- a/spectrocloud/resource_cloud_account_maas_test.go
+++ b/spectrocloud/resource_cloud_account_maas_test.go
@@ -2,11 +2,13 @@ package spectrocloud
 
 import (
 	"context"
+	"testing"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/spectrocloud/palette-sdk-go/api/models"
-	"github.com/spectrocloud/terraform-provider-spectrocloud/types"
 	"github.com/stretchr/testify/assert"
-	"testing"
+
+	"github.com/spectrocloud/terraform-provider-spectrocloud/util/ptr"
 )
 
 // Test for the `toMaasAccount` function
@@ -31,8 +33,8 @@ func TestToMaasAccount(t *testing.T) {
 					UID:         "",
 				},
 				Spec: &models.V1MaasCloudAccount{
-					APIEndpoint: types.Ptr("http://api.endpoint"),
-					APIKey:      types.Ptr("api-key"),
+					APIEndpoint: ptr.To("http://api.endpoint"),
+					APIKey:      ptr.To("api-key"),
 				},
 			},
 		},

--- a/spectrocloud/resource_cloud_account_openstack.go
+++ b/spectrocloud/resource_cloud_account_openstack.go
@@ -7,7 +7,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/spectrocloud/palette-sdk-go/api/models"
-	"github.com/spectrocloud/terraform-provider-spectrocloud/types"
+
+	"github.com/spectrocloud/terraform-provider-spectrocloud/util/ptr"
 )
 
 func resourceCloudAccountOpenstack() *schema.Resource {
@@ -195,11 +196,11 @@ func toOpenStackAccount(d *schema.ResourceData) *models.V1OpenStackAccount {
 			CaCert:           d.Get("ca_certificate").(string),
 			DefaultDomain:    d.Get("default_domain").(string),
 			DefaultProject:   d.Get("default_project").(string),
-			IdentityEndpoint: types.Ptr(d.Get("identity_endpoint").(string)),
+			IdentityEndpoint: ptr.To(d.Get("identity_endpoint").(string)),
 			Insecure:         d.Get("openstack_allow_insecure").(bool),
 			ParentRegion:     d.Get("parent_region").(string),
-			Password:         types.Ptr(d.Get("openstack_password").(string)),
-			Username:         types.Ptr(d.Get("openstack_username").(string)),
+			Password:         ptr.To(d.Get("openstack_password").(string)),
+			Username:         ptr.To(d.Get("openstack_username").(string)),
 		},
 	}
 

--- a/spectrocloud/resource_cloud_account_openstack_test.go
+++ b/spectrocloud/resource_cloud_account_openstack_test.go
@@ -2,11 +2,13 @@ package spectrocloud
 
 import (
 	"context"
+	"testing"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/spectrocloud/palette-sdk-go/api/models"
-	"github.com/spectrocloud/terraform-provider-spectrocloud/types"
 	"github.com/stretchr/testify/assert"
-	"testing"
+
+	"github.com/spectrocloud/terraform-provider-spectrocloud/util/ptr"
 )
 
 // Test for the `toOpenStackAccount` function
@@ -40,11 +42,11 @@ func TestToOpenStackAccount(t *testing.T) {
 					CaCert:           "ca-cert",
 					DefaultDomain:    "default-domain",
 					DefaultProject:   "default-project",
-					IdentityEndpoint: types.Ptr("http://identity.endpoint"),
+					IdentityEndpoint: ptr.To("http://identity.endpoint"),
 					Insecure:         true,
 					ParentRegion:     "parent-region",
-					Password:         types.Ptr("password"),
-					Username:         types.Ptr("username"),
+					Password:         ptr.To("password"),
+					Username:         ptr.To("username"),
 				},
 			},
 		},
@@ -69,10 +71,10 @@ func TestToOpenStackAccount(t *testing.T) {
 				Spec: &models.V1OpenStackCloudAccount{
 					DefaultDomain:    "default-domain",
 					DefaultProject:   "default-project",
-					IdentityEndpoint: types.Ptr("http://identity.endpoint"),
+					IdentityEndpoint: ptr.To("http://identity.endpoint"),
 					ParentRegion:     "parent-region",
-					Password:         types.Ptr("password"),
-					Username:         types.Ptr("username"),
+					Password:         ptr.To("password"),
+					Username:         ptr.To("username"),
 				},
 			},
 		},

--- a/spectrocloud/resource_cloud_account_tke.go
+++ b/spectrocloud/resource_cloud_account_tke.go
@@ -7,7 +7,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/spectrocloud/palette-sdk-go/api/models"
-	"github.com/spectrocloud/terraform-provider-spectrocloud/types"
+
+	"github.com/spectrocloud/terraform-provider-spectrocloud/util/ptr"
 )
 
 func resourceCloudAccountTencent() *schema.Resource {
@@ -134,8 +135,8 @@ func toTencentAccount(d *schema.ResourceData) *models.V1TencentAccount {
 			UID:  d.Id(),
 		},
 		Spec: &models.V1TencentCloudAccount{
-			SecretID:  types.Ptr(d.Get("tencent_secret_id").(string)),
-			SecretKey: types.Ptr(d.Get("tencent_secret_key").(string)),
+			SecretID:  ptr.To(d.Get("tencent_secret_id").(string)),
+			SecretKey: ptr.To(d.Get("tencent_secret_key").(string)),
 		},
 	}
 

--- a/spectrocloud/resource_cloud_account_tke_test.go
+++ b/spectrocloud/resource_cloud_account_tke_test.go
@@ -2,11 +2,13 @@ package spectrocloud
 
 import (
 	"context"
+	"testing"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/spectrocloud/palette-sdk-go/api/models"
-	"github.com/spectrocloud/terraform-provider-spectrocloud/types"
 	"github.com/stretchr/testify/assert"
-	"testing"
+
+	"github.com/spectrocloud/terraform-provider-spectrocloud/util/ptr"
 )
 
 // Test for the `toTencentAccount` function
@@ -29,8 +31,8 @@ func TestToTencentAccount(t *testing.T) {
 					UID:  "", // UID is set from d.Id(), which is usually populated during resource creation
 				},
 				Spec: &models.V1TencentCloudAccount{
-					SecretID:  types.Ptr("test-secret-id"),
-					SecretKey: types.Ptr("test-secret-key"),
+					SecretID:  ptr.To("test-secret-id"),
+					SecretKey: ptr.To("test-secret-key"),
 				},
 			},
 		},
@@ -47,8 +49,8 @@ func TestToTencentAccount(t *testing.T) {
 					UID:  "",
 				},
 				Spec: &models.V1TencentCloudAccount{
-					SecretID:  types.Ptr(""),
-					SecretKey: types.Ptr(""),
+					SecretID:  ptr.To(""),
+					SecretKey: ptr.To(""),
 				},
 			},
 		},

--- a/spectrocloud/resource_cloud_account_vsphere.go
+++ b/spectrocloud/resource_cloud_account_vsphere.go
@@ -7,7 +7,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/spectrocloud/palette-sdk-go/api/models"
-	"github.com/spectrocloud/terraform-provider-spectrocloud/types"
+
+	"github.com/spectrocloud/terraform-provider-spectrocloud/util/ptr"
 )
 
 const OverlordUID = "overlordUid"
@@ -175,9 +176,9 @@ func toVsphereAccount(d *schema.ResourceData) *models.V1VsphereAccount {
 			UID: d.Id(),
 		},
 		Spec: &models.V1VsphereCloudAccount{
-			VcenterServer: types.Ptr(d.Get("vsphere_vcenter").(string)),
-			Username:      types.Ptr(d.Get("vsphere_username").(string)),
-			Password:      types.Ptr(d.Get("vsphere_password").(string)),
+			VcenterServer: ptr.To(d.Get("vsphere_vcenter").(string)),
+			Username:      ptr.To(d.Get("vsphere_username").(string)),
+			Password:      ptr.To(d.Get("vsphere_password").(string)),
 			Insecure:      d.Get("vsphere_ignore_insecure_error").(bool),
 		},
 	}

--- a/spectrocloud/resource_cloud_account_vsphere_negative_test.go
+++ b/spectrocloud/resource_cloud_account_vsphere_negative_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/spectrocloud/palette-sdk-go/api/models"
 
-	"github.com/spectrocloud/terraform-provider-spectrocloud/types"
+	"github.com/spectrocloud/terraform-provider-spectrocloud/util/ptr"
 )
 
 func skipSchemaAttributes(originalSchema map[string]*schema.Schema, keysToRemove []string) map[string]*schema.Schema {
@@ -38,8 +38,8 @@ func TestFlattenVsphereCloudAccountAttributes(t *testing.T) {
 			},
 		},
 		Spec: &models.V1VsphereCloudAccount{
-			VcenterServer: types.Ptr("vcenter.example.com"),
-			Username:      types.Ptr("user"),
+			VcenterServer: ptr.To("vcenter.example.com"),
+			Username:      ptr.To("user"),
 			Insecure:      false,
 		},
 	}

--- a/spectrocloud/resource_cloud_account_vsphere_test.go
+++ b/spectrocloud/resource_cloud_account_vsphere_test.go
@@ -2,13 +2,14 @@ package spectrocloud
 
 import (
 	"context"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
 	"github.com/spectrocloud/palette-sdk-go/api/models"
 	"github.com/stretchr/testify/assert"
 
-	"github.com/spectrocloud/terraform-provider-spectrocloud/types"
+	"github.com/spectrocloud/terraform-provider-spectrocloud/util/ptr"
 )
 
 func TestToVsphereAccount(t *testing.T) {
@@ -60,8 +61,8 @@ func TestFlattenVsphereCloudAccount(t *testing.T) {
 			UID:         "abcdef",
 		},
 		Spec: &models.V1VsphereCloudAccount{
-			VcenterServer: types.Ptr("vcenter.example.com"),
-			Username:      types.Ptr("testuser"),
+			VcenterServer: ptr.To("vcenter.example.com"),
+			Username:      ptr.To("testuser"),
 			Insecure:      true,
 		},
 	}

--- a/spectrocloud/resource_cluster_aks.go
+++ b/spectrocloud/resource_cluster_aks.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
 	"github.com/spectrocloud/terraform-provider-spectrocloud/spectrocloud/schemas"
-	"github.com/spectrocloud/terraform-provider-spectrocloud/types"
+	"github.com/spectrocloud/terraform-provider-spectrocloud/util/ptr"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -641,17 +641,17 @@ func toAksCluster(c *client.V1Client, d *schema.ResourceData) (*models.V1Spectro
 	cluster := &models.V1SpectroAzureClusterEntity{
 		Metadata: getClusterMetadata(d),
 		Spec: &models.V1SpectroAzureClusterEntitySpec{
-			CloudAccountUID: types.Ptr(d.Get("cloud_account_id").(string)),
+			CloudAccountUID: ptr.To(d.Get("cloud_account_id").(string)),
 			Profiles:        profiles,
 			Policies:        toPolicies(d),
 			CloudConfig: &models.V1AzureClusterConfig{
-				Location:      types.Ptr(cloudConfigMap["region"].(string)),
+				Location:      ptr.To(cloudConfigMap["region"].(string)),
 				ResourceGroup: cloudConfigMap["resource_group"].(string),
-				SSHKey:        types.Ptr(cloudConfigMap["ssh_key"].(string)),
+				SSHKey:        ptr.To(cloudConfigMap["ssh_key"].(string)),
 				APIServerAccessProfile: &models.V1APIServerAccessProfile{
 					EnablePrivateCluster: cloudConfigMap["private_cluster"].(bool),
 				},
-				SubscriptionID:     types.Ptr(cloudConfigMap["subscription_id"].(string)),
+				SubscriptionID:     ptr.To(cloudConfigMap["subscription_id"].(string)),
 				VnetName:           vnetname,
 				VnetResourceGroup:  vnetResourceGroup,
 				VnetCidrBlock:      vnetcidr,
@@ -714,8 +714,8 @@ func toMachinePoolAks(machinePool interface{}) *models.V1AzureMachinePoolConfigE
 			Taints:           toClusterTaints(m),
 			IsControlPlane:   controlPlane,
 			Labels:           labels,
-			Name:             types.Ptr(m["name"].(string)),
-			Size:             types.Ptr(int32(m["count"].(int))),
+			Name:             ptr.To(m["name"].(string)),
+			Size:             ptr.To(int32(m["count"].(int))),
 			UpdateStrategy: &models.V1UpdateStrategy{
 				Type: getUpdateStrategy(m),
 			},

--- a/spectrocloud/resource_cluster_aks_test.go
+++ b/spectrocloud/resource_cluster_aks_test.go
@@ -1,10 +1,12 @@
 package spectrocloud
 
 import (
-	"github.com/spectrocloud/gomi/pkg/ptr"
+	"testing"
+
 	"github.com/spectrocloud/palette-sdk-go/api/models"
 	"github.com/stretchr/testify/assert"
-	"testing"
+
+	"github.com/spectrocloud/terraform-provider-spectrocloud/util/ptr"
 )
 
 func TestToMachinePoolAks(t *testing.T) {
@@ -42,10 +44,10 @@ func TestFlattenClusterConfigsAks(t *testing.T) {
 	azureCloudConfig := &models.V1AzureCloudConfig{
 		Spec: &models.V1AzureCloudConfigSpec{
 			ClusterConfig: &models.V1AzureClusterConfig{
-				SubscriptionID: ptr.StringPtr("mySubscriptionID"),
+				SubscriptionID: ptr.To("mySubscriptionID"),
 				ResourceGroup:  "myResourceGroup",
-				Location:       ptr.StringPtr("eastus"),
-				SSHKey:         ptr.StringPtr("sshPublicKey"),
+				Location:       ptr.To("eastus"),
+				SSHKey:         ptr.To("sshPublicKey"),
 				APIServerAccessProfile: &models.V1APIServerAccessProfile{
 					EnablePrivateCluster: true,
 				},
@@ -74,7 +76,7 @@ func TestFlattenClusterConfigsAks(t *testing.T) {
 	assert.Len(t, flattened, 1)
 
 	m := flattened[0].(map[string]interface{})
-	assert.Equal(t, ptr.StringPtr("mySubscriptionID"), m["subscription_id"])
+	assert.Equal(t, ptr.To("mySubscriptionID"), m["subscription_id"])
 	assert.Equal(t, "myResourceGroup", m["resource_group"])
 	assert.Equal(t, "eastus", m["region"])
 	assert.Equal(t, "sshPublicKey", m["ssh_key"])

--- a/spectrocloud/resource_cluster_aws.go
+++ b/spectrocloud/resource_cluster_aws.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
 	"github.com/spectrocloud/terraform-provider-spectrocloud/spectrocloud/schemas"
-	"github.com/spectrocloud/terraform-provider-spectrocloud/types"
+	"github.com/spectrocloud/terraform-provider-spectrocloud/util/ptr"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -597,12 +597,12 @@ func toAwsCluster(c *client.V1Client, d *schema.ResourceData) (*models.V1Spectro
 	cluster := &models.V1SpectroAwsClusterEntity{
 		Metadata: getClusterMetadata(d),
 		Spec: &models.V1SpectroAwsClusterEntitySpec{
-			CloudAccountUID: types.Ptr(d.Get("cloud_account_id").(string)),
+			CloudAccountUID: ptr.To(d.Get("cloud_account_id").(string)),
 			Profiles:        profiles,
 			Policies:        toPolicies(d),
 			CloudConfig: &models.V1AwsClusterConfig{
 				SSHKeyName:               cloudConfig["ssh_key_name"].(string),
-				Region:                   types.Ptr(cloudConfig["region"].(string)),
+				Region:                   ptr.To(cloudConfig["region"].(string)),
 				VpcID:                    cloudConfig["vpc_id"].(string),
 				ControlPlaneLoadBalancer: cloudConfig["control_plane_lb"].(string),
 			},
@@ -683,7 +683,7 @@ func toMachinePoolAws(machinePool interface{}, vpcId string) (*models.V1AwsMachi
 	mp := &models.V1AwsMachinePoolConfigEntity{
 		CloudConfig: &models.V1AwsMachinePoolCloudConfigEntity{
 			Azs:            azs,
-			InstanceType:   types.Ptr(m["instance_type"].(string)),
+			InstanceType:   ptr.To(m["instance_type"].(string)),
 			CapacityType:   &capacityType,
 			RootDeviceSize: int64(m["disk_size_gb"].(int)),
 			Subnets:        azSubnetsConfigs,
@@ -693,8 +693,8 @@ func toMachinePoolAws(machinePool interface{}, vpcId string) (*models.V1AwsMachi
 			Taints:           toClusterTaints(m),
 			IsControlPlane:   controlPlane,
 			Labels:           labels,
-			Name:             types.Ptr(m["name"].(string)),
-			Size:             types.Ptr(int32(m["count"].(int))),
+			Name:             ptr.To(m["name"].(string)),
+			Size:             ptr.To(int32(m["count"].(int))),
 			UpdateStrategy: &models.V1UpdateStrategy{
 				Type: getUpdateStrategy(m),
 			},

--- a/spectrocloud/resource_cluster_aws_expand_test.go
+++ b/spectrocloud/resource_cluster_aws_expand_test.go
@@ -1,11 +1,13 @@
 package spectrocloud
 
 import (
+	"testing"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/spectrocloud/palette-sdk-go/api/models"
-	"github.com/spectrocloud/terraform-provider-spectrocloud/types"
 	"github.com/stretchr/testify/assert"
-	"testing"
+
+	"github.com/spectrocloud/terraform-provider-spectrocloud/util/ptr"
 )
 
 func TestToMachinePoolAws(t *testing.T) {
@@ -32,14 +34,14 @@ func TestToMachinePoolAws(t *testing.T) {
 			expected: &models.V1AwsMachinePoolConfigEntity{
 				CloudConfig: &models.V1AwsMachinePoolCloudConfigEntity{
 					Azs:            []string{"us-west-2b", "us-west-2a"},
-					InstanceType:   types.Ptr("t3.large"),
-					CapacityType:   types.Ptr("on-demand"),
+					InstanceType:   ptr.To("t3.large"),
+					CapacityType:   ptr.To("on-demand"),
 					RootDeviceSize: 100,
 					Subnets:        []*models.V1AwsSubnetEntity{},
 				},
 				PoolConfig: &models.V1MachinePoolConfigEntity{
-					Name:             types.Ptr("control-plane-pool"),
-					Size:             types.Ptr(int32(3)),
+					Name:             ptr.To("control-plane-pool"),
+					Size:             ptr.To(int32(3)),
 					MinSize:          3,
 					MaxSize:          3,
 					IsControlPlane:   true,
@@ -71,8 +73,8 @@ func TestToMachinePoolAws(t *testing.T) {
 			expected: &models.V1AwsMachinePoolConfigEntity{
 				CloudConfig: &models.V1AwsMachinePoolCloudConfigEntity{
 					Azs:            []string{"us-west-1a"},
-					InstanceType:   types.Ptr("t3.medium"),
-					CapacityType:   types.Ptr("spot"),
+					InstanceType:   ptr.To("t3.medium"),
+					CapacityType:   ptr.To("spot"),
 					RootDeviceSize: 50,
 					Subnets: []*models.V1AwsSubnetEntity{
 						{ID: "subnet-1", Az: "us-west-1a"},
@@ -82,8 +84,8 @@ func TestToMachinePoolAws(t *testing.T) {
 					},
 				},
 				PoolConfig: &models.V1MachinePoolConfigEntity{
-					Name:               types.Ptr("worker-pool"),
-					Size:               types.Ptr(int32(5)),
+					Name:               ptr.To("worker-pool"),
+					Size:               ptr.To(int32(5)),
 					MinSize:            5,
 					MaxSize:            5,
 					IsControlPlane:     false,

--- a/spectrocloud/resource_cluster_aws_flatten_test.go
+++ b/spectrocloud/resource_cluster_aws_flatten_test.go
@@ -6,8 +6,9 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/spectrocloud/palette-sdk-go/api/models"
 
-	"github.com/spectrocloud/terraform-provider-spectrocloud/types"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/spectrocloud/terraform-provider-spectrocloud/util/ptr"
 )
 
 func TestFlattenMachinePoolConfigsAws(t *testing.T) {
@@ -31,7 +32,7 @@ func TestFlattenMachinePoolConfigsAws(t *testing.T) {
 			input: []*models.V1AwsMachinePoolConfig{
 				{
 					Name:                    "pool1",
-					IsControlPlane:          types.Ptr(true),
+					IsControlPlane:          ptr.To(true),
 					UseControlPlaneAsWorker: false,
 					Size:                    3,
 					MinSize:                 1,
@@ -134,7 +135,7 @@ func TestFlattenClusterConfigsAws(t *testing.T) {
 				Spec: &models.V1AwsCloudConfigSpec{
 					ClusterConfig: &models.V1AwsClusterConfig{
 						SSHKeyName:               "my-ssh-key",
-						Region:                   types.Ptr("us-west-2"),
+						Region:                   ptr.To("us-west-2"),
 						VpcID:                    "vpc-12345",
 						ControlPlaneLoadBalancer: "lb-12345",
 					},

--- a/spectrocloud/resource_cluster_azure.go
+++ b/spectrocloud/resource_cluster_azure.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
 	"github.com/spectrocloud/terraform-provider-spectrocloud/spectrocloud/schemas"
-	"github.com/spectrocloud/terraform-provider-spectrocloud/types"
+	"github.com/spectrocloud/terraform-provider-spectrocloud/util/ptr"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -635,13 +635,13 @@ func toAzureCluster(c *client.V1Client, d *schema.ResourceData) (*models.V1Spect
 	cluster := &models.V1SpectroAzureClusterEntity{
 		Metadata: getClusterMetadata(d),
 		Spec: &models.V1SpectroAzureClusterEntitySpec{
-			CloudAccountUID: types.Ptr(d.Get("cloud_account_id").(string)),
+			CloudAccountUID: ptr.To(d.Get("cloud_account_id").(string)),
 			Profiles:        profiles,
 			Policies:        toPolicies(d),
 			CloudConfig: &models.V1AzureClusterConfig{
-				Location:           types.Ptr(cloudConfig["region"].(string)),
-				SSHKey:             types.Ptr(cloudConfig["ssh_key"].(string)),
-				SubscriptionID:     types.Ptr(cloudConfig["subscription_id"].(string)),
+				Location:           ptr.To(cloudConfig["region"].(string)),
+				SSHKey:             ptr.To(cloudConfig["ssh_key"].(string)),
+				SubscriptionID:     ptr.To(cloudConfig["subscription_id"].(string)),
 				ResourceGroup:      cloudConfig["resource_group"].(string),
 				StorageAccountName: cloudConfig["storage_account_name"].(string),
 				ContainerName:      cloudConfig["container_name"].(string),
@@ -741,8 +741,8 @@ func toMachinePoolAzure(machinePool interface{}) (*models.V1AzureMachinePoolConf
 			Taints:           toClusterTaints(m),
 			IsControlPlane:   controlPlane,
 			Labels:           labels,
-			Name:             types.Ptr(m["name"].(string)),
-			Size:             types.Ptr(int32(m["count"].(int))),
+			Name:             ptr.To(m["name"].(string)),
+			Size:             ptr.To(int32(m["count"].(int))),
 			UpdateStrategy: &models.V1UpdateStrategy{
 				Type: getUpdateStrategy(m),
 			},

--- a/spectrocloud/resource_cluster_azure_test.go
+++ b/spectrocloud/resource_cluster_azure_test.go
@@ -4,13 +4,12 @@ import (
 	"sort"
 	"testing"
 
-	"github.com/spectrocloud/gomi/pkg/ptr"
+	"github.com/spectrocloud/terraform-provider-spectrocloud/util/ptr"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/spectrocloud/palette-sdk-go/api/models"
-	"github.com/spectrocloud/terraform-provider-spectrocloud/types"
 )
 
 func prepareAzureTestData() *schema.ResourceData {
@@ -137,8 +136,8 @@ func TestValidateCPPoolCount(t *testing.T) {
 	cpConfig1 := &models.V1AzureMachinePoolConfigEntity{
 		PoolConfig: &models.V1MachinePoolConfigEntity{
 			IsControlPlane: true,
-			Size:           types.Ptr(int32(4)),
-			Name:           types.Ptr("cp1"),
+			Size:           ptr.To(int32(4)),
+			Name:           ptr.To("cp1"),
 		},
 	}
 
@@ -146,8 +145,8 @@ func TestValidateCPPoolCount(t *testing.T) {
 	workerConfig := &models.V1AzureMachinePoolConfigEntity{
 		PoolConfig: &models.V1MachinePoolConfigEntity{
 			IsControlPlane: false,
-			Size:           types.Ptr(int32(6)),
-			Name:           types.Ptr("worker1"),
+			Size:           ptr.To(int32(6)),
+			Name:           ptr.To("worker1"),
 		},
 	}
 
@@ -155,8 +154,8 @@ func TestValidateCPPoolCount(t *testing.T) {
 	nonCPConfig := &models.V1AzureMachinePoolConfigEntity{
 		PoolConfig: &models.V1MachinePoolConfigEntity{
 			IsControlPlane: false,
-			Size:           types.Ptr(int32(7)),
-			Name:           types.Ptr("worker2"),
+			Size:           ptr.To(int32(7)),
+			Name:           ptr.To("worker2"),
 		},
 	}
 
@@ -231,7 +230,7 @@ func TestFlattenMachinePoolConfigsAzure(t *testing.T) {
 			Azs:                   azsList,
 			InstanceConfig:        nil,
 			InstanceType:          "Standard_DS2_v2",
-			IsControlPlane:        types.Ptr(false),
+			IsControlPlane:        ptr.To(false),
 			IsSystemNodePool:      false,
 			Labels:                nil,
 			MachinePoolProperties: nil,
@@ -280,10 +279,10 @@ func TestFlattenClusterConfigsAzure(t *testing.T) {
 		config := &models.V1AzureCloudConfig{
 			Spec: &models.V1AzureCloudConfigSpec{
 				ClusterConfig: &models.V1AzureClusterConfig{
-					SubscriptionID:     types.Ptr("test-subscription-id"),
+					SubscriptionID:     ptr.To("test-subscription-id"),
 					ResourceGroup:      "test-resource-group",
-					Location:           types.Ptr("test-location"),
-					SSHKey:             types.Ptr("test-ssh-key"),
+					Location:           ptr.To("test-location"),
+					SSHKey:             ptr.To("test-ssh-key"),
 					StorageAccountName: "test-storage-account",
 					ContainerName:      "test-container",
 					VnetResourceGroup:  "test-network-resource-group",
@@ -297,10 +296,10 @@ func TestFlattenClusterConfigsAzure(t *testing.T) {
 
 		expected := []interface{}{
 			map[string]interface{}{
-				"subscription_id":            ptr.StringPtr("test-subscription-id"),
+				"subscription_id":            ptr.To("test-subscription-id"),
 				"resource_group":             "test-resource-group",
-				"region":                     ptr.StringPtr("test-location"),
-				"ssh_key":                    ptr.StringPtr("test-ssh-key"),
+				"region":                     ptr.To("test-location"),
+				"ssh_key":                    ptr.To("test-ssh-key"),
 				"storage_account_name":       "test-storage-account",
 				"container_name":             "test-container",
 				"network_resource_group":     "test-network-resource-group",
@@ -334,7 +333,7 @@ func TestFlattenClusterConfigsAzure(t *testing.T) {
 			Spec: &models.V1AzureCloudConfigSpec{
 				ClusterConfig: &models.V1AzureClusterConfig{
 					ResourceGroup: "test-resource-group",
-					Location:      types.Ptr("test-location"),
+					Location:      ptr.To("test-location"),
 				},
 			},
 		}
@@ -342,7 +341,7 @@ func TestFlattenClusterConfigsAzure(t *testing.T) {
 		expected := []interface{}{
 			map[string]interface{}{
 				"resource_group": "test-resource-group",
-				"region":         ptr.StringPtr("test-location"),
+				"region":         ptr.To("test-location"),
 			},
 		}
 

--- a/spectrocloud/resource_cluster_custom_cloud.go
+++ b/spectrocloud/resource_cluster_custom_cloud.go
@@ -2,17 +2,18 @@ package spectrocloud
 
 import (
 	"context"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/spectrocloud/gomi/pkg/ptr"
-	"github.com/spectrocloud/palette-sdk-go/api/models"
-	"github.com/spectrocloud/palette-sdk-go/client"
-	"github.com/spectrocloud/terraform-provider-spectrocloud/spectrocloud/schemas"
-	"github.com/spectrocloud/terraform-provider-spectrocloud/types"
 	"log"
 	"strings"
 	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/spectrocloud/palette-sdk-go/api/models"
+	"github.com/spectrocloud/palette-sdk-go/client"
+
+	"github.com/spectrocloud/terraform-provider-spectrocloud/spectrocloud/schemas"
+	"github.com/spectrocloud/terraform-provider-spectrocloud/util/ptr"
 )
 
 func resourceClusterCustomCloud() *schema.Resource {
@@ -389,7 +390,7 @@ func toCustomCloudCluster(c *client.V1Client, d *schema.ResourceData) (*models.V
 	cluster := &models.V1SpectroCustomClusterEntity{
 		Metadata: toClusterMetadataUpdate(d),
 		Spec: &models.V1SpectroCustomClusterEntitySpec{
-			CloudAccountUID:   types.Ptr(d.Get("cloud_account_id").(string)),
+			CloudAccountUID:   ptr.To(d.Get("cloud_account_id").(string)),
 			CloudConfig:       customCloudConfig,
 			ClusterConfig:     customClusterConfig,
 			Machinepoolconfig: machinePoolConfigs,
@@ -404,7 +405,7 @@ func toCustomCloudConfig(d *schema.ResourceData) *models.V1CustomClusterConfig {
 	cloudConfig := d.Get("cloud_config").([]interface{})[0].(map[string]interface{})
 	valuesYamlStr := strings.TrimSpace(cloudConfig["values"].(string))
 	customCloudConfig := &models.V1CustomClusterConfig{
-		Values: ptr.StringPtr(valuesYamlStr),
+		Values: ptr.To(valuesYamlStr),
 	}
 
 	return customCloudConfig
@@ -489,8 +490,8 @@ func flattenCloudConfigsValuesCustomCloud(config *models.V1CustomCloudConfig) []
 
 	m := make(map[string]interface{})
 
-	if ptr.String(config.Spec.ClusterConfig.Values) != "" {
-		m["values"] = ptr.String(config.Spec.ClusterConfig.Values)
+	if ptr.DeRef(config.Spec.ClusterConfig.Values) != "" {
+		m["values"] = ptr.DeRef(config.Spec.ClusterConfig.Values)
 	}
 	return []interface{}{m}
 }

--- a/spectrocloud/resource_cluster_custom_cloud_test.go
+++ b/spectrocloud/resource_cluster_custom_cloud_test.go
@@ -3,9 +3,10 @@ package spectrocloud
 import (
 	"testing"
 
-	"github.com/spectrocloud/gomi/pkg/ptr"
 	"github.com/spectrocloud/palette-sdk-go/api/models"
 	"github.com/spectrocloud/palette-sdk-go/client"
+
+	"github.com/spectrocloud/terraform-provider-spectrocloud/util/ptr"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -27,7 +28,7 @@ func TestFlattenCloudConfigsValuesCustomCloud(t *testing.T) {
 
 	// Test case 4: When config.Spec.ClusterConfig.Values is not nil
 	config.Spec.ClusterConfig = &models.V1CustomClusterConfig{
-		Values: ptr.StringPtr("test-values"),
+		Values: ptr.To("test-values"),
 	}
 	result = flattenCloudConfigsValuesCustomCloud(config)
 	assert.Len(t, result, 1, "Expected one element in the slice")
@@ -152,11 +153,11 @@ func TestToCustomCloudCluster(t *testing.T) {
 	// Assertions
 	assert.NoError(t, err) // Ensure no error occurred
 	assert.NotNil(t, cluster)
-	assert.Equal(t, ptr.StringPtr("test-cloud-account-id"), cluster.Spec.CloudAccountUID) // Verify CloudAccountUID
-	assert.NotNil(t, cluster.Spec.CloudConfig)                                            // Verify CloudConfig
-	assert.NotNil(t, cluster.Spec.ClusterConfig)                                          // Verify ClusterConfig
-	assert.NotNil(t, cluster.Spec.Machinepoolconfig)                                      // Verify Machinepoolconfig
-	assert.NotNil(t, cluster.Spec.Profiles)                                               // Verify Profiles
+	assert.Equal(t, ptr.To("test-cloud-account-id"), cluster.Spec.CloudAccountUID) // Verify CloudAccountUID
+	assert.NotNil(t, cluster.Spec.CloudConfig)                                     // Verify CloudConfig
+	assert.NotNil(t, cluster.Spec.ClusterConfig)                                   // Verify ClusterConfig
+	assert.NotNil(t, cluster.Spec.Machinepoolconfig)                               // Verify Machinepoolconfig
+	assert.NotNil(t, cluster.Spec.Profiles)                                        // Verify Profiles
 }
 
 func boolPtr(b bool) *bool {

--- a/spectrocloud/resource_cluster_edge_native.go
+++ b/spectrocloud/resource_cluster_edge_native.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
 	schemas "github.com/spectrocloud/terraform-provider-spectrocloud/spectrocloud/schemas"
-	"github.com/spectrocloud/terraform-provider-spectrocloud/types"
+	"github.com/spectrocloud/terraform-provider-spectrocloud/util/ptr"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -678,8 +678,8 @@ func toMachinePoolEdgeNative(machinePool interface{}) (*models.V1EdgeNativeMachi
 			Taints:           toClusterTaints(m),
 			IsControlPlane:   controlPlane,
 			Labels:           labels,
-			Name:             types.Ptr(m["name"].(string)),
-			Size:             types.Ptr(int32(len(cloudConfig.EdgeHosts))),
+			Name:             ptr.To(m["name"].(string)),
+			Size:             ptr.To(int32(len(cloudConfig.EdgeHosts))),
 			UpdateStrategy: &models.V1UpdateStrategy{
 				Type: getUpdateStrategy(m),
 			},

--- a/spectrocloud/resource_cluster_edge_native_test.go
+++ b/spectrocloud/resource_cluster_edge_native_test.go
@@ -1,9 +1,10 @@
 package spectrocloud
 
 import (
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"reflect"
 	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
 	"github.com/stretchr/testify/assert"
 
@@ -11,7 +12,7 @@ import (
 
 	"github.com/spectrocloud/palette-sdk-go/api/models"
 
-	"github.com/spectrocloud/terraform-provider-spectrocloud/types"
+	"github.com/spectrocloud/terraform-provider-spectrocloud/util/ptr"
 )
 
 func ToSchemaSetFromStrings(strings []string) *schema.Set {
@@ -321,8 +322,8 @@ func TestToMachinePoolEdgeNative(t *testing.T) {
 					Taints:                  toClusterTaints(tt.input),
 					IsControlPlane:          true,
 					Labels:                  []string{"control-plane"},
-					Name:                    types.Ptr("pool1"),
-					Size:                    types.Ptr(int32(len(edgeHosts.EdgeHosts))),
+					Name:                    ptr.To("pool1"),
+					Size:                    ptr.To(int32(len(edgeHosts.EdgeHosts))),
 					UpdateStrategy:          &models.V1UpdateStrategy{Type: getUpdateStrategy(tt.input)},
 					UseControlPlaneAsWorker: false,
 				},

--- a/spectrocloud/resource_cluster_edge_vsphere.go
+++ b/spectrocloud/resource_cluster_edge_vsphere.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
 	"github.com/spectrocloud/terraform-provider-spectrocloud/spectrocloud/schemas"
-	"github.com/spectrocloud/terraform-provider-spectrocloud/types"
+	"github.com/spectrocloud/terraform-provider-spectrocloud/util/ptr"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -612,7 +612,7 @@ func toMachinePoolEdgeVsphere(machinePool interface{}) (*models.V1VsphereMachine
 			ResourcePool: p["resource_pool"].(string),
 			Datastore:    p["datastore"].(string),
 			Network: &models.V1VsphereNetworkConfigEntity{
-				NetworkName:   types.Ptr(p["network"].(string)),
+				NetworkName:   ptr.To(p["network"].(string)),
 				ParentPoolUID: poolID,
 				StaticIP:      staticIP,
 			},
@@ -622,9 +622,9 @@ func toMachinePoolEdgeVsphere(machinePool interface{}) (*models.V1VsphereMachine
 
 	ins := m["instance_type"].([]interface{})[0].(map[string]interface{})
 	instanceType := models.V1VsphereInstanceType{
-		DiskGiB:   types.Ptr(int32(ins["disk_size_gb"].(int))),
-		MemoryMiB: types.Ptr(int64(ins["memory_mb"].(int))),
-		NumCPUs:   types.Ptr(int32(ins["cpu"].(int))),
+		DiskGiB:   ptr.To(int32(ins["disk_size_gb"].(int))),
+		MemoryMiB: ptr.To(int64(ins["memory_mb"].(int))),
+		NumCPUs:   ptr.To(int32(ins["cpu"].(int))),
 	}
 
 	mp := &models.V1VsphereMachinePoolConfigEntity{
@@ -637,8 +637,8 @@ func toMachinePoolEdgeVsphere(machinePool interface{}) (*models.V1VsphereMachine
 			Taints:           toClusterTaints(m),
 			IsControlPlane:   controlPlane,
 			Labels:           labels,
-			Name:             types.Ptr(m["name"].(string)),
-			Size:             types.Ptr(int32(m["count"].(int))),
+			Name:             ptr.To(m["name"].(string)),
+			Size:             ptr.To(int32(m["count"].(int))),
 			UpdateStrategy: &models.V1UpdateStrategy{
 				Type: getUpdateStrategy(m),
 			},

--- a/spectrocloud/resource_cluster_edge_vsphere_test.go
+++ b/spectrocloud/resource_cluster_edge_vsphere_test.go
@@ -1,10 +1,12 @@
 package spectrocloud
 
 import (
-	"github.com/spectrocloud/gomi/pkg/ptr"
-	"github.com/spectrocloud/palette-sdk-go/api/models"
-	"github.com/spectrocloud/terraform-provider-spectrocloud/types"
 	"testing"
+
+	"github.com/spectrocloud/palette-sdk-go/api/models"
+
+	"github.com/spectrocloud/terraform-provider-spectrocloud/util/ptr"
+	"github.com/spectrocloud/terraform-provider-spectrocloud/util/ptr"
 )
 
 func TestFlattenMachinePoolConfigsEdgeVsphere(t *testing.T) {
@@ -36,28 +38,28 @@ func TestFlattenMachinePoolConfigsEdgeVsphere(t *testing.T) {
 							Value:     "np",
 						},
 					},
-					IsControlPlane:          ptr.BoolPtr(true),
-					NodeRepaveInterval:      30,
+					IsControlPlane: ptr.To((true),
+						NodeRepaveInterval:      30,
 					UseControlPlaneAsWorker: true,
 					Name:                    "pool1",
 					Size:                    3,
 					InstanceType: &models.V1VsphereInstanceType{
-						DiskGiB:   int32Ptr(100),
-						MemoryMiB: int64Ptr(8192),
-						NumCPUs:   int32Ptr(4),
-					},
+					DiskGiB:   int32Ptr(100),
+					MemoryMiB: int64Ptr(8192),
+					NumCPUs:   int32Ptr(4),
+				},
 					Placements: []*models.V1VspherePlacementConfig{
-						{
-							UID:          "placement1",
-							Cluster:      "cluster1",
-							ResourcePool: "resourcepool1",
-							Datastore:    "datastore1",
-							Network: &models.V1VsphereNetworkConfig{
-								NetworkName:   ptr.StringPtr("network1"),
-								ParentPoolRef: &models.V1ObjectReference{UID: "pool1"},
-							},
-						},
-					},
+				{
+					UID:          "placement1",
+					Cluster:      "cluster1",
+					ResourcePool: "resourcepool1",
+					Datastore:    "datastore1",
+					Network: &models.V1VsphereNetworkConfig{
+					NetworkName:   ptr.To("network1"),
+					ParentPoolRef: &models.V1ObjectReference{UID: "pool1"},
+				},
+				},
+				},
 				},
 			},
 			expected: []interface{}{
@@ -136,23 +138,23 @@ func TestToMachinePoolEdgeVsphere(t *testing.T) {
 							ResourcePool: "resourcepool1",
 							Datastore:    "datastore1",
 							Network: &models.V1VsphereNetworkConfigEntity{
-								NetworkName:   types.Ptr("network1"),
+								NetworkName:   ptr.To("network1"),
 								ParentPoolUID: "pool1",
 								StaticIP:      true,
 							},
 						},
 					},
 					InstanceType: &models.V1VsphereInstanceType{
-						DiskGiB:   types.Ptr(int32(100)),
-						MemoryMiB: types.Ptr(int64(8192)),
-						NumCPUs:   types.Ptr(int32(4)),
+						DiskGiB:   ptr.To(int32(100)),
+						MemoryMiB: ptr.To(int64(8192)),
+						NumCPUs:   ptr.To(int32(4)),
 					},
 				},
 				PoolConfig: &models.V1MachinePoolConfigEntity{
 					IsControlPlane:     false,
 					Labels:             []string{"worker"},
-					Name:               types.Ptr("worker-pool"),
-					Size:               types.Ptr(int32(3)),
+					Name:               ptr.To("worker-pool"),
+					Size:               ptr.To(int32(3)),
 					NodeRepaveInterval: 24,
 					UpdateStrategy: &models.V1UpdateStrategy{
 						Type: "",
@@ -197,23 +199,23 @@ func TestToMachinePoolEdgeVsphere(t *testing.T) {
 							ResourcePool: "resourcepool2",
 							Datastore:    "datastore2",
 							Network: &models.V1VsphereNetworkConfigEntity{
-								NetworkName:   types.Ptr("network2"),
+								NetworkName:   ptr.To("network2"),
 								ParentPoolUID: "",
 								StaticIP:      false,
 							},
 						},
 					},
 					InstanceType: &models.V1VsphereInstanceType{
-						DiskGiB:   types.Ptr(int32(200)),
-						MemoryMiB: types.Ptr(int64(16384)),
-						NumCPUs:   types.Ptr(int32(8)),
+						DiskGiB:   ptr.To(int32(200)),
+						MemoryMiB: ptr.To(int64(16384)),
+						NumCPUs:   ptr.To(int32(8)),
 					},
 				},
 				PoolConfig: &models.V1MachinePoolConfigEntity{
 					IsControlPlane: true,
 					Labels:         []string{"control-plane"},
-					Name:           types.Ptr("control-plane-pool"),
-					Size:           types.Ptr(int32(1)),
+					Name:           ptr.To("control-plane-pool"),
+					Size:           ptr.To(int32(1)),
 					UpdateStrategy: &models.V1UpdateStrategy{
 						Type: "",
 					},

--- a/spectrocloud/resource_cluster_eks.go
+++ b/spectrocloud/resource_cluster_eks.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	"github.com/spectrocloud/terraform-provider-spectrocloud/spectrocloud/schemas"
-	"github.com/spectrocloud/terraform-provider-spectrocloud/types"
+	"github.com/spectrocloud/terraform-provider-spectrocloud/util/ptr"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -740,13 +740,13 @@ func toEksCluster(c *client.V1Client, d *schema.ResourceData) (*models.V1Spectro
 	cluster := &models.V1SpectroEksClusterEntity{
 		Metadata: getClusterMetadata(d),
 		Spec: &models.V1SpectroEksClusterEntitySpec{
-			CloudAccountUID: types.Ptr(d.Get("cloud_account_id").(string)),
+			CloudAccountUID: ptr.To(d.Get("cloud_account_id").(string)),
 			Profiles:        profiles,
 			Policies:        toPolicies(d),
 			CloudConfig: &models.V1EksClusterConfig{
 				BastionDisabled:  true,
 				VpcID:            cloudConfig["vpc_id"].(string),
-				Region:           types.Ptr(cloudConfig["region"].(string)),
+				Region:           ptr.To(cloudConfig["region"].(string)),
 				SSHKeyName:       cloudConfig["ssh_key_name"].(string),
 				EncryptionConfig: encryptionConfig,
 			},
@@ -872,8 +872,8 @@ func toMachinePoolEks(machinePool interface{}) *models.V1EksMachinePoolConfigEnt
 			Taints:           toClusterTaints(m),
 			IsControlPlane:   controlPlane,
 			Labels:           labels,
-			Name:             types.Ptr(m["name"].(string)),
-			Size:             types.Ptr(int32(m["count"].(int))),
+			Name:             ptr.To(m["name"].(string)),
+			Size:             ptr.To(int32(m["count"].(int))),
 			UpdateStrategy: &models.V1UpdateStrategy{
 				Type: getUpdateStrategy(m),
 			},
@@ -977,12 +977,12 @@ func toFargateProfileEks(fargateProfile interface{}) *models.V1FargateProfile {
 
 		selectors = append(selectors, &models.V1FargateSelector{
 			Labels:    expandStringMap(s["labels"].(map[string]interface{})),
-			Namespace: types.Ptr(s["namespace"].(string)),
+			Namespace: ptr.To(s["namespace"].(string)),
 		})
 	}
 
 	f := &models.V1FargateProfile{
-		Name:           types.Ptr(m["name"].(string)),
+		Name:           ptr.To(m["name"].(string)),
 		AdditionalTags: expandStringMap(m["additional_tags"].(map[string]interface{})),
 		Selectors:      selectors,
 		SubnetIds:      expandStringList(m["subnets"].([]interface{})),

--- a/spectrocloud/resource_cluster_eks_expand_test.go
+++ b/spectrocloud/resource_cluster_eks_expand_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/spectrocloud/palette-sdk-go/api/models"
 	"github.com/stretchr/testify/assert"
 
-	"github.com/spectrocloud/terraform-provider-spectrocloud/types"
+	"github.com/spectrocloud/terraform-provider-spectrocloud/util/ptr"
 )
 
 func TestSetAwsLaunchTemplate(t *testing.T) {
@@ -130,7 +130,7 @@ func TestToMachinePoolEks(t *testing.T) {
 				CloudConfig: &models.V1EksMachineCloudConfigEntity{
 					RootDeviceSize: 10,
 					InstanceType:   "t2.micro",
-					CapacityType:   types.Ptr("on-demand"),
+					CapacityType:   ptr.To("on-demand"),
 					Azs:            []string{"us-west-1a"},
 					Subnets: []*models.V1EksSubnetEntity{
 						{
@@ -142,8 +142,8 @@ func TestToMachinePoolEks(t *testing.T) {
 				PoolConfig: &models.V1MachinePoolConfigEntity{
 					IsControlPlane:   false,
 					Labels:           []string{},
-					Name:             types.Ptr("test-pool"),
-					Size:             types.Ptr(int32(2)),
+					Name:             ptr.To("test-pool"),
+					Size:             ptr.To(int32(2)),
 					MinSize:          2,
 					MaxSize:          2,
 					AdditionalLabels: map[string]string{},
@@ -170,7 +170,7 @@ func TestToMachinePoolEks(t *testing.T) {
 				CloudConfig: &models.V1EksMachineCloudConfigEntity{
 					RootDeviceSize: 10,
 					InstanceType:   "t2.micro",
-					CapacityType:   types.Ptr("spot"),
+					CapacityType:   ptr.To("spot"),
 					Azs:            []string{"us-west-1a"},
 					Subnets: []*models.V1EksSubnetEntity{
 						{
@@ -185,8 +185,8 @@ func TestToMachinePoolEks(t *testing.T) {
 				PoolConfig: &models.V1MachinePoolConfigEntity{
 					IsControlPlane:   false,
 					Labels:           []string{},
-					Name:             types.Ptr("test-pool-spot"),
-					Size:             types.Ptr(int32(2)),
+					Name:             ptr.To("test-pool-spot"),
+					Size:             ptr.To(int32(2)),
 					MinSize:          2,
 					MaxSize:          2,
 					AdditionalLabels: map[string]string{},

--- a/spectrocloud/resource_cluster_eks_flatten_test.go
+++ b/spectrocloud/resource_cluster_eks_flatten_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/spectrocloud/palette-sdk-go/api/models"
 
-	"github.com/spectrocloud/terraform-provider-spectrocloud/types"
+	"github.com/spectrocloud/terraform-provider-spectrocloud/util/ptr"
 )
 
 func TestFlattenEksLaunchTemplate(t *testing.T) {
@@ -135,7 +135,7 @@ func TestFlattenClusterConfigsEKS(t *testing.T) {
 			input: &models.V1EksCloudConfig{
 				Spec: &models.V1EksCloudConfigSpec{
 					ClusterConfig: &models.V1EksClusterConfig{
-						Region: types.Ptr("us-west-2"),
+						Region: ptr.To("us-west-2"),
 						EndpointAccess: &models.V1EksClusterConfigEndpointAccess{
 							PublicCIDRs: []string{"0.0.0.0/0"},
 							Private:     true,
@@ -197,7 +197,7 @@ func TestFlattenClusterConfigsEKSPrivateCIDRS(t *testing.T) {
 			input: &models.V1EksCloudConfig{
 				Spec: &models.V1EksCloudConfigSpec{
 					ClusterConfig: &models.V1EksClusterConfig{
-						Region: types.Ptr("us-west-2"),
+						Region: ptr.To("us-west-2"),
 						EndpointAccess: &models.V1EksClusterConfigEndpointAccess{
 							PrivateCIDRs: []string{"172.23.12.12/0"},
 							Private:      true,

--- a/spectrocloud/resource_cluster_gcp.go
+++ b/spectrocloud/resource_cluster_gcp.go
@@ -2,19 +2,19 @@ package spectrocloud
 
 import (
 	"context"
-	"github.com/spectrocloud/gomi/pkg/ptr"
 	"log"
 	"time"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/spectrocloud/terraform-provider-spectrocloud/util/ptr"
 
-	"github.com/spectrocloud/terraform-provider-spectrocloud/spectrocloud/schemas"
-	"github.com/spectrocloud/terraform-provider-spectrocloud/types"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/spectrocloud/palette-sdk-go/api/models"
 	"github.com/spectrocloud/palette-sdk-go/client"
+
+	"github.com/spectrocloud/terraform-provider-spectrocloud/spectrocloud/schemas"
 )
 
 func resourceClusterGcp() *schema.Resource {
@@ -357,8 +357,8 @@ func flattenClusterConfigsGcp(config *models.V1GcpCloudConfig) []interface{} {
 	if config.Spec.ClusterConfig.Network != "" {
 		m["network"] = config.Spec.ClusterConfig.Network
 	}
-	if ptr.String(config.Spec.ClusterConfig.Region) != "" {
-		m["region"] = ptr.String(config.Spec.ClusterConfig.Region)
+	if ptr.DeRef(config.Spec.ClusterConfig.Region) != "" {
+		m["region"] = ptr.DeRef(config.Spec.ClusterConfig.Region)
 	}
 	return []interface{}{m}
 }
@@ -495,13 +495,13 @@ func toGcpCluster(c *client.V1Client, d *schema.ResourceData) (*models.V1Spectro
 	cluster := &models.V1SpectroGcpClusterEntity{
 		Metadata: getClusterMetadata(d),
 		Spec: &models.V1SpectroGcpClusterEntitySpec{
-			CloudAccountUID: types.Ptr(d.Get("cloud_account_id").(string)),
+			CloudAccountUID: ptr.To(d.Get("cloud_account_id").(string)),
 			Profiles:        profiles,
 			Policies:        toPolicies(d),
 			CloudConfig: &models.V1GcpClusterConfig{
 				Network: cloudConfig["network"].(string),
-				Project: types.Ptr(cloudConfig["project"].(string)),
-				Region:  types.Ptr(cloudConfig["region"].(string)),
+				Project: ptr.To(cloudConfig["project"].(string)),
+				Region:  ptr.To(cloudConfig["region"].(string)),
 			},
 		},
 	}
@@ -541,7 +541,7 @@ func toMachinePoolGcp(machinePool interface{}) (*models.V1GcpMachinePoolConfigEn
 	mp := &models.V1GcpMachinePoolConfigEntity{
 		CloudConfig: &models.V1GcpMachinePoolCloudConfigEntity{
 			Azs:            azs,
-			InstanceType:   types.Ptr(m["instance_type"].(string)),
+			InstanceType:   ptr.To(m["instance_type"].(string)),
 			RootDeviceSize: int64(m["disk_size_gb"].(int)),
 		},
 		PoolConfig: &models.V1MachinePoolConfigEntity{
@@ -549,8 +549,8 @@ func toMachinePoolGcp(machinePool interface{}) (*models.V1GcpMachinePoolConfigEn
 			Taints:           toClusterTaints(m),
 			IsControlPlane:   controlPlane,
 			Labels:           labels,
-			Name:             types.Ptr(m["name"].(string)),
-			Size:             types.Ptr(int32(m["count"].(int))),
+			Name:             ptr.To(m["name"].(string)),
+			Size:             ptr.To(int32(m["count"].(int))),
 			UpdateStrategy: &models.V1UpdateStrategy{
 				Type: getUpdateStrategy(m),
 			},

--- a/spectrocloud/resource_cluster_gcp_test.go
+++ b/spectrocloud/resource_cluster_gcp_test.go
@@ -1,12 +1,13 @@
 package spectrocloud
 
 import (
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/spectrocloud/gomi/pkg/ptr"
-	"github.com/spectrocloud/palette-sdk-go/api/models"
-	"github.com/spectrocloud/terraform-provider-spectrocloud/types"
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/spectrocloud/palette-sdk-go/api/models"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/spectrocloud/terraform-provider-spectrocloud/util/ptr"
 )
 
 func TestToMachinePoolGcp(t *testing.T) {
@@ -31,7 +32,7 @@ func TestToMachinePoolGcp(t *testing.T) {
 			expectedOutput: &models.V1GcpMachinePoolConfigEntity{
 				CloudConfig: &models.V1GcpMachinePoolCloudConfigEntity{
 					Azs:            []string{"us-central1-a"},
-					InstanceType:   types.Ptr("n1-standard-1"),
+					InstanceType:   ptr.To("n1-standard-1"),
 					RootDeviceSize: int64(50),
 				},
 				PoolConfig: &models.V1MachinePoolConfigEntity{
@@ -39,8 +40,8 @@ func TestToMachinePoolGcp(t *testing.T) {
 					Taints:           nil,
 					IsControlPlane:   true,
 					Labels:           []string{"control-plane"},
-					Name:             types.Ptr("example-name"),
-					Size:             types.Ptr(int32(3)),
+					Name:             ptr.To("example-name"),
+					Size:             ptr.To(int32(3)),
 					UpdateStrategy: &models.V1UpdateStrategy{
 						Type: "RollingUpdateScaleOut",
 					},
@@ -64,7 +65,7 @@ func TestToMachinePoolGcp(t *testing.T) {
 			expectedOutput: &models.V1GcpMachinePoolConfigEntity{
 				CloudConfig: &models.V1GcpMachinePoolCloudConfigEntity{
 					Azs:            []string{"us-central1-a"},
-					InstanceType:   types.Ptr("n1-standard-2"),
+					InstanceType:   ptr.To("n1-standard-2"),
 					RootDeviceSize: int64(100),
 				},
 				PoolConfig: &models.V1MachinePoolConfigEntity{
@@ -72,8 +73,8 @@ func TestToMachinePoolGcp(t *testing.T) {
 					Taints:           []*models.V1Taint{},
 					IsControlPlane:   true,
 					Labels:           []string{"control-plane"},
-					Name:             types.Ptr("example-name-2"),
-					Size:             types.Ptr(int32(2)),
+					Name:             ptr.To("example-name-2"),
+					Size:             ptr.To(int32(2)),
 					UpdateStrategy: &models.V1UpdateStrategy{
 						Type: "RollingUpdate",
 					},
@@ -110,12 +111,12 @@ func TestFlattenMachinePoolConfigsGcp(t *testing.T) {
 				{
 					AdditionalLabels:        map[string]string{"label1": "value1", "label2": "value2"},
 					Taints:                  []*models.V1Taint{{Key: "taint1", Value: "value1", Effect: "NoSchedule"}},
-					IsControlPlane:          ptr.BoolPtr(true),
+					IsControlPlane:          ptr.To(true),
 					UseControlPlaneAsWorker: true,
 					Name:                    "machine-pool-1",
 					Size:                    int32(3),
 					UpdateStrategy:          &models.V1UpdateStrategy{Type: "RollingUpdate"},
-					InstanceType:            types.Ptr("n1-standard-4"),
+					InstanceType:            ptr.To("n1-standard-4"),
 					RootDeviceSize:          int64(100),
 					Azs:                     []string{"us-west1-a", "us-west1-b"},
 					NodeRepaveInterval:      0,
@@ -166,15 +167,15 @@ func TestFlattenClusterConfigsGcp(t *testing.T) {
 			input: &models.V1GcpCloudConfig{
 				Spec: &models.V1GcpCloudConfigSpec{
 					ClusterConfig: &models.V1GcpClusterConfig{
-						Project: ptr.StringPtr("my-project"),
+						Project: ptr.To("my-project"),
 						Network: "my-network",
-						Region:  ptr.StringPtr("us-west1"),
+						Region:  ptr.To("us-west1"),
 					},
 				},
 			},
 			expectedOutput: []interface{}{
 				map[string]interface{}{
-					"project": ptr.StringPtr("my-project"),
+					"project": ptr.To("my-project"),
 					"network": "my-network",
 					"region":  "us-west1",
 				},

--- a/spectrocloud/resource_cluster_gke_test.go
+++ b/spectrocloud/resource_cluster_gke_test.go
@@ -1,10 +1,12 @@
 package spectrocloud
 
 import (
-	"github.com/spectrocloud/palette-sdk-go/api/models"
-	"github.com/spectrocloud/terraform-provider-spectrocloud/types"
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/spectrocloud/palette-sdk-go/api/models"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/spectrocloud/terraform-provider-spectrocloud/util/ptr"
 )
 
 func TestToMachinePoolGke(t *testing.T) {
@@ -77,13 +79,13 @@ func TestFlattenMachinePoolConfigsGke(t *testing.T) {
 	// Simulate input data
 	machinePools := []*models.V1GcpMachinePoolConfig{
 		{
-			InstanceType:   types.Ptr("n1-standard-2"),
+			InstanceType:   ptr.To("n1-standard-2"),
 			Name:           "pool1",
 			RootDeviceSize: 100,
 			Size:           3,
 		},
 		{
-			InstanceType:   types.Ptr("n1-standard-4"),
+			InstanceType:   ptr.To("n1-standard-4"),
 			Name:           "pool2",
 			Size:           2,
 			RootDeviceSize: 200,

--- a/spectrocloud/resource_cluster_maas.go
+++ b/spectrocloud/resource_cluster_maas.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
 	"github.com/spectrocloud/terraform-provider-spectrocloud/spectrocloud/schemas"
-	"github.com/spectrocloud/terraform-provider-spectrocloud/types"
+	"github.com/spectrocloud/terraform-provider-spectrocloud/util/ptr"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -558,7 +558,7 @@ func toMaasCluster(c *client.V1Client, d *schema.ResourceData) (*models.V1Spectr
 	cluster := &models.V1SpectroMaasClusterEntity{
 		Metadata: getClusterMetadata(d),
 		Spec: &models.V1SpectroMaasClusterEntitySpec{
-			CloudAccountUID: types.Ptr(d.Get("cloud_account_id").(string)),
+			CloudAccountUID: ptr.To(d.Get("cloud_account_id").(string)),
 			Profiles:        profiles,
 			Policies:        toPolicies(d),
 			CloudConfig: &models.V1MaasClusterConfig{
@@ -632,8 +632,8 @@ func toMachinePoolMaas(machinePool interface{}) (*models.V1MaasMachinePoolConfig
 			Taints:           toClusterTaints(m),
 			IsControlPlane:   controlPlane,
 			Labels:           labels,
-			Name:             types.Ptr(m["name"].(string)),
-			Size:             types.Ptr(int32(m["count"].(int))),
+			Name:             ptr.To(m["name"].(string)),
+			Size:             ptr.To(int32(m["count"].(int))),
 			UpdateStrategy: &models.V1UpdateStrategy{
 				Type: getUpdateStrategy(m),
 			},
@@ -644,7 +644,7 @@ func toMachinePoolMaas(machinePool interface{}) (*models.V1MaasMachinePoolConfig
 	}
 	if len(m["placement"].([]interface{})) > 0 {
 		Placement := m["placement"].([]interface{})[0].(map[string]interface{})
-		mp.CloudConfig.ResourcePool = types.Ptr(Placement["resource_pool"].(string))
+		mp.CloudConfig.ResourcePool = ptr.To(Placement["resource_pool"].(string))
 	} else {
 		rp := ""
 		mp.CloudConfig.ResourcePool = &rp // backend is not accepting nil, rather pointer to empty string.

--- a/spectrocloud/resource_cluster_mass_test.go
+++ b/spectrocloud/resource_cluster_mass_test.go
@@ -8,7 +8,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
 	"github.com/spectrocloud/palette-sdk-go/api/models"
-	"github.com/spectrocloud/terraform-provider-spectrocloud/types"
+
+	"github.com/spectrocloud/terraform-provider-spectrocloud/util/ptr"
 )
 
 func TestFlattenMachinePoolConfigsMaas(t *testing.T) {
@@ -55,7 +56,7 @@ func TestFlattenMachinePoolConfigsMaas(t *testing.T) {
 		}
 		mockMachinePools = append(mockMachinePools, mp)
 		config := &models.V1MaasClusterConfig{
-			Domain: types.Ptr("maas_resource_pool"),
+			Domain: ptr.To("maas_resource_pool"),
 		}
 
 		expected := []interface{}{

--- a/spectrocloud/resource_cluster_openstack.go
+++ b/spectrocloud/resource_cluster_openstack.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
 	"github.com/spectrocloud/terraform-provider-spectrocloud/spectrocloud/schemas"
-	"github.com/spectrocloud/terraform-provider-spectrocloud/types"
+	"github.com/spectrocloud/terraform-provider-spectrocloud/util/ptr"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -314,7 +314,7 @@ func toOpenStackCluster(c *client.V1Client, d *schema.ResourceData) (*models.V1S
 	cluster := &models.V1SpectroOpenStackClusterEntity{
 		Metadata: getClusterMetadata(d),
 		Spec: &models.V1SpectroOpenStackClusterEntitySpec{
-			CloudAccountUID: types.Ptr(d.Get("cloud_account_id").(string)),
+			CloudAccountUID: ptr.To(d.Get("cloud_account_id").(string)),
 			Profiles:        profiles,
 			Policies:        toPolicies(d),
 			CloudConfig: &models.V1OpenStackClusterConfig{
@@ -603,7 +603,7 @@ func toMachinePoolOpenStack(machinePool interface{}) (*models.V1OpenStackMachine
 				ID: m["subnet_id"].(string),
 			},
 			FlavorConfig: &models.V1OpenstackFlavorConfig{
-				Name: types.Ptr(m["instance_type"].(string)),
+				Name: ptr.To(m["instance_type"].(string)),
 			},
 		},
 		PoolConfig: &models.V1MachinePoolConfigEntity{
@@ -611,8 +611,8 @@ func toMachinePoolOpenStack(machinePool interface{}) (*models.V1OpenStackMachine
 			Taints:           toClusterTaints(m),
 			IsControlPlane:   controlPlane,
 			Labels:           labels,
-			Name:             types.Ptr(m["name"].(string)),
-			Size:             types.Ptr(int32(m["count"].(int))),
+			Name:             ptr.To(m["name"].(string)),
+			Size:             ptr.To(int32(m["count"].(int))),
 			UpdateStrategy: &models.V1UpdateStrategy{
 				Type: getUpdateStrategy(m),
 			},

--- a/spectrocloud/resource_cluster_openstack_test.go
+++ b/spectrocloud/resource_cluster_openstack_test.go
@@ -1,8 +1,9 @@
 package spectrocloud
 
 import (
-	"github.com/spectrocloud/terraform-provider-spectrocloud/types"
 	"testing"
+
+	"github.com/spectrocloud/terraform-provider-spectrocloud/util/ptr"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -182,7 +183,7 @@ func TestToMachinePoolOpenStack(t *testing.T) {
 						ID: "subnet-123",
 					},
 					FlavorConfig: &models.V1OpenstackFlavorConfig{
-						Name: types.Ptr("m4.large"),
+						Name: ptr.To("m4.large"),
 					},
 				},
 				PoolConfig: &models.V1MachinePoolConfigEntity{
@@ -219,7 +220,7 @@ func TestToMachinePoolOpenStack(t *testing.T) {
 						ID: "subnet-456",
 					},
 					FlavorConfig: &models.V1OpenstackFlavorConfig{
-						Name: types.Ptr("m4.large"),
+						Name: ptr.To("m4.large"),
 					},
 				},
 				PoolConfig: &models.V1MachinePoolConfigEntity{

--- a/spectrocloud/resource_cluster_profile.go
+++ b/spectrocloud/resource_cluster_profile.go
@@ -4,16 +4,15 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/spectrocloud/gomi/pkg/ptr"
-
-	"github.com/spectrocloud/terraform-provider-spectrocloud/spectrocloud/schemas"
-	"github.com/spectrocloud/terraform-provider-spectrocloud/types"
-
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-
 	"log"
 	"strings"
 	"time"
+
+	"github.com/spectrocloud/terraform-provider-spectrocloud/util/ptr"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/spectrocloud/terraform-provider-spectrocloud/spectrocloud/schemas"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -343,7 +342,7 @@ func toClusterProfilePackCreate(pSrc interface{}) (*models.V1PackManifestEntity,
 	}
 
 	pack := &models.V1PackManifestEntity{
-		Name:        types.Ptr(pName),
+		Name:        ptr.To(pName),
 		Tag:         p["tag"].(string),
 		RegistryUID: pRegistryUID,
 		UID:         pUID,
@@ -438,7 +437,7 @@ func toClusterProfilePackUpdate(pSrc interface{}, packs []*models.V1PackRef) (*m
 
 	pack := &models.V1PackManifestUpdateEntity{
 		//Layer:  p["layer"].(string),
-		Name:        types.Ptr(pName),
+		Name:        ptr.To(pName),
 		Tag:         p["tag"].(string),
 		RegistryUID: pRegistryUID,
 		UID:         pUID,
@@ -452,7 +451,7 @@ func toClusterProfilePackUpdate(pSrc interface{}, packs []*models.V1PackRef) (*m
 		m := manifest.(map[string]interface{})
 		manifests = append(manifests, &models.V1ManifestRefUpdateEntity{
 			Content: strings.TrimSpace(m["content"].(string)),
-			Name:    types.Ptr(m["name"].(string)),
+			Name:    ptr.To(m["name"].(string)),
 			UID:     getManifestUID(m["name"].(string), packs),
 		})
 	}
@@ -498,7 +497,7 @@ func toClusterProfileVariables(d *schema.ResourceData) ([]*models.V1Variable, er
 					Format:       models.V1VariableFormat(variable["format"].(string)),
 					Hidden:       variable["hidden"].(bool),
 					Immutable:    variable["immutable"].(bool),
-					Name:         ptr.StringPtr(variable["name"].(string)),
+					Name:         ptr.To(variable["name"].(string)),
 					Regex:        variable["regex"].(string),
 					IsSensitive:  variable["is_sensitive"].(bool),
 					Required:     variable["required"].(bool),
@@ -536,7 +535,7 @@ func flattenProfileVariables(d *schema.ResourceData, pv []*models.V1Variable) ([
 		mapV := cv.(map[string]interface{})
 		for _, va := range variables {
 			vs := va.(map[string]interface{})
-			if mapV["name"].(string) == ptr.String(vs["name"].(*string)) {
+			if mapV["name"].(string) == ptr.DeRef(vs["name"].(*string)) {
 				sortedVariables = append(sortedVariables, va)
 			}
 		}

--- a/spectrocloud/resource_cluster_profile_test.go
+++ b/spectrocloud/resource_cluster_profile_test.go
@@ -2,12 +2,13 @@ package spectrocloud
 
 import (
 	"context"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/spectrocloud/gomi/pkg/ptr"
-	"github.com/spectrocloud/palette-sdk-go/api/models"
-	"github.com/spectrocloud/terraform-provider-spectrocloud/types"
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/spectrocloud/palette-sdk-go/api/models"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/spectrocloud/terraform-provider-spectrocloud/util/ptr"
 )
 
 func TestToClusterProfileVariables(t *testing.T) {
@@ -112,8 +113,8 @@ func TestFlattenProfileVariables(t *testing.T) {
 	_ = mockResourceData.Set("profile_variables", proVar)
 
 	pv := []*models.V1Variable{
-		{Name: ptr.StringPtr("variable_name_1"), DisplayName: "display_name_1", Description: "description_1", Format: "string", DefaultValue: "default_value_1", Regex: "regex_1", Required: true, Immutable: false, Hidden: false},
-		{Name: ptr.StringPtr("variable_name_2"), DisplayName: "display_name_2", Description: "description_2", Format: "integer", DefaultValue: "default_value_2", Regex: "regex_2", Required: false, Immutable: true, Hidden: true},
+		{Name: ptr.To("variable_name_1"), DisplayName: "display_name_1", Description: "description_1", Format: "string", DefaultValue: "default_value_1", Regex: "regex_1", Required: true, Immutable: false, Hidden: false},
+		{Name: ptr.To("variable_name_2"), DisplayName: "display_name_2", Description: "description_2", Format: "integer", DefaultValue: "default_value_2", Regex: "regex_2", Required: false, Immutable: true, Hidden: true},
 	}
 
 	result, err := flattenProfileVariables(mockResourceData, pv)
@@ -125,7 +126,7 @@ func TestFlattenProfileVariables(t *testing.T) {
 		map[string]interface{}{
 			"variable": []interface{}{
 				map[string]interface{}{
-					"name":          ptr.StringPtr("variable_name_1"),
+					"name":          ptr.To("variable_name_1"),
 					"display_name":  "display_name_1",
 					"description":   "description_1",
 					"format":        models.V1VariableFormat("string"),
@@ -137,7 +138,7 @@ func TestFlattenProfileVariables(t *testing.T) {
 					"is_sensitive":  false,
 				},
 				map[string]interface{}{
-					"name":          ptr.StringPtr("variable_name_2"),
+					"name":          ptr.To("variable_name_2"),
 					"display_name":  "display_name_2",
 					"description":   "description_2",
 					"format":        models.V1VariableFormat("integer"),
@@ -259,7 +260,7 @@ func TestToClusterProfilePackCreate(t *testing.T) {
 			},
 			expectedError: "",
 			expectedPack: &models.V1PackManifestEntity{
-				Name:        types.Ptr("test-pack"),
+				Name:        ptr.To("test-pack"),
 				Tag:         "v1.0",
 				RegistryUID: "test-registry-uid",
 				UID:         "test-uid",
@@ -298,7 +299,7 @@ func TestToClusterProfilePackCreate(t *testing.T) {
 			},
 			expectedError: "",
 			expectedPack: &models.V1PackManifestEntity{
-				Name:        types.Ptr("test-manifest-pack"),
+				Name:        ptr.To("test-manifest-pack"),
 				Tag:         "",
 				RegistryUID: "",
 				UID:         "spectro-manifest-pack",
@@ -329,7 +330,7 @@ func TestToClusterProfilePackCreate(t *testing.T) {
 			},
 			expectedError: "",
 			expectedPack: &models.V1PackManifestEntity{
-				Name:        types.Ptr("test-manifest-pack"),
+				Name:        ptr.To("test-manifest-pack"),
 				Tag:         "",
 				RegistryUID: "",
 				UID:         "custom-uid",

--- a/spectrocloud/resource_cluster_tke.go
+++ b/spectrocloud/resource_cluster_tke.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	"github.com/spectrocloud/terraform-provider-spectrocloud/spectrocloud/schemas"
-	"github.com/spectrocloud/terraform-provider-spectrocloud/types"
+	"github.com/spectrocloud/terraform-provider-spectrocloud/util/ptr"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -524,12 +524,12 @@ func toTkeCluster(c *client.V1Client, d *schema.ResourceData) (*models.V1Spectro
 	cluster := &models.V1SpectroTencentClusterEntity{
 		Metadata: getClusterMetadata(d),
 		Spec: &models.V1SpectroTencentClusterEntitySpec{
-			CloudAccountUID: types.Ptr(d.Get("cloud_account_id").(string)),
+			CloudAccountUID: ptr.To(d.Get("cloud_account_id").(string)),
 			Profiles:        profiles,
 			Policies:        toPolicies(d),
 			CloudConfig: &models.V1TencentClusterConfig{
 				VpcID:     cloudConfig["vpc_id"].(string),
-				Region:    types.Ptr(cloudConfig["region"].(string)),
+				Region:    ptr.To(cloudConfig["region"].(string)),
 				SSHKeyIDs: sshKeyIds,
 			},
 		},
@@ -618,8 +618,8 @@ func toMachinePoolTke(machinePool interface{}) *models.V1TencentMachinePoolConfi
 			Taints:           toClusterTaints(m),
 			IsControlPlane:   controlPlane,
 			Labels:           labels,
-			Name:             types.Ptr(m["name"].(string)),
-			Size:             types.Ptr(int32(m["count"].(int))),
+			Name:             ptr.To(m["name"].(string)),
+			Size:             ptr.To(int32(m["count"].(int))),
 			UpdateStrategy: &models.V1UpdateStrategy{
 				Type: getUpdateStrategy(m),
 			},

--- a/spectrocloud/resource_cluster_tke_test.go
+++ b/spectrocloud/resource_cluster_tke_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/spectrocloud/palette-sdk-go/api/models"
 
-	"github.com/spectrocloud/terraform-provider-spectrocloud/types"
+	"github.com/spectrocloud/terraform-provider-spectrocloud/util/ptr"
 )
 
 func TestFlattenMachinePoolConfigsTke(t *testing.T) {
@@ -136,8 +136,8 @@ func TestToMachinePoolTke(t *testing.T) {
 				},
 				PoolConfig: &models.V1MachinePoolConfigEntity{
 					Labels:         []string{"worker"},
-					Name:           types.Ptr("worker-pool"),
-					Size:           types.Ptr(int32(3)),
+					Name:           ptr.To("worker-pool"),
+					Size:           ptr.To(int32(3)),
 					MinSize:        1,
 					MaxSize:        5,
 					IsControlPlane: false,
@@ -170,8 +170,8 @@ func TestToMachinePoolTke(t *testing.T) {
 				},
 				PoolConfig: &models.V1MachinePoolConfigEntity{
 					Labels:         []string{"control-plane"},
-					Name:           types.Ptr("control-plane-pool"),
-					Size:           types.Ptr(int32(3)),
+					Name:           ptr.To("control-plane-pool"),
+					Size:           ptr.To(int32(3)),
 					MinSize:        3,
 					MaxSize:        3,
 					IsControlPlane: true,

--- a/spectrocloud/resource_cluster_vsphere.go
+++ b/spectrocloud/resource_cluster_vsphere.go
@@ -16,7 +16,7 @@ import (
 	"github.com/spectrocloud/palette-sdk-go/client"
 
 	"github.com/spectrocloud/terraform-provider-spectrocloud/spectrocloud/schemas"
-	"github.com/spectrocloud/terraform-provider-spectrocloud/types"
+	"github.com/spectrocloud/terraform-provider-spectrocloud/util/ptr"
 )
 
 func resourceClusterVsphere() *schema.Resource {
@@ -864,7 +864,7 @@ func toMachinePoolVsphere(machinePool interface{}) (*models.V1VsphereMachinePool
 			ResourcePool: p["resource_pool"].(string),
 			Datastore:    p["datastore"].(string),
 			Network: &models.V1VsphereNetworkConfigEntity{
-				NetworkName:   types.Ptr(p["network"].(string)),
+				NetworkName:   ptr.To(p["network"].(string)),
 				ParentPoolUID: poolID,
 				StaticIP:      staticIP,
 			},
@@ -874,9 +874,9 @@ func toMachinePoolVsphere(machinePool interface{}) (*models.V1VsphereMachinePool
 
 	ins := m["instance_type"].([]interface{})[0].(map[string]interface{})
 	instanceType := models.V1VsphereInstanceType{
-		DiskGiB:   types.Ptr(int32(ins["disk_size_gb"].(int))),
-		MemoryMiB: types.Ptr(int64(ins["memory_mb"].(int))),
-		NumCPUs:   types.Ptr(int32(ins["cpu"].(int))),
+		DiskGiB:   ptr.To(int32(ins["disk_size_gb"].(int))),
+		MemoryMiB: ptr.To(int64(ins["memory_mb"].(int))),
+		NumCPUs:   ptr.To(int32(ins["cpu"].(int))),
 	}
 	min := int32(m["count"].(int))
 	max := int32(m["count"].(int))
@@ -899,8 +899,8 @@ func toMachinePoolVsphere(machinePool interface{}) (*models.V1VsphereMachinePool
 			Taints:           toClusterTaints(m),
 			IsControlPlane:   controlPlane,
 			Labels:           labels,
-			Name:             types.Ptr(m["name"].(string)),
-			Size:             types.Ptr(int32(m["count"].(int))),
+			Name:             ptr.To(m["name"].(string)),
+			Size:             ptr.To(int32(m["count"].(int))),
 			UpdateStrategy: &models.V1UpdateStrategy{
 				Type: getUpdateStrategy(m),
 			},

--- a/spectrocloud/resource_cluster_vsphere_test.go
+++ b/spectrocloud/resource_cluster_vsphere_test.go
@@ -2,9 +2,10 @@ package spectrocloud
 
 import (
 	"fmt"
-	"github.com/spectrocloud/terraform-provider-spectrocloud/types"
 	"reflect"
 	"testing"
+
+	"github.com/spectrocloud/terraform-provider-spectrocloud/util/ptr"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/stretchr/testify/assert"
@@ -294,16 +295,16 @@ func TestFlattenMachinePoolConfigsVsphere(t *testing.T) {
 					Size:                    int32(3),
 					MinSize:                 1,
 					MaxSize:                 5,
-					IsControlPlane:          types.Ptr(true),
+					IsControlPlane:          ptr.To(true),
 					UseControlPlaneAsWorker: false,
 					NodeRepaveInterval:      int32(24),
 					UpdateStrategy: &models.V1UpdateStrategy{
 						Type: "RollingUpdate",
 					},
 					InstanceType: &models.V1VsphereInstanceType{
-						DiskGiB:   types.Ptr(int32(100)),
-						MemoryMiB: types.Ptr(int64(8192)),
-						NumCPUs:   types.Ptr(int32(4)),
+						DiskGiB:   ptr.To(int32(100)),
+						MemoryMiB: ptr.To(int64(8192)),
+						NumCPUs:   ptr.To(int32(4)),
 					},
 					Placements: []*models.V1VspherePlacementConfig{
 						{
@@ -312,7 +313,7 @@ func TestFlattenMachinePoolConfigsVsphere(t *testing.T) {
 							ResourcePool: "resource-pool1",
 							Datastore:    "datastore1",
 							Network: &models.V1VsphereNetworkConfig{
-								NetworkName: types.Ptr("network1"),
+								NetworkName: ptr.To("network1"),
 								ParentPoolRef: &models.V1ObjectReference{
 									UID: "pool1",
 								},
@@ -342,7 +343,7 @@ func TestFlattenMachinePoolConfigsVsphere(t *testing.T) {
 							"cluster":           "cluster1",
 							"resource_pool":     "resource-pool1",
 							"datastore":         "datastore1",
-							"network":           types.Ptr("network1"), // Handle pointer or use (*string)(nil) if necessary
+							"network":           ptr.To("network1"), // Handle pointer or use (*string)(nil) if necessary
 							"static_ip_pool_id": "pool1",
 						},
 					},

--- a/spectrocloud/resource_kubevirt_datavolume.go
+++ b/spectrocloud/resource_kubevirt_datavolume.go
@@ -10,10 +10,11 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/spectrocloud/palette-sdk-go/api/models"
+
 	"github.com/spectrocloud/terraform-provider-spectrocloud/spectrocloud/convert"
 	"github.com/spectrocloud/terraform-provider-spectrocloud/spectrocloud/kubevirt/schema/datavolume"
 	"github.com/spectrocloud/terraform-provider-spectrocloud/spectrocloud/kubevirt/utils"
-	"github.com/spectrocloud/terraform-provider-spectrocloud/types"
+	"github.com/spectrocloud/terraform-provider-spectrocloud/util/ptr"
 )
 
 func resourceKubevirtDataVolume() *schema.Resource {
@@ -158,7 +159,7 @@ func resourceKubevirtDataVolumeDelete(ctx context.Context, d *schema.ResourceDat
 	if err := c.DeleteDataVolume(clusterUid, namespace, vm_name, &models.V1VMRemoveVolumeEntity{
 		Persist: true,
 		RemoveVolumeOptions: &models.V1VMRemoveVolumeOptions{
-			Name: types.Ptr(vol_name),
+			Name: ptr.To(vol_name),
 		},
 	}); err != nil {
 		return diag.FromErr(err)
@@ -178,13 +179,13 @@ func ExpandAddVolumeOptions(addVolumeOptions []interface{}) *models.V1VMAddVolum
 	m := addVolumeOptions[0].(map[string]interface{})
 
 	result := &models.V1VMAddVolumeOptions{
-		Name: types.Ptr(m["name"].(string)),
+		Name: ptr.To(m["name"].(string)),
 	}
 
 	if diskList, ok := m["disk"].([]interface{}); ok && len(diskList) > 0 {
 		if diskMap, ok := diskList[0].(map[string]interface{}); ok {
 			result.Disk = &models.V1VMDisk{
-				Name: types.Ptr(diskMap["name"].(string)),
+				Name: ptr.To(diskMap["name"].(string)),
 				Disk: &models.V1VMDiskTarget{
 					Bus: diskMap["bus"].(string),
 				},
@@ -198,7 +199,7 @@ func ExpandAddVolumeOptions(addVolumeOptions []interface{}) *models.V1VMAddVolum
 				if dataVolumeMap, ok := dataVolumeList[0].(map[string]interface{}); ok {
 					result.VolumeSource = &models.V1VMHotplugVolumeSource{
 						DataVolume: &models.V1VMCoreDataVolumeSource{
-							Name:         types.Ptr(dataVolumeMap["name"].(string)),
+							Name:         ptr.To(dataVolumeMap["name"].(string)),
 							Hotpluggable: dataVolumeMap["hotpluggable"].(bool),
 						},
 					}

--- a/spectrocloud/resource_macros.go
+++ b/spectrocloud/resource_macros.go
@@ -4,12 +4,13 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"time"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/spectrocloud/hapi/apiutil/transport"
+	"github.com/spectrocloud/palette-sdk-go/api/apiutil/transport"
 	"github.com/spectrocloud/palette-sdk-go/api/models"
 	"github.com/spectrocloud/palette-sdk-go/client"
-	"time"
 )
 
 func resourceMacros() *schema.Resource {

--- a/spectrocloud/resource_pcg_dns_map.go
+++ b/spectrocloud/resource_pcg_dns_map.go
@@ -2,13 +2,15 @@ package spectrocloud
 
 import (
 	"context"
+	"regexp"
+	"time"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/spectrocloud/gomi/pkg/ptr"
 	"github.com/spectrocloud/palette-sdk-go/api/models"
-	"regexp"
-	"time"
+
+	"github.com/spectrocloud/terraform-provider-spectrocloud/util/ptr"
 )
 
 func resourcePrivateCloudGatewayDNSMap() *schema.Resource {
@@ -63,10 +65,10 @@ func toDNSMap(d *schema.ResourceData) *models.V1VsphereDNSMapping {
 			Name: d.Get("search_domain_name").(string),
 		},
 		Spec: &models.V1VsphereDNSMappingSpec{
-			Datacenter:        ptr.StringPtr(d.Get("data_center").(string)),
-			DNSName:           ptr.StringPtr(d.Get("search_domain_name").(string)),
-			Network:           ptr.StringPtr(d.Get("network").(string)),
-			PrivateGatewayUID: ptr.StringPtr(d.Get("private_cloud_gateway_id").(string)),
+			Datacenter:        ptr.To(d.Get("data_center").(string)),
+			DNSName:           ptr.To(d.Get("search_domain_name").(string)),
+			Network:           ptr.To(d.Get("network").(string)),
+			PrivateGatewayUID: ptr.To(d.Get("private_cloud_gateway_id").(string)),
 			// UI doesn't send network_url may need to enable in the future.
 			// NetworkURL:        "",
 		},

--- a/tests/mockApiServer/routes/mockAppliances.go
+++ b/tests/mockApiServer/routes/mockAppliances.go
@@ -1,10 +1,12 @@
 package routes
 
 import (
-	"github.com/spectrocloud/gomi/pkg/ptr"
-	"github.com/spectrocloud/palette-sdk-go/api/models"
 	"net/http"
 	"strconv"
+
+	"github.com/spectrocloud/palette-sdk-go/api/models"
+
+	"github.com/spectrocloud/terraform-provider-spectrocloud/util/ptr"
 )
 
 func getEdgeHostSearchSummary() models.V1EdgeHostsSearchSummary {
@@ -42,7 +44,7 @@ func getEdgeHostSearchSummary() models.V1EdgeHostsSearchSummary {
 		Spec: &models.V1EdgeHostsMetadataSpec{
 			ClusterProfileTemplates: profileSummary,
 			Device: &models.V1DeviceSpec{
-				ArchType: ptr.StringPtr("AMD"),
+				ArchType: ptr.To("AMD"),
 				CPU: &models.V1CPU{
 					Cores: 2,
 				},
@@ -113,7 +115,7 @@ func getEdgeHostPayload() models.V1EdgeHostDevice {
 			CloudProperties:         nil,
 			ClusterProfileTemplates: nil,
 			Device: &models.V1DeviceSpec{
-				ArchType: ptr.StringPtr("amd64"),
+				ArchType: ptr.To("amd64"),
 				CPU:      nil,
 				Disks:    nil,
 				Gpus:     nil,
@@ -145,7 +147,7 @@ func getEdgeHostPayload() models.V1EdgeHostDevice {
 //func creatEdgeHostErrorResponse() interface{} {
 //	var payload interface{}
 //	payload = map[string]interface{}{
-//		"UID": ptr.StringPtr("test-edge-host-id"),
+//		"UID": ptr.To("test-edge-host-id"),
 //	}
 //	return map[string]interface{}{
 //		"AuditUID": generateRandomStringUID(),

--- a/tests/mockApiServer/routes/mockBackup.go
+++ b/tests/mockApiServer/routes/mockBackup.go
@@ -1,8 +1,9 @@
 package routes
 
 import (
-	"github.com/spectrocloud/gomi/pkg/ptr"
 	"github.com/spectrocloud/palette-sdk-go/api/models"
+
+	"github.com/spectrocloud/terraform-provider-spectrocloud/util/ptr"
 )
 
 func BackupRoutes() []Route {
@@ -44,7 +45,7 @@ func BackupRoutes() []Route {
 					},
 					Spec: &models.V1UserAssetsLocationS3Spec{
 						Config: &models.V1S3StorageConfig{
-							BucketName: ptr.StringPtr("test-bucket"),
+							BucketName: ptr.To("test-bucket"),
 							CaCert:     "test-cert",
 							Credentials: &models.V1AwsCloudAccount{
 								AccessKey:      "test-access-key",
@@ -54,8 +55,8 @@ func BackupRoutes() []Route {
 								SecretKey:      "test-secret-key",
 								Sts:            nil,
 							},
-							Region:           ptr.StringPtr("test-east"),
-							S3ForcePathStyle: ptr.BoolPtr(false),
+							Region:           ptr.To("test-east"),
+							S3ForcePathStyle: ptr.To(false),
 							S3URL:            "s3://test/test",
 							UseRestic:        nil,
 						},

--- a/tests/mockApiServer/routes/mockCloudAccounts.go
+++ b/tests/mockApiServer/routes/mockCloudAccounts.go
@@ -1,8 +1,9 @@
 package routes
 
 import (
-	"github.com/spectrocloud/gomi/pkg/ptr"
 	"github.com/spectrocloud/palette-sdk-go/api/models"
+
+	"github.com/spectrocloud/terraform-provider-spectrocloud/util/ptr"
 )
 
 func getAccountResponse(cloud string) interface{} {
@@ -69,11 +70,11 @@ func getAccountResponse(cloud string) interface{} {
 						UID:  "test-azure-account-id-1",
 					},
 					Spec: &models.V1AzureCloudAccount{
-						AzureEnvironment: ptr.StringPtr("test-env"),
-						ClientID:         ptr.StringPtr("test-client-id"),
-						ClientSecret:     ptr.StringPtr("test-secret"),
+						AzureEnvironment: ptr.To("test-env"),
+						ClientID:         ptr.To("test-client-id"),
+						ClientSecret:     ptr.To("test-secret"),
 						Settings:         nil,
-						TenantID:         ptr.StringPtr("tenant-id"),
+						TenantID:         ptr.To("tenant-id"),
 						TenantName:       "test",
 					},
 					Status: nil,
@@ -97,8 +98,8 @@ func getAccountResponse(cloud string) interface{} {
 						UID:                   "test-tke-account-id-1",
 					},
 					Spec: &models.V1TencentCloudAccount{
-						SecretID:  ptr.StringPtr("test-secretID"),
-						SecretKey: ptr.StringPtr("test-secretKey"),
+						SecretID:  ptr.To("test-secretID"),
+						SecretKey: ptr.To("test-secretKey"),
 					},
 					Status: &models.V1CloudAccountStatus{
 						State: "active",
@@ -166,8 +167,8 @@ func getAccountResponse(cloud string) interface{} {
 						UID:  "test-maas-account-id-1",
 					},
 					Spec: &models.V1MaasCloudAccount{
-						APIEndpoint:      ptr.StringPtr("test.end.com"),
-						APIKey:           ptr.StringPtr("testApiKey"),
+						APIEndpoint:      ptr.To("test.end.com"),
+						APIKey:           ptr.To("testApiKey"),
 						PreferredSubnets: []string{"subnet1"},
 					},
 				},
@@ -234,11 +235,11 @@ func getAccountNegativeResponse(cloud string) interface{} {
 						UID:  "test-azure-account-id-1-neg",
 					},
 					Spec: &models.V1AzureCloudAccount{
-						AzureEnvironment: ptr.StringPtr("test-env"),
-						ClientID:         ptr.StringPtr("test-client-id"),
-						ClientSecret:     ptr.StringPtr("test-secret"),
+						AzureEnvironment: ptr.To("test-env"),
+						ClientID:         ptr.To("test-client-id"),
+						ClientSecret:     ptr.To("test-secret"),
 						Settings:         nil,
-						TenantID:         ptr.StringPtr("tenant-id"),
+						TenantID:         ptr.To("tenant-id"),
 						TenantName:       "test",
 					},
 					Status: nil,
@@ -262,8 +263,8 @@ func getAccountNegativeResponse(cloud string) interface{} {
 						UID:                   "test-id-1",
 					},
 					Spec: &models.V1TencentCloudAccount{
-						SecretID:  ptr.StringPtr("test-secretID"),
-						SecretKey: ptr.StringPtr("test-secretKey"),
+						SecretID:  ptr.To("test-secretID"),
+						SecretKey: ptr.To("test-secretKey"),
 					},
 					Status: &models.V1CloudAccountStatus{
 						State: "notActive",
@@ -331,8 +332,8 @@ func getAccountNegativeResponse(cloud string) interface{} {
 						UID:  "test-maas-account-id-1-neg",
 					},
 					Spec: &models.V1MaasCloudAccount{
-						APIEndpoint:      ptr.StringPtr("test.end.com"),
-						APIKey:           ptr.StringPtr("testApiKey"),
+						APIEndpoint:      ptr.To("test.end.com"),
+						APIKey:           ptr.To("testApiKey"),
 						PreferredSubnets: []string{"subnet1"},
 					},
 				},
@@ -514,8 +515,8 @@ func CloudAccountsRoutes() []Route {
 						Annotations: map[string]string{"overlordUid": "test-pcg-id"},
 					},
 					Spec: &models.V1MaasCloudAccount{
-						APIEndpoint:      ptr.StringPtr("test.end.com"),
-						APIKey:           ptr.StringPtr("testApiKey"),
+						APIEndpoint:      ptr.To("test.end.com"),
+						APIKey:           ptr.To("testApiKey"),
 						PreferredSubnets: []string{"subnet1"},
 					},
 				},
@@ -578,13 +579,13 @@ func CloudAccountsRoutes() []Route {
 						UID:         "test-azure-account-id-1",
 					},
 					Spec: &models.V1AzureCloudAccount{
-						AzureEnvironment: ptr.StringPtr("test-env"),
-						ClientID:         ptr.StringPtr("test-client-id"),
-						ClientSecret:     ptr.StringPtr("test-secret"),
+						AzureEnvironment: ptr.To("test-env"),
+						ClientID:         ptr.To("test-client-id"),
+						ClientSecret:     ptr.To("test-secret"),
 						Settings: &models.V1CloudAccountSettings{
 							DisablePropertiesRequest: false,
 						},
-						TenantID:   ptr.StringPtr("tenant-id"),
+						TenantID:   ptr.To("tenant-id"),
 						TenantName: "test",
 					},
 					Status: nil,
@@ -728,8 +729,8 @@ func CloudAccountsRoutes() []Route {
 						UID:                   "test-tke-account-id-1",
 					},
 					Spec: &models.V1TencentCloudAccount{
-						SecretID:  ptr.StringPtr("test-secretID"),
-						SecretKey: ptr.StringPtr("test-secretKey"),
+						SecretID:  ptr.To("test-secretID"),
+						SecretKey: ptr.To("test-secretKey"),
 					},
 					Status: &models.V1CloudAccountStatus{
 						State: "active",
@@ -800,9 +801,9 @@ func CloudAccountsRoutes() []Route {
 					},
 					Spec: &models.V1VsphereCloudAccount{
 						Insecure:      false,
-						Password:      ptr.StringPtr("test-pwd"),
-						Username:      ptr.StringPtr("test-uname"),
-						VcenterServer: ptr.StringPtr("test-uname.com"),
+						Password:      ptr.To("test-pwd"),
+						Username:      ptr.To("test-uname"),
+						VcenterServer: ptr.To("test-uname.com"),
 					},
 					Status: &models.V1CloudAccountStatus{
 						State: "Running",
@@ -874,11 +875,11 @@ func CloudAccountsRoutes() []Route {
 						CaCert:           "testcert",
 						DefaultDomain:    "test.com",
 						DefaultProject:   "Default",
-						IdentityEndpoint: ptr.StringPtr("testtest"),
+						IdentityEndpoint: ptr.To("testtest"),
 						Insecure:         false,
 						ParentRegion:     "test-region",
-						Password:         ptr.StringPtr("test-pwd"),
-						Username:         ptr.StringPtr("test-uname"),
+						Password:         ptr.To("test-pwd"),
+						Username:         ptr.To("test-uname"),
 					},
 					Status: &models.V1CloudAccountStatus{
 						State: "Running",

--- a/tests/mockApiServer/routes/mockClusterCommon.go
+++ b/tests/mockApiServer/routes/mockClusterCommon.go
@@ -1,8 +1,9 @@
 package routes
 
 import (
-	"github.com/spectrocloud/gomi/pkg/ptr"
 	"github.com/spectrocloud/palette-sdk-go/api/models"
+
+	"github.com/spectrocloud/terraform-provider-spectrocloud/util/ptr"
 )
 
 func ClusterCommonRoutes() []Route {
@@ -100,7 +101,7 @@ func ClusterCommonRoutes() []Route {
 									LastTransitionTime: models.V1Time{},
 									Message:            "",
 									Reason:             "",
-									Status:             ptr.StringPtr("Ready"),
+									Status:             ptr.To("Ready"),
 									Type:               nil,
 								},
 								EndTime:    models.V1Time{},

--- a/tests/mockApiServer/routes/mockClusterProfile.go
+++ b/tests/mockApiServer/routes/mockClusterProfile.go
@@ -1,9 +1,11 @@
 package routes
 
 import (
-	"github.com/spectrocloud/gomi/pkg/ptr"
-	"github.com/spectrocloud/palette-sdk-go/api/models"
 	"net/http"
+
+	"github.com/spectrocloud/palette-sdk-go/api/models"
+
+	"github.com/spectrocloud/terraform-provider-spectrocloud/util/ptr"
 )
 
 func getClusterProfilesMetadataResponse() *models.V1ClusterProfilesMetadata {
@@ -57,7 +59,7 @@ func getClusterProfileResponse() *models.V1ClusterProfile {
 				PackServerSecret: "",
 				Packs: []*models.V1PackRef{
 					{
-						Name:        ptr.StringPtr("k8"),
+						Name:        ptr.To("k8"),
 						PackUID:     generateRandomStringUID(),
 						RegistryUID: generateRandomStringUID(),
 						Schema:      nil,

--- a/tests/mockApiServer/routes/mockFilter.go
+++ b/tests/mockApiServer/routes/mockFilter.go
@@ -1,10 +1,12 @@
 package routes
 
 import (
-	"github.com/spectrocloud/gomi/pkg/ptr"
-	"github.com/spectrocloud/palette-sdk-go/api/models"
 	"net/http"
 	"strconv"
+
+	"github.com/spectrocloud/palette-sdk-go/api/models"
+
+	"github.com/spectrocloud/terraform-provider-spectrocloud/util/ptr"
 )
 
 func getFiltersResponse() models.V1FiltersSummary {
@@ -56,7 +58,7 @@ func getFilterSummary() *models.V1TagFilterSummary {
 		},
 		Spec: &models.V1TagFilterSpec{
 			FilterGroup: &models.V1TagFilterGroup{
-				Conjunction: (*models.V1SearchFilterConjunctionOperator)(ptr.StringPtr("and")),
+				Conjunction: (*models.V1SearchFilterConjunctionOperator)(ptr.To("and")),
 				Filters: []*models.V1TagFilterItem{
 					{
 						Key:      "name",

--- a/tests/mockApiServer/routes/mockRegistries.go
+++ b/tests/mockApiServer/routes/mockRegistries.go
@@ -1,9 +1,11 @@
 package routes
 
 import (
-	"github.com/spectrocloud/gomi/pkg/ptr"
-	"github.com/spectrocloud/palette-sdk-go/api/models"
 	"net/http"
+
+	"github.com/spectrocloud/palette-sdk-go/api/models"
+
+	"github.com/spectrocloud/terraform-provider-spectrocloud/util/ptr"
 )
 
 func getHelmRegistryPayload() *models.V1HelmRegistry {
@@ -27,7 +29,7 @@ func getHelmRegistryPayload() *models.V1HelmRegistry {
 				Type:     "token",
 				Username: "sf",
 			},
-			Endpoint:    ptr.StringPtr("test.com"),
+			Endpoint:    ptr.To("test.com"),
 			IsPrivate:   false,
 			Name:        "Public",
 			RegistryUID: generateRandomStringUID(),
@@ -83,7 +85,7 @@ func RegistriesRoutes() []Route {
 						Credentials: &models.V1AwsCloudAccount{
 							AccessKey:      "test-key",
 							CredentialType: "sts",
-							Partition:      ptr.StringPtr("test-part"),
+							Partition:      ptr.To("test-part"),
 							PolicyARNs:     []string{"test-arns"},
 							SecretKey:      "test-secret-key",
 							Sts: &models.V1AwsStsCredentials{
@@ -92,18 +94,18 @@ func RegistriesRoutes() []Route {
 							},
 						},
 						DefaultRegion: "test-region",
-						Endpoint:      ptr.StringPtr("test.point"),
-						IsPrivate:     ptr.BoolPtr(false),
-						ProviderType:  ptr.StringPtr("test-type"),
+						Endpoint:      ptr.To("test.point"),
+						IsPrivate: ptr.To((false),
+							ProviderType:  ptr.To("test-type"),
 						RegistryUID:   "test-reg-uid",
 						Scope:         "project",
 						TLS: &models.V1TLSConfiguration{
-							Ca:                 "test-ca",
-							Certificate:        "test-cert",
-							Enabled:            false,
-							InsecureSkipVerify: false,
-							Key:                "test-key",
-						},
+						Ca:                 "test-ca",
+						Certificate:        "test-cert",
+						Enabled:            false,
+						InsecureSkipVerify: false,
+						Key:                "test-key",
+					},
 					},
 				},
 			},

--- a/types/types.go
+++ b/types/types.go
@@ -1,9 +1,0 @@
-package types
-
-func Ptr[T any](v T) *T {
-	return &v
-}
-
-func Val[T any](v *T) T {
-	return *v
-}

--- a/util/ptr/ptr.go
+++ b/util/ptr/ptr.go
@@ -1,0 +1,9 @@
+package ptr
+
+func To[T any](v T) *T {
+	return &v
+}
+
+func DeRef[T any](v *T) T {
+	return *v
+}


### PR DESCRIPTION
This changelist uses `strings.Replacer` and a single type to represent patch operations. 