### PR TITLE
PLT-1727: Support import for spectrocloud_macros

### DIFF
--- a/docs/resources/macro.md
+++ b/docs/resources/macro.md
@@ -22,6 +22,12 @@ resource "spectrocloud_macro" "tenant_macro" {
   name  = "tenant1"
   value = "tenant_val1"
 }
+resource "spectrocloud_macros" "imported_macros" {
+    
+}
+resource "spectrocloud_macros" "imported_macros_project" {
+    
+}
 ```
 
 
@@ -50,3 +56,28 @@ Optional:
 - `create` (String)
 - `delete` (String)
 - `update` (String)
+- `import` (String)
+
+To retrieve a list of macros without managing them directly in Terraform, you can use a data source in conjunction with your .tfvars:
+##Example
+data "spectrocloud_macros" "project" {
+  project = "Default"
+}
+
+output "available_macros_project" {
+  value = data.spectrocloud_macros.project.macros
+}
+
+data "spectrocloud_macros" "tenant" {
+
+}
+output "available_macros_tenant" {
+  value = data.spectrocloud_macros.tenant.macros
+}
+#terraform apply -auto-approve -var-file="terraform.template.tfvars"
+
+You can import existing macros into Terraform’s state by specifying their scope and ID.
+terraform import spectrocloud_macros.imported_macros_project project-macros-<project-Name>
+terraform import spectrocloud_macros.imported_macros_tenant tenant-macros
+After import, inspect the imported data using:
+terraform state show spectrocloud_macros.imported_macros_project

--- a/examples/data-sources/spectrocloud_macros/data-source.tf
+++ b/examples/data-sources/spectrocloud_macros/data-source.tf
@@ -1,0 +1,14 @@
+data "spectrocloud_macros" "project" {
+  project = "Default"
+}
+
+output "available_macros_project" {
+  value = data.spectrocloud_macros.project.macros
+}
+
+data "spectrocloud_macros" "tenant" {
+
+}
+output "available_macros_tenant" {
+  value = data.spectrocloud_macros.tenant.macros
+}

--- a/examples/data-sources/spectrocloud_macros/providers.tf
+++ b/examples/data-sources/spectrocloud_macros/providers.tf
@@ -1,0 +1,18 @@
+terraform {
+  required_providers {
+    spectrocloud = {
+      version = ">= 0.1"
+      source  = "spectrocloud/spectrocloud"
+    }
+  }
+}
+
+variable "sc_host" {}
+variable "sc_api_key" {}
+variable "sc_project_name" {}
+
+provider "spectrocloud" {
+  host         = var.sc_host
+  api_key      = var.sc_api_key
+  project_name = var.sc_project_name
+}

--- a/examples/data-sources/spectrocloud_macros/terraform.template.tfvars
+++ b/examples/data-sources/spectrocloud_macros/terraform.template.tfvars
@@ -1,0 +1,4 @@
+# Spectro Cloud credentials
+sc_host         = "{Enter Spectro Cloud API Host}" #e.g: api.spectrocloud.com (for SaaS)
+sc_api_key      = "{Enter Spectro Cloud API Key}"
+sc_project_name = "{Enter Spectro Cloud Project Name}" #e.g: Default

--- a/examples/resources/spectrocloud_macros/resource.tf
+++ b/examples/resources/spectrocloud_macros/resource.tf
@@ -12,3 +12,12 @@ resource "spectrocloud_macros" "tenant_macro" {
     "tenant_macro_2" = "tenant_val2",
   }
 }
+
+resource "spectrocloud_macros" "imported_macros" {
+    
+}
+
+
+resource "spectrocloud_macros" "imported_macros_project" {
+    
+}

--- a/spectrocloud/data_source_macros.go
+++ b/spectrocloud/data_source_macros.go
@@ -28,14 +28,6 @@ func dataSourceMacros() *schema.Resource {
 				},
 				Description: "The key-value mapping of macros to look up.",
 			},
-			"macro_ids": {
-				Type:     schema.TypeMap,
-				Computed: true,
-				Elem: &schema.Schema{
-					Type: schema.TypeString,
-				},
-				Description: "A map of macro names to their import IDs (which are just the macro names).",
-			},
 			"id": {
 				Type:        schema.TypeString,
 				Computed:    true,

--- a/spectrocloud/data_source_macros.go
+++ b/spectrocloud/data_source_macros.go
@@ -1,0 +1,127 @@
+package spectrocloud
+
+import (
+	"context"
+	"log"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/spectrocloud/palette-sdk-go/api/models"
+)
+
+func dataSourceMacros() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceMacrosRead,
+		Description: "Use this data source to get the ID of a macros resource for use with terraform import.",
+
+		Schema: map[string]*schema.Schema{
+			"project": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The Spectro Cloud project name. If not specified, macros will be looked up at tenant level.",
+			},
+			"macros": {
+				Type:     schema.TypeMap,
+				Computed: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+				Description: "The key-value mapping of macros to look up.",
+			},
+			"macro_ids": {
+				Type:     schema.TypeMap,
+				Computed: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+				Description: "A map of macro names to their import IDs (which are just the macro names).",
+			},
+			"id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The ID of the macros resource that can be used with terraform import.",
+			},
+		},
+	}
+}
+
+func dataSourceMacrosRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	log.Printf("[DEBUG] ===== Starting dataSourceMacrosRead =====")
+
+	c := getV1ClientWithResourceContext(m, "")
+	log.Printf("[DEBUG] Got client with context")
+
+	var diags diag.Diagnostics
+	var err error
+
+	var projectName string
+	var uid string
+	var importID string
+	var macros []*models.V1Macro
+
+	if v, ok := d.GetOk("project"); ok && v.(string) != "" {
+		projectName = v.(string)
+		log.Printf("[DEBUG] Project name specified: %s", projectName)
+
+		// Get project UID
+		log.Printf("[DEBUG] Getting project UID for project: %s", projectName)
+		uid, err = c.GetProjectUID(projectName)
+		if err != nil {
+			log.Printf("[ERROR] Failed to get project UID: %v", err)
+			return diag.FromErr(err)
+		}
+		log.Printf("[DEBUG] Got project UID: %s", uid)
+		ProviderInitProjectUid = uid
+		log.Printf("[DEBUG] Set ProviderInitProjectUid to: %s", uid)
+		importID = "project-macros-" + projectName
+		log.Printf("[DEBUG] Set importID to: %s", importID)
+		macros, err = c.GetMacrosV2(uid)
+		if err != nil {
+			log.Printf("[ERROR] Failed to get project macros: %v", err)
+			return diag.FromErr(err)
+		}
+		log.Printf("[DEBUG] Retrieved %d project macros", len(macros))
+	} else {
+		log.Printf("[DEBUG] No project specified, getting tenant macros")
+		ProviderInitProjectUid = ""
+		log.Printf("[DEBUG] Reset ProviderInitProjectUid to empty string")
+
+		// Tenant
+		log.Printf("[DEBUG] Getting tenant UID")
+		uid, err = c.GetTenantUID()
+		if err != nil {
+			log.Printf("[ERROR] Failed to get tenant UID: %v", err)
+			return diag.FromErr(err)
+		}
+		log.Printf("[DEBUG] Got tenant UID: %s", uid)
+		importID = "tenant-macros"
+		log.Printf("[DEBUG] Set importID to: %s", importID)
+		macros, err = c.GetMacrosV2("")
+		if err != nil {
+			log.Printf("[ERROR] Failed to get tenant macros: %v", err)
+			return diag.FromErr(err)
+		}
+		log.Printf("[DEBUG] Retrieved %d tenant macros", len(macros))
+	}
+
+	// ✅ Build map[string]interface{} to return
+	out := make(map[string]interface{}, len(macros))
+	macroIDs := make(map[string]interface{}, len(macros))
+	for _, macro := range macros {
+		out[macro.Name] = macro.Value
+		macroIDs[macro.Name] = macro.Name
+		log.Printf("[DEBUG] Processing macro: %s = %s", macro.Name, macro.Value)
+	}
+
+	log.Printf("[DEBUG] Setting macros in state: %+v", out)
+	_ = d.Set("macros", out)
+
+	log.Printf("[DEBUG] Setting macro_ids in state: %+v", macroIDs)
+	_ = d.Set("macro_ids", macroIDs)
+
+	log.Printf("[DEBUG] Setting resource ID to: %s", importID)
+	d.SetId(importID)
+
+	log.Printf("[DEBUG] ===== dataSourceMacrosRead completed successfully =====")
+	return diags
+}

--- a/spectrocloud/data_source_macros_test.go
+++ b/spectrocloud/data_source_macros_test.go
@@ -1,0 +1,43 @@
+package spectrocloud
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/stretchr/testify/assert"
+)
+
+func prepareMacrosTestData() *schema.ResourceData {
+	d := dataSourceMacros().TestResourceData()
+	d.Set("macros", map[string]interface{}{
+		"macro1": "value1",
+		"macro2": "value2",
+	})
+	return d
+}
+
+func TestDataSourceMacrosRead(t *testing.T) {
+	ctx := context.Background()
+	resourceData := prepareMacrosTestData()
+
+	// Call the function
+	diags := dataSourceMacrosRead(ctx, resourceData, unitTestMockAPIClient)
+
+	// Assertions
+	assert.Equal(t, 0, len(diags))
+	assert.NotEmpty(t, resourceData.Id())
+}
+
+func TestDataSourceProjectMacrosRead(t *testing.T) {
+	ctx := context.Background()
+	resourceData := prepareMacrosTestData()
+	resourceData.Set("project", "Default")
+
+	// Call the function
+	diags := dataSourceMacrosRead(ctx, resourceData, unitTestMockAPIClient)
+
+	// Assertions
+	assert.Equal(t, 0, len(diags))
+	assert.NotEmpty(t, resourceData.Id())
+}

--- a/spectrocloud/provider.go
+++ b/spectrocloud/provider.go
@@ -188,6 +188,7 @@ func New(_ string) func() *schema.Provider {
 				"spectrocloud_privatecloudgateway_dns_map": dataSourcePrivateCloudGatewayDNSMap(),
 				"spectrocloud_ssh_key":                     dataSourceSSHKey(),
 				"spectrocloud_registration_token":          dataSourceRegistrationToken(),
+				"spectrocloud_macros":                      dataSourceMacros(),
 			},
 			ConfigureContextFunc: providerConfigure,
 		}

--- a/spectrocloud/resource_macros_test.go
+++ b/spectrocloud/resource_macros_test.go
@@ -395,7 +395,7 @@ func TestResourceProjectMacrosImportState(t *testing.T) {
 	resourceData := prepareBaseProjectMacrosSchema()
 
 	// Set a test ID that matches the format from GetMacrosId
-	resourceData.SetId("project-macros-<test-project-id>")
+	resourceData.SetId("project-macros-<project-name>")
 
 	// Call the import function
 	importedData, err := resourceMacrosImport(ctx, resourceData, unitTestMockAPIClient)
@@ -404,7 +404,7 @@ func TestResourceProjectMacrosImportState(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, importedData)
 	assert.Equal(t, 1, len(importedData))
-	assert.Equal(t, "project-macros-<test-project-id>", importedData[0].Id())
+	assert.Equal(t, "project-macros-<project-name>", importedData[0].Id())
 	assert.NotEmpty(t, importedData[0].Get("macros"))
 	assert.Equal(t, "project", importedData[0].Get("context"))
 }

--- a/spectrocloud/resource_macros_test.go
+++ b/spectrocloud/resource_macros_test.go
@@ -2,10 +2,11 @@ package spectrocloud
 
 import (
 	"context"
+	"testing"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/spectrocloud/palette-sdk-go/api/models"
 	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
 func TestToMacros(t *testing.T) {
@@ -369,4 +370,56 @@ func TestResourceTenantMacrosDeleteNegative(t *testing.T) {
 	if assert.NotEmpty(t, diags) { // Check that diags is not empty
 		assert.Contains(t, diags[0].Summary, "Macro not found") // Verify the error message
 	}
+}
+
+func TestResourceTenantMacrosImportState(t *testing.T) {
+	ctx := context.Background()
+	resourceData := prepareBaseTenantMacrosSchema()
+
+	// Set a test ID that matches the format from GetMacrosId
+	resourceData.SetId("tenant-macros")
+
+	// Call the import function
+	importedData, err := resourceMacrosImport(ctx, resourceData, unitTestMockAPIClient)
+
+	// Assertions
+	assert.NoError(t, err)
+	assert.NotNil(t, importedData)
+	assert.Equal(t, 1, len(importedData))
+	assert.Equal(t, "tenant-macros", importedData[0].Id())
+	assert.NotEmpty(t, importedData[0].Get("macros"))
+}
+
+func TestResourceProjectMacrosImportState(t *testing.T) {
+	ctx := context.Background()
+	resourceData := prepareBaseProjectMacrosSchema()
+
+	// Set a test ID that matches the format from GetMacrosId
+	resourceData.SetId("project-macros-<test-project-id>")
+
+	// Call the import function
+	importedData, err := resourceMacrosImport(ctx, resourceData, unitTestMockAPIClient)
+
+	// Assertions
+	assert.NoError(t, err)
+	assert.NotNil(t, importedData)
+	assert.Equal(t, 1, len(importedData))
+	assert.Equal(t, "project-macros-<test-project-id>", importedData[0].Id())
+	assert.NotEmpty(t, importedData[0].Get("macros"))
+	assert.Equal(t, "project", importedData[0].Get("context"))
+}
+
+func TestResourceMacrosImportStateInvalidID(t *testing.T) {
+	ctx := context.Background()
+	resourceData := prepareBaseTenantMacrosSchema()
+
+	// Set an invalid ID
+	resourceData.SetId("invalid-id")
+
+	// Call the import function
+	importedData, err := resourceMacrosImport(ctx, resourceData, unitTestMockAPIClient)
+
+	// Assertions
+	assert.Error(t, err)
+	assert.Nil(t, importedData)
 }


### PR DESCRIPTION
PLT-1727: Support import for spectrocloud_macros

Enabled import of existing project-level and tenant-level macros into Terraform state:
	•	terraform import spectrocloud_macros.imported_macros_project project-macros-<project-name>
	•	terraform import spectrocloud_macros.imported_macros_tenant tenant-macros

Supported retrieval of existing macros via data source 