### PR TITLE
implement tags_map for AWS IaaS and EKS

### DIFF
--- a/docs/resources/application_profile.md
+++ b/docs/resources/application_profile.md
@@ -393,6 +393,7 @@ resource "spectrocloud_application_profile" "app_profile_all_tiers" {
 - `context` (String) Context of the profile. Allowed values are `project`, `cluster`, or `namespace`. Default value is `project`.If  the `project` context is specified, the project name will sourced from the provider configuration parameter [`project_name`](https://registry.terraform.io/providers/spectrocloud/spectrocloud/latest/docs#schema).
 - `description` (String) Description of the profile.
 - `tags` (Set of String) A list of tags to be applied to the application profile. Tags must be in the form of `key:value`.
+- `tags_map` (Map of String) A map of tags to be applied to the cluster.
 - `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
 - `version` (String) Version of the profile. Default value is 1.0.0.
 

--- a/docs/resources/cluster_aws.md
+++ b/docs/resources/cluster_aws.md
@@ -170,6 +170,7 @@ Refer to the [Import section](/docs#import) to learn more.
 - `scan_policy` (Block List, Max: 1) The scan policy for the cluster. (see [below for nested schema](#nestedblock--scan_policy))
 - `skip_completion` (Boolean) If `true`, the cluster will be created asynchronously. Default value is `false`.
 - `tags` (Set of String) A list of tags to be applied to the cluster. Tags must be in the form of `key:value`.
+- `tags_map` (Map of String) A map of tags to be applied to the cluster.
 - `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
 
 ### Read-Only

--- a/docs/resources/cluster_eks.md
+++ b/docs/resources/cluster_eks.md
@@ -120,6 +120,7 @@ resource "spectrocloud_cluster_eks" "cluster" {
 - `scan_policy` (Block List, Max: 1) The scan policy for the cluster. (see [below for nested schema](#nestedblock--scan_policy))
 - `skip_completion` (Boolean) If `true`, the cluster will be created asynchronously. Default value is `false`.
 - `tags` (Set of String) A list of tags to be applied to the cluster. Tags must be in the form of `key:value`.
+- `tags_map` (Map of String) A map of tags to be applied to the cluster.
 - `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
 
 ### Read-Only

--- a/spectrocloud/cluster_common_fields.go
+++ b/spectrocloud/cluster_common_fields.go
@@ -3,11 +3,12 @@ package spectrocloud
 import (
 	"errors"
 	"fmt"
+	"strings"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/spectrocloud/palette-sdk-go/api/models"
 	"github.com/spectrocloud/palette-sdk-go/client"
-	"strings"
 )
 
 // read common fields like kubeconfig, tags, backup policy, scan policy, cluster_rbac_binding, namespaces
@@ -135,7 +136,7 @@ func getSpectroComponentsUpgrade(cluster *models.V1SpectroCluster) string {
 
 // update common fields like namespaces, cluster_rbac_binding, cluster_profile, backup_policy, scan_policy
 func updateCommonFields(d *schema.ResourceData, c *client.V1Client) (diag.Diagnostics, bool) {
-	if d.HasChanges("name", "tags", "description") {
+	if d.HasChanges("name", "tags", "tags_map", "description") {
 		if err := updateClusterMetadata(c, d); err != nil {
 			return diag.FromErr(err), true
 		}

--- a/spectrocloud/cluster_common_metadata.go
+++ b/spectrocloud/cluster_common_metadata.go
@@ -10,7 +10,7 @@ func getClusterMetadata(d *schema.ResourceData) *models.V1ObjectMeta {
 	return &models.V1ObjectMeta{
 		Name:        d.Get("name").(string),
 		UID:         d.Id(),
-		Labels:      toTags(d),
+		Labels:      toMergedTags(d),
 		Annotations: map[string]string{"description": d.Get("description").(string)},
 	}
 }
@@ -18,7 +18,7 @@ func getClusterMetadata(d *schema.ResourceData) *models.V1ObjectMeta {
 func toClusterMetadataUpdate(d *schema.ResourceData) *models.V1ObjectMetaInputEntity {
 	return &models.V1ObjectMetaInputEntity{
 		Name:        d.Get("name").(string),
-		Labels:      toTags(d),
+		Labels:      toMergedTags(d),
 		Annotations: map[string]string{"description": d.Get("description").(string)},
 	}
 }

--- a/spectrocloud/cluster_common_tag_map.go
+++ b/spectrocloud/cluster_common_tag_map.go
@@ -1,0 +1,40 @@
+package spectrocloud
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func toTagsMap(d *schema.ResourceData) map[string]string {
+	tags := make(map[string]string)
+	if d.Get("tags_map") != nil {
+		for k, v := range d.Get("tags_map").(map[string]interface{}) {
+			vStr := v.(string)
+			if v != "" {
+				tags[k] = vStr
+			} else {
+				tags[k] = "spectro__tag"
+			}
+		}
+		return tags
+	} else {
+		return nil
+	}
+}
+
+func flattenTagsMap(labels map[string]string) []interface{} {
+	tags := make([]interface{}, 0)
+	if len(labels) > 0 {
+		for k, v := range labels {
+			if v == "spectro__tag" {
+				tags = append(tags, k)
+			} else {
+				tags = append(tags, fmt.Sprintf("%s:%s", k, v))
+			}
+		}
+		return tags
+	} else {
+		return nil
+	}
+}

--- a/spectrocloud/cluster_common_tag_map_test.go
+++ b/spectrocloud/cluster_common_tag_map_test.go
@@ -1,0 +1,74 @@
+package spectrocloud
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestToTagsMap(t *testing.T) {
+	tagRD := getBaseResourceData()
+	tagMap := map[string]string{
+		"my:key1":         "my:value1",
+		"my@key:longer:2": "my@value:longer:2",
+		"mykey":           "",
+	}
+	err := tagRD.Set("tags_map", tagMap)
+	if err != nil {
+		assert.Fail(t, "Error setting tags_map.")
+	}
+	tags := toTagsMap(tagRD)
+	assert.Equal(t, tags["my:key1"], "my:value1")
+	assert.Equal(t, tags["my@key:longer:2"], "my@value:longer:2")
+	assert.Equal(t, tags["mykey"], "spectro__tag")
+}
+
+func TestFlattenTagsMap(t *testing.T) {
+	tagMap := make(map[string]string)
+	tagMap["unittest"] = "spectro__tag"
+	tagMap["owner"] = "siva"
+	tags := flattenTagsMap(tagMap)
+
+	// Check that the tags slice contains the expected tags, regardless of order
+	assert.Contains(t, tags, "unittest")
+	assert.Contains(t, tags, "owner:"+tagMap["owner"])
+}
+
+func TestToMergedTags(t *testing.T) {
+	tagRD := getBaseResourceData()
+	tags := []string{"mykeytooverwrite:overwriteme", "mytagskey:mytagsvalue"}
+	tagMap := map[string]string{
+		"my@long:key:colons": "my@long:values:2",
+		"mykey":              "",
+		"mykeytooverwrite":   "overwrittenbymergefrommap",
+	}
+	err := tagRD.Set("tags", tags)
+	if err != nil {
+		assert.Fail(t, "Error setting tags.")
+	}
+	err = tagRD.Set("tags_map", tagMap)
+	if err != nil {
+		assert.Fail(t, "Error setting tags_map.")
+	}
+	mergedTags := toMergedTags(tagRD)
+	assert.Equal(t, mergedTags["my@long:key:colons"], "my@long:values:2")        // multiple colons in key and value
+	assert.Equal(t, mergedTags["mykey"], "spectro__tag")                         // empty value default
+	assert.Equal(t, mergedTags["mykeytooverwrite"], "overwrittenbymergefrommap") // overwrite kv in tags if exists in tags_map
+	assert.Equal(t, mergedTags["mytagskey"], "mytagsvalue")                      // preserve kv in tags on merge
+}
+
+func TestToMergedTagsNilMap(t *testing.T) {
+	tagRD := getBaseResourceData()
+	tags := []string{"mykeytooverwrite:overwriteme", "mytagskey:mytagsvalue"}
+	err := tagRD.Set("tags", tags)
+	if err != nil {
+		assert.Fail(t, "Error setting tags.")
+	}
+	err = tagRD.Set("tags_map", nil)
+	if err != nil {
+		assert.Fail(t, "Error setting tags_map.")
+	}
+	mergedTags := toMergedTags(tagRD)
+	assert.Equal(t, mergedTags["mykeytooverwrite"], "overwriteme") // overwrite kv in tags if exists in tags_map
+	assert.Equal(t, mergedTags["mytagskey"], "mytagsvalue")        // preserve kv in tags on merge
+}

--- a/spectrocloud/cluster_common_tags.go
+++ b/spectrocloud/cluster_common_tags.go
@@ -2,9 +2,21 @@ package spectrocloud
 
 import (
 	"fmt"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"maps"
 	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
+
+func toMergedTags(d *schema.ResourceData) map[string]string {
+	tags := toTags(d)
+	tagsMap := toTagsMap(d)
+	// copy tags_map k:v into tags, if same keys are present in both maps then tags_map value will be used
+	if tagsMap != nil {
+		maps.Copy(tags, tagsMap)
+	}
+	return tags
+}
 
 func toTags(d *schema.ResourceData) map[string]string {
 	tags := make(map[string]string)

--- a/spectrocloud/resource_application_profile.go
+++ b/spectrocloud/resource_application_profile.go
@@ -62,6 +62,14 @@ func resourceApplicationProfile() *schema.Resource {
 					Type: schema.TypeString,
 				},
 			},
+			"tags_map": {
+				Type:     schema.TypeMap,
+				Optional: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+				Description: "A map of tags to be applied to the cluster.",
+			},
 			"description": {
 				Type:        schema.TypeString,
 				Description: "Description of the profile.",

--- a/spectrocloud/resource_cluster_aws.go
+++ b/spectrocloud/resource_cluster_aws.go
@@ -58,6 +58,14 @@ func resourceClusterAws() *schema.Resource {
 				},
 				Description: "A list of tags to be applied to the cluster. Tags must be in the form of `key:value`.",
 			},
+			"tags_map": {
+				Type:     schema.TypeMap,
+				Optional: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+				Description: "A map of tags to be applied to the cluster.",
+			},
 			"description": {
 				Type:        schema.TypeString,
 				Optional:    true,

--- a/spectrocloud/resource_cluster_eks.go
+++ b/spectrocloud/resource_cluster_eks.go
@@ -59,6 +59,14 @@ func resourceClusterEks() *schema.Resource {
 				},
 				Description: "A list of tags to be applied to the cluster. Tags must be in the form of `key:value`.",
 			},
+			"tags_map": {
+				Type:     schema.TypeMap,
+				Optional: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+				Description: "A map of tags to be applied to the cluster.",
+			},
 			"description": {
 				Type:        schema.TypeString,
 				Optional:    true,


### PR DESCRIPTION
Tested by defining `tags_map` in `spectrocloud_cluster_aws` and `spectrocloud_cluster_eks` cluster resources and saw tags reflected in Palette UI and EKS.  Tested with mix of `tags` and `tags_map` definitions as well.