### PR TITLE
fix: update sso oidc resource to have correct validation and description

### DIFF
--- a/docs/resources/sso.md
+++ b/docs/resources/sso.md
@@ -91,12 +91,12 @@ Required:
 
 - `client_id` (String) Client ID for OIDC authentication.
 - `client_secret` (String, Sensitive) Client secret for OIDC authentication (sensitive).
-- `email` (String) User's email address retrieved from identity provider.
-- `first_name` (String) User's first name retrieved from identity provider.
+- `email` (String) The name of the claim that returns the user's email address from the identity provider.
+- `first_name` (String) The name of the claim that returns the user's first name from the identity provider.
 - `issuer_url` (String) URL of the OIDC issuer.
-- `last_name` (String) User's last name retrieved from identity provider.
+- `last_name` (String) The name of the claim that returns the user's last name from the identity provider.
 - `scopes` (Set of String) Scopes requested during OIDC authentication.
-- `spectro_team` (String) The SpectroCloud team the user belongs to.
+- `spectro_team` (String) The name of the claim that returns the user's group memberships from the Identity Provider. The values of this claim will map to SpectroCloud teams.
 
 Optional:
 
@@ -115,10 +115,10 @@ Read-Only:
 
 Required:
 
-- `email` (String) User's email address retrieved from identity provider.
-- `first_name` (String) User's first name retrieved from identity provider.
-- `last_name` (String) User's last name retrieved from identity provider.
-- `spectro_team` (String) The SpectroCloud team the user belongs to.
+- `email` (String) The name of the claim that returns the user's email address from the identity provider.
+- `first_name` (String) The name of the claim that returns the user's first name from the identity provider.
+- `last_name` (String) The name of the claim that returns the user's last name from the identity provider.
+- `spectro_team` (String) The name of the claim that returns the user's group memberships from the Identity Provider. The values of this claim will map to SpectroCloud teams.
 
 
 

--- a/spectrocloud/resource_sso.go
+++ b/spectrocloud/resource_sso.go
@@ -152,27 +152,22 @@ func resourceSSO() *schema.Resource {
 						"first_name": {
 							Type:        schema.TypeString,
 							Required:    true,
-							Description: "User's first name retrieved from identity provider.",
+							Description: "The name of the claim that returns the user's first name from the identity provider.",
 						},
 						"last_name": {
 							Type:        schema.TypeString,
 							Required:    true,
-							Description: "User's last name retrieved from identity provider.",
+							Description: "The name of the claim that returns the user's last name from the identity provider.",
 						},
 						"email": {
 							Type:        schema.TypeString,
 							Required:    true,
-							Description: "User's email address retrieved from identity provider.",
+							Description: "The name of the claim that returns the user's email address from the identity provider.",
 							ValidateFunc: func(val interface{}, key string) (warns []string, errs []error) {
 								v := val.(string)
 								if v == "" {
 									errs = append(errs, fmt.Errorf("%q must not be empty", key))
 									return
-								}
-								emailRegex := `^[a-zA-Z0-9._%+\-]+@[a-zA-Z0-9.\-]+\.[a-zA-Z]{2,}$`
-								matched, err := regexp.MatchString(emailRegex, v)
-								if err != nil || !matched {
-									errs = append(errs, fmt.Errorf("%q must be a valid email address", key))
 								}
 								return
 							},
@@ -180,7 +175,7 @@ func resourceSSO() *schema.Resource {
 						"spectro_team": {
 							Type:        schema.TypeString,
 							Required:    true,
-							Description: "The SpectroCloud team the user belongs to.",
+							Description: "The name of the claim that returns the user's group memberships from the Identity Provider. The values of this claim will map to SpectroCloud teams.",
 						},
 						"user_info_endpoint": {
 							Type:        schema.TypeList,
@@ -192,27 +187,22 @@ func resourceSSO() *schema.Resource {
 									"first_name": {
 										Type:        schema.TypeString,
 										Required:    true,
-										Description: "User's first name retrieved from identity provider.",
+										Description: "The name of the claim that returns the user's first name from the identity provider.",
 									},
 									"last_name": {
 										Type:        schema.TypeString,
 										Required:    true,
-										Description: "User's last name retrieved from identity provider.",
+										Description: "The name of the claim that returns the user's last name from the identity provider.",
 									},
 									"email": {
 										Type:        schema.TypeString,
 										Required:    true,
-										Description: "User's email address retrieved from identity provider.",
+										Description: "The name of the claim that returns the user's email address from the identity provider.",
 										ValidateFunc: func(val interface{}, key string) (warns []string, errs []error) {
 											v := val.(string)
 											if v == "" {
 												errs = append(errs, fmt.Errorf("%q must not be empty", key))
 												return
-											}
-											emailRegex := `^[a-zA-Z0-9._%+\-]+@[a-zA-Z0-9.\-]+\.[a-zA-Z]{2,}$`
-											matched, err := regexp.MatchString(emailRegex, v)
-											if err != nil || !matched {
-												errs = append(errs, fmt.Errorf("%q must be a valid email address", key))
 											}
 											return
 										},
@@ -220,7 +210,7 @@ func resourceSSO() *schema.Resource {
 									"spectro_team": {
 										Type:        schema.TypeString,
 										Required:    true,
-										Description: "The SpectroCloud team the user belongs to.",
+										Description: "The name of the claim that returns the user's group memberships from the Identity Provider. The values of this claim will map to SpectroCloud teams.",
 									},
 								},
 							},

--- a/spectrocloud/resource_sso_test.go
+++ b/spectrocloud/resource_sso_test.go
@@ -51,17 +51,17 @@ func TestToOIDC(t *testing.T) {
 				"insecure_skip_tls_verify":         true,
 				"issuer_url":                       "https://issuer.com",
 				"logout_url":                       "https://example.com/logout",
-				"email":                            "user@example.com",
-				"first_name":                       "John",
-				"last_name":                        "Doe",
-				"spectro_team":                     "devops",
+				"email":                            "email",
+				"first_name":                       "given_name",
+				"last_name":                        "family_name",
+				"spectro_team":                     "groups",
 				"scopes":                           schema.NewSet(schema.HashString, []interface{}{"openid", "profile"}),
 				"user_info_endpoint": []interface{}{
 					map[string]interface{}{
-						"email":        "user@example.com",
-						"first_name":   "John",
-						"last_name":    "Doe",
-						"spectro_team": "devops",
+						"email":        "email",
+						"first_name":   "given_name",
+						"last_name":    "family_name",
+						"spectro_team": "groups",
 					},
 				},
 			},
@@ -83,14 +83,14 @@ func TestToOIDC(t *testing.T) {
 	assert.Equal(t, true, *result.IssuerTLS.InsecureSkipVerify)
 	assert.Equal(t, "https://issuer.com", result.IssuerURL)
 	assert.Equal(t, "https://example.com/logout", result.LogoutURL)
-	assert.Equal(t, "user@example.com", result.RequiredClaims.Email)
-	assert.Equal(t, "John", result.RequiredClaims.FirstName)
-	assert.Equal(t, "Doe", result.RequiredClaims.LastName)
-	assert.Equal(t, "devops", result.RequiredClaims.SpectroTeam)
-	assert.Equal(t, "user@example.com", result.UserInfo.Claims.Email)
-	assert.Equal(t, "John", result.UserInfo.Claims.FirstName)
-	assert.Equal(t, "Doe", result.UserInfo.Claims.LastName)
-	assert.Equal(t, "devops", result.UserInfo.Claims.SpectroTeam)
+	assert.Equal(t, "email", result.RequiredClaims.Email)
+	assert.Equal(t, "given_name", result.RequiredClaims.FirstName)
+	assert.Equal(t, "family_name", result.RequiredClaims.LastName)
+	assert.Equal(t, "groups", result.RequiredClaims.SpectroTeam)
+	assert.Equal(t, "email", result.UserInfo.Claims.Email)
+	assert.Equal(t, "given_name", result.UserInfo.Claims.FirstName)
+	assert.Equal(t, "family_name", result.UserInfo.Claims.LastName)
+	assert.Equal(t, "groups", result.UserInfo.Claims.SpectroTeam)
 	assert.Equal(t, true, *result.UserInfo.UseUserInfo)
 }
 
@@ -146,18 +146,18 @@ func TestFlattenOidc(t *testing.T) {
 		IssuerURL: "https://issuer.com",
 		LogoutURL: "https://example.com/logout",
 		RequiredClaims: &models.V1TenantOidcClaims{
-			Email:       "user@example.com",
-			FirstName:   "John",
-			LastName:    "Doe",
-			SpectroTeam: "devops",
+			Email:       "email",
+			FirstName:   "given_name",
+			LastName:    "family_name",
+			SpectroTeam: "groups",
 		},
 		Scopes: []string{"openid", "profile"},
 		UserInfo: &models.V1OidcUserInfo{
 			Claims: &models.V1TenantOidcClaims{
-				Email:       "user@example.com",
-				FirstName:   "John",
-				LastName:    "Doe",
-				SpectroTeam: "devops",
+				Email:       "email",
+				FirstName:   "given_name",
+				LastName:    "family_name",
+				SpectroTeam: "groups",
 			},
 		},
 	}
@@ -174,17 +174,17 @@ func TestFlattenOidc(t *testing.T) {
 	assert.Equal(t, true, flattened["insecure_skip_tls_verify"])
 	assert.Equal(t, "https://issuer.com", flattened["issuer_url"])
 	assert.Equal(t, "https://example.com/logout", flattened["logout_url"])
-	assert.Equal(t, "user@example.com", flattened["email"])
-	assert.Equal(t, "John", flattened["first_name"])
-	assert.Equal(t, "Doe", flattened["last_name"])
-	assert.Equal(t, "devops", flattened["spectro_team"])
+	assert.Equal(t, "email", flattened["email"])
+	assert.Equal(t, "given_name", flattened["first_name"])
+	assert.Equal(t, "family_name", flattened["last_name"])
+	assert.Equal(t, "groups", flattened["spectro_team"])
 	assert.Equal(t, []interface{}{"openid", "profile"}, flattened["scopes"])
 
 	userInfo := flattened["user_info_endpoint"].([]interface{})[0].(map[string]interface{})
-	assert.Equal(t, "user@example.com", userInfo["email"])
-	assert.Equal(t, "John", userInfo["first_name"])
-	assert.Equal(t, "Doe", userInfo["last_name"])
-	assert.Equal(t, "devops", userInfo["spectro_team"])
+	assert.Equal(t, "email", userInfo["email"])
+	assert.Equal(t, "given_name", userInfo["first_name"])
+	assert.Equal(t, "family_name", userInfo["last_name"])
+	assert.Equal(t, "groups", userInfo["spectro_team"])
 }
 
 func TestToSAML(t *testing.T) {


### PR DESCRIPTION
Summary:
- Updating descriptions of SSO OIDC fields to be more accurate. The value of these fields is the name of the claim that is returned from the identity provider
- Removing email validation from email OIDC fields. This value is not a real email address; it is the name of the claim that points to the user's email address