### PR TITLE
PLT-1673: use GetClusterClientKubeConfig instead of GetClusterKubeConfig(PEM-7335)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/hashicorp/terraform-plugin-docs v0.16.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.30.0
 	github.com/robfig/cron v1.2.0
-	github.com/spectrocloud/palette-sdk-go v0.0.0-20250401155513-59cafca8643d
+	github.com/spectrocloud/palette-sdk-go v0.0.0-20250402051801-d9cad104a6f9
 	github.com/stretchr/testify v1.10.0
 	gotest.tools v2.2.0+incompatible
 	k8s.io/api v0.23.5

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/hashicorp/terraform-plugin-docs v0.16.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.30.0
 	github.com/robfig/cron v1.2.0
-	github.com/spectrocloud/palette-sdk-go v0.0.0-20250303143254-e47062a74558
+	github.com/spectrocloud/palette-sdk-go v0.0.0-20250401155513-59cafca8643d
 	github.com/stretchr/testify v1.10.0
 	gotest.tools v2.2.0+incompatible
 	k8s.io/api v0.23.5

--- a/go.sum
+++ b/go.sum
@@ -597,8 +597,6 @@ github.com/smartystreets/goconvey v1.6.4/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9
 github.com/soheilhy/cmux v0.1.4/go.mod h1:IM3LyeVVIOuxMH7sFAkER9+bJ4dT7Ms6E4xg4kGIyLM=
 github.com/soheilhy/cmux v0.1.5/go.mod h1:T7TcVDs9LWfQgPlPsdngu6I6QIoyIFZDDC6sNE1GqG0=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
-github.com/spectrocloud/palette-sdk-go v0.0.0-20250303143254-e47062a74558 h1:4yt/t66X41iBB6YiWC5D+FjT+tSQUoKIS7h5z1r2gC0=
-github.com/spectrocloud/palette-sdk-go v0.0.0-20250303143254-e47062a74558/go.mod h1:b5x4jIKc9CR5Hv3o4wsCeadjtw0EM4lx9jrEDWRZSSo=
 github.com/spectrocloud/palette-sdk-go v0.0.0-20250401155513-59cafca8643d h1:+mSLXyhMRfPMomZIMPVpnJpjzQK7zTbs3yI090UqjGI=
 github.com/spectrocloud/palette-sdk-go v0.0.0-20250401155513-59cafca8643d/go.mod h1:b5x4jIKc9CR5Hv3o4wsCeadjtw0EM4lx9jrEDWRZSSo=
 github.com/spf13/afero v1.1.2/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=

--- a/go.sum
+++ b/go.sum
@@ -599,6 +599,8 @@ github.com/soheilhy/cmux v0.1.5/go.mod h1:T7TcVDs9LWfQgPlPsdngu6I6QIoyIFZDDC6sNE
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spectrocloud/palette-sdk-go v0.0.0-20250303143254-e47062a74558 h1:4yt/t66X41iBB6YiWC5D+FjT+tSQUoKIS7h5z1r2gC0=
 github.com/spectrocloud/palette-sdk-go v0.0.0-20250303143254-e47062a74558/go.mod h1:b5x4jIKc9CR5Hv3o4wsCeadjtw0EM4lx9jrEDWRZSSo=
+github.com/spectrocloud/palette-sdk-go v0.0.0-20250401155513-59cafca8643d h1:+mSLXyhMRfPMomZIMPVpnJpjzQK7zTbs3yI090UqjGI=
+github.com/spectrocloud/palette-sdk-go v0.0.0-20250401155513-59cafca8643d/go.mod h1:b5x4jIKc9CR5Hv3o4wsCeadjtw0EM4lx9jrEDWRZSSo=
 github.com/spf13/afero v1.1.2/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=
 github.com/spf13/afero v1.2.2/go.mod h1:9ZxEEn6pIJ8Rxe320qSDBk6AsU0r9pR7Q4OcevTdifk=
 github.com/spf13/afero v1.6.0/go.mod h1:Ai8FlHk4v/PARR026UzYexafAt9roJ7LcLMAmO6Z93I=

--- a/go.sum
+++ b/go.sum
@@ -597,8 +597,8 @@ github.com/smartystreets/goconvey v1.6.4/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9
 github.com/soheilhy/cmux v0.1.4/go.mod h1:IM3LyeVVIOuxMH7sFAkER9+bJ4dT7Ms6E4xg4kGIyLM=
 github.com/soheilhy/cmux v0.1.5/go.mod h1:T7TcVDs9LWfQgPlPsdngu6I6QIoyIFZDDC6sNE1GqG0=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
-github.com/spectrocloud/palette-sdk-go v0.0.0-20250401155513-59cafca8643d h1:+mSLXyhMRfPMomZIMPVpnJpjzQK7zTbs3yI090UqjGI=
-github.com/spectrocloud/palette-sdk-go v0.0.0-20250401155513-59cafca8643d/go.mod h1:b5x4jIKc9CR5Hv3o4wsCeadjtw0EM4lx9jrEDWRZSSo=
+github.com/spectrocloud/palette-sdk-go v0.0.0-20250402051801-d9cad104a6f9 h1:YRZeubanJUGDwnm0ME17Qt0Rb7p8jmC4DLB/MYUPQPg=
+github.com/spectrocloud/palette-sdk-go v0.0.0-20250402051801-d9cad104a6f9/go.mod h1:b5x4jIKc9CR5Hv3o4wsCeadjtw0EM4lx9jrEDWRZSSo=
 github.com/spf13/afero v1.1.2/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=
 github.com/spf13/afero v1.2.2/go.mod h1:9ZxEEn6pIJ8Rxe320qSDBk6AsU0r9pR7Q4OcevTdifk=
 github.com/spf13/afero v1.6.0/go.mod h1:Ai8FlHk4v/PARR026UzYexafAt9roJ7LcLMAmO6Z93I=

--- a/spectrocloud/cluster_common_fields.go
+++ b/spectrocloud/cluster_common_fields.go
@@ -16,7 +16,7 @@ func readCommonFields(c *client.V1Client, d *schema.ResourceData, cluster *model
 	//if cluster.Metadata.Annotations["scope"] != "" {
 	//	ClusterContext = cluster.Metadata.Annotations["scope"]
 	//}
-	kubecfg, err := c.GetClusterKubeConfig(d.Id())
+	kubecfg, err := c.GetClusterClientKubeConfig(d.Id())
 	if err != nil {
 		return diag.FromErr(err), true
 	}

--- a/spectrocloud/data_source_cluster.go
+++ b/spectrocloud/data_source_cluster.go
@@ -59,7 +59,7 @@ func dataSourceClusterRead(_ context.Context, d *schema.ResourceData, m interfac
 		}
 		if cluster != nil {
 			d.SetId(cluster.Metadata.UID)
-			kubeConfig, _ := c.GetClusterKubeConfig(cluster.Metadata.UID)
+			kubeConfig, _ := c.GetClusterClientKubeConfig(cluster.Metadata.UID)
 			if err := d.Set("kube_config", kubeConfig); err != nil {
 				return diag.FromErr(err)
 			}


### PR DESCRIPTION
PLT-1672: use GetClusterClientKubeConfig instead of GetClusterKubeConfig(PEM-7335)

ref: https://github.com/spectrocloud/palette-sdk-go/pull/157