### PR TITLE
mark spectrocloud_macro as deprecated

### DIFF
--- a/docs/resources/macro.md
+++ b/docs/resources/macro.md
@@ -2,12 +2,12 @@
 page_title: "spectrocloud_macro Resource - terraform-provider-spectrocloud"
 subcategory: ""
 description: |-
-  A resource for creating and managing service output variables and macro.
+  A resource for creating and managing service output variables and macro. (Deprecated)
 ---
 
-# spectrocloud_macro (Resource)
+# spectrocloud_macro (Resource, Deprecated)
 
-  A resource for creating and managing service output variables and macro.
+  A resource for creating and managing service output variables and macro. (Deprecated)
 
 ## Example Usage
 

--- a/spectrocloud/resource_macro.go
+++ b/spectrocloud/resource_macro.go
@@ -2,8 +2,9 @@ package spectrocloud
 
 import (
 	"context"
-	"github.com/spectrocloud/palette-sdk-go/client/apiutil"
 	"time"
+
+	"github.com/spectrocloud/palette-sdk-go/client/apiutil"
 
 	"github.com/spectrocloud/palette-sdk-go/api/models"
 
@@ -17,7 +18,7 @@ func resourceMacro() *schema.Resource {
 		ReadContext:   resourceMacroRead,
 		UpdateContext: resourceMacroUpdate,
 		DeleteContext: resourceMacroDelete,
-		Description:   "A resource for creating and managing service output variables and macro.",
+		Description:   "A resource for creating and managing service output variables and macro. (Deprecated)",
 
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(10 * time.Minute),

--- a/templates/resources/macro.md.tmpl
+++ b/templates/resources/macro.md.tmpl
@@ -5,7 +5,7 @@ description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---
 
-# {{.Name}} ({{.Type}})
+# {{.Name}} ({{.Type}}, Deprecated)
 
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 


### PR DESCRIPTION
We need to be marking deprecated items in our external facing docs if they are deprecated.  I am labeling this as such given the following comment: https://spectrocloud.atlassian.net/browse/PFR-971?focusedCommentId=135380.