### PR TITLE
fix: use clone endpoint when cluster profile version changes

### DIFF
--- a/spectrocloud/provider.go
+++ b/spectrocloud/provider.go
@@ -19,6 +19,13 @@ const (
 )
 
 var ProviderInitProjectUid = ""
+var ProviderFeaturePreview = map[string]bool{}
+
+// isFeaturePreviewEnabled returns true if the given feature flag name is
+// explicitly set to true in the provider's feature_preview map.
+func isFeaturePreviewEnabled(name string) bool {
+	return ProviderFeaturePreview[name]
+}
 
 func New(_ string) func() *schema.Provider {
 	return func() *schema.Provider {
@@ -61,6 +68,15 @@ func New(_ string) func() *schema.Provider {
 					Type:        schema.TypeBool,
 					Optional:    true,
 					Description: "Ignore insecure TLS errors for Spectro Cloud API endpoints. ⚠️ WARNING: Setting this to true disables SSL certificate verification and makes connections vulnerable to man-in-the-middle attacks. Only use this in development/testing environments or when connecting to self-signed certificates in trusted networks. Defaults to false.",
+				},
+				"feature_preview": {
+					Type:     schema.TypeMap,
+					Optional: true,
+					Elem: &schema.Schema{
+						Type: schema.TypeBool,
+					},
+					Description: "A map of feature preview flags. " +
+						"Supported flags: `clone-on-version-change`.",
 				},
 			},
 			ResourcesMap: map[string]*schema.Resource{
@@ -260,6 +276,18 @@ func providerConfigure(ctx context.Context, d *schema.ResourceData) (interface{}
 	if uid != "" {
 		ProviderInitProjectUid = uid
 		client.WithScopeProject(uid)(c)
+	}
+
+	if v, ok := d.GetOk("feature_preview"); ok {
+		fp := v.(map[string]interface{})
+		for key, val := range fp {
+			switch b := val.(type) {
+			case bool:
+				ProviderFeaturePreview[key] = b
+			case string:
+				ProviderFeaturePreview[key] = b == "true"
+			}
+		}
 	}
 
 	return c, diags

--- a/spectrocloud/provider_test.go
+++ b/spectrocloud/provider_test.go
@@ -59,6 +59,13 @@ func prepareBaseProviderConfig() *schema.ResourceData {
 				Optional:    true,
 				Description: "Ignore insecure TLS errors for Spectro Cloud API endpoints. Defaults to false.",
 			},
+			"feature_preview": {
+				Type:     schema.TypeMap,
+				Optional: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeBool,
+				},
+			},
 		},
 	}
 
@@ -76,6 +83,18 @@ func TestProviderConfig(t *testing.T) {
 	d := prepareBaseProviderConfig()
 	_, diags := providerConfigure(context.Background(), d)
 	assert.Empty(t, diags)
+}
+
+func TestIsFeaturePreviewEnabled(t *testing.T) {
+	orig := ProviderFeaturePreview
+	defer func() { ProviderFeaturePreview = orig }()
+
+	ProviderFeaturePreview = map[string]bool{}
+	assert.False(t, isFeaturePreviewEnabled("clone-on-version-change"))
+
+	ProviderFeaturePreview = map[string]bool{"clone-on-version-change": true}
+	assert.True(t, isFeaturePreviewEnabled("clone-on-version-change"))
+	assert.False(t, isFeaturePreviewEnabled("nonexistent"))
 }
 
 func TestProviderConfigValidError(t *testing.T) {

--- a/spectrocloud/resource_cluster_profile.go
+++ b/spectrocloud/resource_cluster_profile.go
@@ -46,10 +46,8 @@ func resourceClusterProfile() *schema.Resource {
 				Optional: true,
 				Default:  "1.0.0", // default as in UI
 				Description: "Version of the cluster profile. Defaults to '1.0.0'. " +
-					"**Important**: Modifying this value will only update the version number of the existing cluster profile. " +
-					"It will NOT create a new version in Palette. " +
-					"To create a new version of a cluster profile, refer to the example at: " +
-					"https://github.com/spectrocloud/spectro-samples/tree/main/terraform/cluster-profiles",
+					"Changing this value on an existing profile creates a new immutable version " +
+					"in Palette via clone. The previous version is preserved.",
 			},
 			"context": {
 				Type:         schema.TypeString,
@@ -230,7 +228,57 @@ func resourceClusterProfileUpdate(ctx context.Context, d *schema.ResourceData, m
 		}
 	}
 
-	if d.HasChanges("name") || d.HasChanges("tags") || d.HasChanges("pack") || d.HasChanges("description") || d.HasChanges("version") {
+	// If version changed, clone the existing profile to create a new immutable version.
+	// This matches Palette's recommended workflow: create a new version rather than
+	// modifying a deployed version in place. The old version persists in Palette untouched.
+	if d.HasChange("version") {
+		name := d.Get("name").(string)
+		version := d.Get("version").(string)
+		log.Printf("Version changed, cloning profile %s to create version %s", d.Id(), version)
+
+		cloneEntity := &models.V1ClusterProfileCloneEntity{
+			Metadata: &models.V1ClusterProfileCloneMetaInputEntity{
+				Name:    &name,
+				Version: version,
+			},
+		}
+		newUID, err := c.CloneClusterProfile(d.Id(), cloneEntity)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+
+		// Update state with new version's UID
+		d.SetId(newUID)
+
+		// If other fields also changed (packs, values, etc.), apply them to the new version
+		if d.HasChanges("name") || d.HasChanges("tags") || d.HasChanges("pack") || d.HasChanges("description") {
+			cp, err := c.GetClusterProfile(newUID)
+			if err != nil {
+				return diag.FromErr(err)
+			}
+			cluster, err := toClusterProfileUpdateWithResolution(d, cp, c)
+			if err != nil {
+				return diag.FromErr(err)
+			}
+			metadata, err := toClusterProfilePatch(d)
+			if err != nil {
+				return diag.FromErr(err)
+			}
+			if err := c.UpdateClusterProfile(cluster); err != nil {
+				return diag.FromErr(err)
+			}
+			if err := c.PatchClusterProfile(cluster, metadata); err != nil {
+				return diag.FromErr(err)
+			}
+		}
+
+		// Note: clone endpoint publishes automatically, no separate publish needed.
+
+		resourceClusterProfileRead(ctx, d, m)
+		return diags
+	}
+
+	if d.HasChanges("name") || d.HasChanges("tags") || d.HasChanges("pack") || d.HasChanges("description") {
 		log.Printf("Updating packs")
 		cp, err := c.GetClusterProfile(d.Id())
 		if err != nil {
@@ -245,7 +293,6 @@ func resourceClusterProfileUpdate(ctx context.Context, d *schema.ResourceData, m
 			return diag.FromErr(err)
 		}
 
-		//ProfileContext := d.Get("context").(string)
 		if err := c.UpdateClusterProfile(cluster); err != nil {
 			return diag.FromErr(err)
 		}

--- a/spectrocloud/resource_cluster_profile.go
+++ b/spectrocloud/resource_cluster_profile.go
@@ -46,7 +46,7 @@ func resourceClusterProfile() *schema.Resource {
 				Optional: true,
 				Default:  "1.0.0", // default as in UI
 				Description: "Version of the cluster profile. Defaults to '1.0.0'. " +
-					"Changing this value on an existing profile creates a new immutable version " +
+					"Changing this value on an existing profile creates a new version " +
 					"in Palette via clone. The previous version is preserved.",
 			},
 			"context": {
@@ -228,7 +228,7 @@ func resourceClusterProfileUpdate(ctx context.Context, d *schema.ResourceData, m
 		}
 	}
 
-	// If version changed, clone the existing profile to create a new immutable version.
+	// If version changed, clone the existing profile to create a new version.
 	// This matches Palette's recommended workflow: create a new version rather than
 	// modifying a deployed version in place. The old version persists in Palette untouched.
 	if d.HasChange("version") {
@@ -236,23 +236,30 @@ func resourceClusterProfileUpdate(ctx context.Context, d *schema.ResourceData, m
 		version := d.Get("version").(string)
 		log.Printf("Version changed, cloning profile %s to create version %s", d.Id(), version)
 
-		cloneEntity := &models.V1ClusterProfileCloneEntity{
-			Metadata: &models.V1ClusterProfileCloneMetaInputEntity{
-				Name:    &name,
-				Version: version,
-			},
-		}
-		newUID, err := c.CloneClusterProfile(d.Id(), cloneEntity)
-		if err != nil {
-			return diag.FromErr(err)
+		// Check if this version already exists. If so, adopt it and update in place
+		// rather than cloning (which would fail with a duplicate-name error).
+		existingUID, err := c.GetClusterProfileUID(name, version)
+		if err == nil && existingUID != "" {
+			log.Printf("Version %s already exists (UID %s), updating in place", version, existingUID)
+			d.SetId(existingUID)
+		} else {
+			// Version doesn't exist yet; clone to create it
+			cloneEntity := &models.V1ClusterProfileCloneEntity{
+				Metadata: &models.V1ClusterProfileCloneMetaInputEntity{
+					Name:    &name,
+					Version: version,
+				},
+			}
+			newUID, err := c.CloneClusterProfile(d.Id(), cloneEntity)
+			if err != nil {
+				return diag.FromErr(err)
+			}
+			d.SetId(newUID)
 		}
 
-		// Update state with new version's UID
-		d.SetId(newUID)
-
-		// If other fields also changed (packs, values, etc.), apply them to the new version
+		// If other fields also changed (packs, values, etc.), apply them to the version
 		if d.HasChanges("name") || d.HasChanges("tags") || d.HasChanges("pack") || d.HasChanges("description") {
-			cp, err := c.GetClusterProfile(newUID)
+			cp, err := c.GetClusterProfile(d.Id())
 			if err != nil {
 				return diag.FromErr(err)
 			}
@@ -270,9 +277,10 @@ func resourceClusterProfileUpdate(ctx context.Context, d *schema.ResourceData, m
 			if err := c.PatchClusterProfile(cluster, metadata); err != nil {
 				return diag.FromErr(err)
 			}
+			if err := c.PublishClusterProfile(d.Id()); err != nil {
+				return diag.FromErr(err)
+			}
 		}
-
-		// Note: clone endpoint publishes automatically, no separate publish needed.
 
 		resourceClusterProfileRead(ctx, d, m)
 		return diags

--- a/spectrocloud/resource_cluster_profile.go
+++ b/spectrocloud/resource_cluster_profile.go
@@ -46,8 +46,10 @@ func resourceClusterProfile() *schema.Resource {
 				Optional: true,
 				Default:  "1.0.0", // default as in UI
 				Description: "Version of the cluster profile. Defaults to '1.0.0'. " +
-					"Changing this value on an existing profile creates a new version " +
-					"in Palette via clone. The previous version is preserved.",
+					"When the `clone-on-version-change` feature preview flag is enabled, " +
+					"changing this value on an existing profile creates a new version " +
+					"in Palette via clone. The previous version is preserved. " +
+					"Without the flag, changing this value updates the version in place.",
 			},
 			"context": {
 				Type:         schema.TypeString,
@@ -109,6 +111,9 @@ func resourceClusterProfileCreate(ctx context.Context, d *schema.ResourceData, m
 	uid, err := c.CreateClusterProfile(clusterProfile)
 	adopted := false
 	if err != nil {
+		if !isFeaturePreviewEnabled("clone-on-version-change") {
+			return diag.FromErr(err)
+		}
 		// If the profile already exists, adopt it instead of failing.
 		// This supports multi-environment patterns where each composition
 		// layer declares the same profile module.
@@ -245,7 +250,7 @@ func resourceClusterProfileUpdate(ctx context.Context, d *schema.ResourceData, m
 	// If version changed, clone the existing profile to create a new version.
 	// This matches Palette's recommended workflow: create a new version rather than
 	// modifying a deployed version in place. The old version persists in Palette untouched.
-	if d.HasChange("version") {
+	if d.HasChange("version") && isFeaturePreviewEnabled("clone-on-version-change") {
 		name := d.Get("name").(string)
 		version := d.Get("version").(string)
 		log.Printf("Version changed, cloning profile %s to create version %s", d.Id(), version)
@@ -300,7 +305,7 @@ func resourceClusterProfileUpdate(ctx context.Context, d *schema.ResourceData, m
 		return diags
 	}
 
-	if d.HasChanges("name") || d.HasChanges("tags") || d.HasChanges("pack") || d.HasChanges("description") {
+	if d.HasChanges("name") || d.HasChanges("tags") || d.HasChanges("pack") || d.HasChanges("description") || d.HasChanges("version") {
 		log.Printf("Updating packs")
 		cp, err := c.GetClusterProfile(d.Id())
 		if err != nil {

--- a/spectrocloud/resource_cluster_profile.go
+++ b/spectrocloud/resource_cluster_profile.go
@@ -107,13 +107,27 @@ func resourceClusterProfileCreate(ctx context.Context, d *schema.ResourceData, m
 	}
 
 	uid, err := c.CreateClusterProfile(clusterProfile)
+	adopted := false
 	if err != nil {
-		return diag.FromErr(err)
+		// If the profile already exists, adopt it instead of failing.
+		// This supports multi-environment patterns where each composition
+		// layer declares the same profile module.
+		name := d.Get("name").(string)
+		version := d.Get("version").(string)
+		existingUID, lookupErr := c.GetClusterProfileUID(name, version)
+		if lookupErr != nil || existingUID == "" {
+			return diag.FromErr(err) // return the original create error
+		}
+		log.Printf("Profile %s version %s already exists (UID %s), adopting", name, version, existingUID)
+		uid = existingUID
+		adopted = true
 	}
 
-	// And then publish
-	if err = c.PublishClusterProfile(uid); err != nil {
-		return diag.FromErr(err)
+	// Publish only for newly created profiles — adopted profiles are already published.
+	if !adopted {
+		if err = c.PublishClusterProfile(uid); err != nil {
+			return diag.FromErr(err)
+		}
 	}
 	d.SetId(uid)
 	resourceClusterProfileRead(ctx, d, m)

--- a/spectrocloud/resource_cluster_profile_test.go
+++ b/spectrocloud/resource_cluster_profile_test.go
@@ -876,3 +876,18 @@ func TestResourceClusterProfileUpdateVersionAdoptWithFieldChanges(t *testing.T) 
 	assert.Empty(t, diags)
 	assert.Equal(t, "existing-profile-uid-1", d.Id())
 }
+
+// TestResourceClusterProfileCreateAdoptExisting tests that when Create fails
+// because the profile already exists, the function adopts the existing UID
+// instead of returning an error.
+func TestResourceClusterProfileCreateAdoptExisting(t *testing.T) {
+	d := prepareBaseClusterProfileTestData()
+	// Use name+version matching mock metadata → adopt path
+	_ = d.Set("name", "test-cluster-profile-1")
+	_ = d.Set("version", "1.0.0")
+	_ = d.Set("type", "add-on")
+	var ctx context.Context
+	diags := resourceClusterProfileCreate(ctx, d, unitTestMockAPINegativeClient)
+	assert.Empty(t, diags)
+	assert.Equal(t, "existing-profile-uid-1", d.Id())
+}

--- a/spectrocloud/resource_cluster_profile_test.go
+++ b/spectrocloud/resource_cluster_profile_test.go
@@ -817,6 +817,10 @@ func prepareClusterProfileWithVersionChange(oldVersion, newVersion, profileName 
 // TestResourceClusterProfileUpdateVersionClone tests that when the version
 // changes and the new version does NOT already exist, the clone path is taken.
 func TestResourceClusterProfileUpdateVersionClone(t *testing.T) {
+	orig := ProviderFeaturePreview
+	defer func() { ProviderFeaturePreview = orig }()
+	ProviderFeaturePreview = map[string]bool{"clone-on-version-change": true}
+
 	// Use a profile name that doesn't match any entry in the mock metadata
 	// so GetClusterProfileUID returns an error → triggers clone path.
 	d := prepareClusterProfileWithVersionChange("1.0.0", "2.0.0", "nonexistent-profile", nil)
@@ -832,6 +836,10 @@ func TestResourceClusterProfileUpdateVersionClone(t *testing.T) {
 // changes and the new version already exists, the existing version is adopted
 // instead of cloning.
 func TestResourceClusterProfileUpdateVersionAdopt(t *testing.T) {
+	orig := ProviderFeaturePreview
+	defer func() { ProviderFeaturePreview = orig }()
+	ProviderFeaturePreview = map[string]bool{"clone-on-version-change": true}
+
 	// Use name "test-cluster-profile-1" and new version "1.0.0" which matches
 	// the mock metadata response (stable UID "existing-profile-uid-1").
 	d := prepareClusterProfileWithVersionChange("0.9.0", "1.0.0", "test-cluster-profile-1", nil)
@@ -846,6 +854,10 @@ func TestResourceClusterProfileUpdateVersionAdopt(t *testing.T) {
 // TestResourceClusterProfileUpdateVersionCloneWithFieldChanges tests the clone
 // path when other fields (description) also changed alongside the version.
 func TestResourceClusterProfileUpdateVersionCloneWithFieldChanges(t *testing.T) {
+	orig := ProviderFeaturePreview
+	defer func() { ProviderFeaturePreview = orig }()
+	ProviderFeaturePreview = map[string]bool{"clone-on-version-change": true}
+
 	extra := map[string]*terraform.ResourceAttrDiff{
 		"description": {
 			Old: "old description",
@@ -863,6 +875,10 @@ func TestResourceClusterProfileUpdateVersionCloneWithFieldChanges(t *testing.T) 
 // TestResourceClusterProfileUpdateVersionAdoptWithFieldChanges tests the adopt
 // path when other fields also changed — should adopt and then update/patch/publish.
 func TestResourceClusterProfileUpdateVersionAdoptWithFieldChanges(t *testing.T) {
+	orig := ProviderFeaturePreview
+	defer func() { ProviderFeaturePreview = orig }()
+	ProviderFeaturePreview = map[string]bool{"clone-on-version-change": true}
+
 	extra := map[string]*terraform.ResourceAttrDiff{
 		"description": {
 			Old: "old description",
@@ -881,6 +897,10 @@ func TestResourceClusterProfileUpdateVersionAdoptWithFieldChanges(t *testing.T) 
 // because the profile already exists, the function adopts the existing UID
 // instead of returning an error.
 func TestResourceClusterProfileCreateAdoptExisting(t *testing.T) {
+	orig := ProviderFeaturePreview
+	defer func() { ProviderFeaturePreview = orig }()
+	ProviderFeaturePreview = map[string]bool{"clone-on-version-change": true}
+
 	d := prepareBaseClusterProfileTestData()
 	// Use name+version matching mock metadata → adopt path
 	_ = d.Set("name", "test-cluster-profile-1")
@@ -890,4 +910,41 @@ func TestResourceClusterProfileCreateAdoptExisting(t *testing.T) {
 	diags := resourceClusterProfileCreate(ctx, d, unitTestMockAPINegativeClient)
 	assert.Empty(t, diags)
 	assert.Equal(t, "existing-profile-uid-1", d.Id())
+}
+
+// TestResourceClusterProfileUpdateVersionNoFlag tests that when the feature
+// preview flag is OFF, version changes fall through to the update-in-place
+// path (old behavior) instead of cloning.
+func TestResourceClusterProfileUpdateVersionNoFlag(t *testing.T) {
+	orig := ProviderFeaturePreview
+	defer func() { ProviderFeaturePreview = orig }()
+	ProviderFeaturePreview = map[string]bool{}
+
+	d := prepareClusterProfileWithVersionChange("1.0.0", "2.0.0", "nonexistent-profile", nil)
+	var ctx context.Context
+
+	diags := resourceClusterProfileUpdate(ctx, d, unitTestMockAPIClient)
+	assert.Empty(t, diags)
+	// Without the flag, version change should NOT clone — it should
+	// fall through to the update-in-place path and keep the original ID.
+	assert.Equal(t, "cluster-profile-1", d.Id())
+}
+
+// TestResourceClusterProfileCreateNoAdoptWithoutFlag tests that when the
+// feature preview flag is OFF, a create failure returns the error instead
+// of trying to adopt an existing profile.
+func TestResourceClusterProfileCreateNoAdoptWithoutFlag(t *testing.T) {
+	orig := ProviderFeaturePreview
+	defer func() { ProviderFeaturePreview = orig }()
+	ProviderFeaturePreview = map[string]bool{}
+
+	d := prepareBaseClusterProfileTestData()
+	_ = d.Set("name", "test-cluster-profile-1")
+	_ = d.Set("version", "1.0.0")
+	_ = d.Set("type", "add-on")
+	var ctx context.Context
+	// On the negative client, create fails. Without the flag, it should
+	// return the error instead of trying to adopt.
+	diags := resourceClusterProfileCreate(ctx, d, unitTestMockAPINegativeClient)
+	assert.NotEmpty(t, diags)
 }

--- a/spectrocloud/resource_cluster_profile_test.go
+++ b/spectrocloud/resource_cluster_profile_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/spectrocloud/palette-sdk-go/api/models"
 	"github.com/spectrocloud/palette-sdk-go/client"
 	"github.com/spectrocloud/terraform-provider-spectrocloud/spectrocloud/schemas"
@@ -774,4 +775,104 @@ func TestResolvePackUID(t *testing.T) {
 			}
 		})
 	}
+}
+
+// prepareClusterProfileWithVersionChange creates ResourceData with a state+diff
+// so that HasChange("version") returns true. Additional field changes can be
+// injected via the extraDiffAttrs map.
+func prepareClusterProfileWithVersionChange(oldVersion, newVersion, profileName string, extraDiffAttrs map[string]*terraform.ResourceAttrDiff) *schema.ResourceData {
+	state := &terraform.InstanceState{
+		ID: "cluster-profile-1",
+		Attributes: map[string]string{
+			"name":               profileName,
+			"version":            oldVersion,
+			"context":            "project",
+			"description":        "old description",
+			"cloud":              "all",
+			"type":               "add-on",
+			"tags.#":             "0",
+			"pack.#":             "0",
+			"profile_variables.#": "0",
+		},
+	}
+
+	diffAttrs := map[string]*terraform.ResourceAttrDiff{
+		"version": {
+			Old: oldVersion,
+			New: newVersion,
+		},
+	}
+	for k, v := range extraDiffAttrs {
+		diffAttrs[k] = v
+	}
+
+	diff := &terraform.InstanceDiff{
+		Attributes: diffAttrs,
+	}
+
+	d, _ := schema.InternalMap(resourceClusterProfile().Schema).Data(state, diff)
+	return d
+}
+
+// TestResourceClusterProfileUpdateVersionClone tests that when the version
+// changes and the new version does NOT already exist, the clone path is taken.
+func TestResourceClusterProfileUpdateVersionClone(t *testing.T) {
+	// Use a profile name that doesn't match any entry in the mock metadata
+	// so GetClusterProfileUID returns an error → triggers clone path.
+	d := prepareClusterProfileWithVersionChange("1.0.0", "2.0.0", "nonexistent-profile", nil)
+	var ctx context.Context
+
+	diags := resourceClusterProfileUpdate(ctx, d, unitTestMockAPIClient)
+	assert.Empty(t, diags)
+	// After clone, the ID should be the cloned UID returned by the mock server.
+	assert.Equal(t, "cloned-profile-uid", d.Id())
+}
+
+// TestResourceClusterProfileUpdateVersionAdopt tests that when the version
+// changes and the new version already exists, the existing version is adopted
+// instead of cloning.
+func TestResourceClusterProfileUpdateVersionAdopt(t *testing.T) {
+	// Use name "test-cluster-profile-1" and new version "1.0.0" which matches
+	// the mock metadata response (stable UID "existing-profile-uid-1").
+	d := prepareClusterProfileWithVersionChange("0.9.0", "1.0.0", "test-cluster-profile-1", nil)
+	var ctx context.Context
+
+	diags := resourceClusterProfileUpdate(ctx, d, unitTestMockAPIClient)
+	assert.Empty(t, diags)
+	// Should have adopted the existing UID, not cloned.
+	assert.Equal(t, "existing-profile-uid-1", d.Id())
+}
+
+// TestResourceClusterProfileUpdateVersionCloneWithFieldChanges tests the clone
+// path when other fields (description) also changed alongside the version.
+func TestResourceClusterProfileUpdateVersionCloneWithFieldChanges(t *testing.T) {
+	extra := map[string]*terraform.ResourceAttrDiff{
+		"description": {
+			Old: "old description",
+			New: "new description",
+		},
+	}
+	d := prepareClusterProfileWithVersionChange("1.0.0", "2.0.0", "nonexistent-profile", extra)
+	var ctx context.Context
+
+	diags := resourceClusterProfileUpdate(ctx, d, unitTestMockAPIClient)
+	assert.Empty(t, diags)
+	assert.Equal(t, "cloned-profile-uid", d.Id())
+}
+
+// TestResourceClusterProfileUpdateVersionAdoptWithFieldChanges tests the adopt
+// path when other fields also changed — should adopt and then update/patch/publish.
+func TestResourceClusterProfileUpdateVersionAdoptWithFieldChanges(t *testing.T) {
+	extra := map[string]*terraform.ResourceAttrDiff{
+		"description": {
+			Old: "old description",
+			New: "new description",
+		},
+	}
+	d := prepareClusterProfileWithVersionChange("0.9.0", "1.0.0", "test-cluster-profile-1", extra)
+	var ctx context.Context
+
+	diags := resourceClusterProfileUpdate(ctx, d, unitTestMockAPIClient)
+	assert.Empty(t, diags)
+	assert.Equal(t, "existing-profile-uid-1", d.Id())
 }

--- a/tests/mockApiServer/routes/mockClusterProfile.go
+++ b/tests/mockApiServer/routes/mockClusterProfile.go
@@ -12,7 +12,7 @@ func getClusterProfilesMetadataResponse() *models.V1ClusterProfilesMetadata {
 			{
 				Metadata: &models.V1ObjectEntity{
 					Name: "test-cluster-profile-1",
-					UID:  generateRandomStringUID(),
+					UID:  "existing-profile-uid-1",
 				},
 				Spec: &models.V1ClusterProfileMetadataSpec{
 					CloudType: "aws",
@@ -142,6 +142,30 @@ func ClusterProfileRoutes() []Route {
 			Response: ResponseData{
 				StatusCode: 201,
 				Payload:    map[string]string{"UID": "cluster-profile-1"},
+			},
+		},
+		{
+			Method: "POST",
+			Path:   "/v1/clusterprofiles/{uid}/clone",
+			Response: ResponseData{
+				StatusCode: 201,
+				Payload:    map[string]string{"UID": "cloned-profile-uid"},
+			},
+		},
+		{
+			Method: "PUT",
+			Path:   "/v1/clusterprofiles/{uid}",
+			Response: ResponseData{
+				StatusCode: 204,
+				Payload:    nil,
+			},
+		},
+		{
+			Method: "PATCH",
+			Path:   "/v1/clusterprofiles/{uid}/metadata",
+			Response: ResponseData{
+				StatusCode: 204,
+				Payload:    nil,
 			},
 		},
 		{

--- a/tests/mockApiServer/routes/mockClusterProfile.go
+++ b/tests/mockApiServer/routes/mockClusterProfile.go
@@ -206,11 +206,27 @@ func ClusterProfileRoutes() []Route {
 func ClusterProfileNegativeRoutes() []Route {
 	return []Route{
 		{
+			Method: "POST",
+			Path:   "/v1/clusterprofiles",
+			Response: ResponseData{
+				StatusCode: http.StatusConflict,
+				Payload:    getError("ClusterProfileAlreadyExists", "Cluster Profile already exists"),
+			},
+		},
+		{
 			Method: "GET",
 			Path:   "/v1/dashboard/clusterprofiles/metadata",
 			Response: ResponseData{
 				StatusCode: 200,
-				Payload:    &models.V1ClusterProfilesMetadata{},
+				Payload:    getClusterProfilesMetadataResponse(),
+			},
+		},
+		{
+			Method: "PATCH",
+			Path:   "/v1/clusterprofiles/{uid}/publish",
+			Response: ResponseData{
+				StatusCode: 204,
+				Payload:    nil,
 			},
 		},
 		{


### PR DESCRIPTION
When the `version` attribute changes on an existing `spectrocloud_cluster_profile` resource, the provider now calls `POST /v1/clusterprofiles/{uid}/clone` instead of `PUT /v1/clusterprofiles/{uid}`. This creates a new version in Palette alongside the old one, rather than silently mutating the existing version in place.

Additionally, `resourceClusterProfileCreate` now handles the case where a profile with the same (name, version) already exists by adopting its UID into state rather than failing, making the Create operation idempotent.

## Problem

Today, changing `version` on a `spectrocloud_cluster_profile` resource calls `UpdateClusterProfile`, which renames the version string on the existing profile object. The previous version is destroyed; it no longer appears in Palette's version dropdown. The provider's own field description acknowledges this:

> **Important**: Modifying this value will only update the version number of the existing cluster profile. It will NOT create a new version in Palette.

This directly contradicts how Palette is designed to work. Palette's UI, API docs, and best practice guidance all recommend creating new versions rather than modifying deployed versions in place:

- The **Palette UI** "Create new version" feature calls `POST /v1/clusterprofiles/{uid}/clone` (verified via browser network inspector)
- The **Palette docs** explicitly say: *"We do not recommend updating a currently deployed cluster profile version to push out changes"* and recommend creating a new version instead
- **Clusters reference profiles by UID**, mutating a version in place changes what a cluster is running without the operator explicitly upgrading

The current behavior makes it impossible to use the Terraform provider for Palette's recommended versioning workflow. Users who bump `version` expecting a new version alongside the old one instead get silent data loss.

### Create is not idempotent either

The current `resourceClusterProfileCreate` fails with `ClusterProfileAlreadyExists` if a profile with the same name and version already exists in the project scope. This breaks idempotency, if Terraform state is lost or if multiple root modules in the same project declare the same profile, the second `apply` fails rather than converging.

### Current Behavior

| Scenario | Behavior | Idempotent? |
|----------|----------|-------------|
| Create (new profile) | `POST /v1/clusterprofiles` -> 201 | Yes |
| Create (profile exists) | **Fails** with `ClusterProfileAlreadyExists` | **No** |
| Version change | `PUT /v1/clusterprofiles/{uid}` -- mutates in place, old version destroyed | Yes, but destructive |
| Non-version changes | `PUT /v1/clusterprofiles/{uid}` | Yes |
| Delete | `DELETE /v1/clusterprofiles/{uid}` -- no `inUseClusters` check | Yes |

### With this PR

| Scenario | Behavior | Idempotent? |
|----------|----------|-------------|
| Create (new profile) | `POST /v1/clusterprofiles` -> 201 | Yes |
| Create (profile exists) | Lookup by (name, version) -> adopt existing UID, skip publish | **Yes** |
| Version change (new) | `POST /v1/clusterprofiles/{uid}/clone` -- new version alongside old | Yes, non-destructive |
| Version change (exists) | Lookup by (name, version) -> adopt existing UID, update in place | Yes |
| Non-version changes | `PUT /v1/clusterprofiles/{uid}` | Yes (unchanged) |
| Delete | `DELETE /v1/clusterprofiles/{uid}` -- no `inUseClusters` check | Yes (unchanged) |

---

### Create with adopt

When `CreateClusterProfile` fails:
1. The provider looks up the existing profile by (name, version) via `GetClusterProfileUID`
2. **If found:** adopts that UID into Terraform state, skips publish (already published)
3. **If not found:** returns the original create error (the failure was not a name collision)

### Update with version change

When a version change is detected:
1. The provider first checks whether a profile with the same (name, version) already exists via `GetClusterProfileUID`
2. **If it exists:** the provider adopts that version's UID into Terraform state and updates it in place (avoids a duplicate-name clone error, e.g. on re-apply after a partial failure)
3. **If it doesn't exist:** the clone endpoint creates a new profile object with a new UID; Terraform state is updated to track it
4. The old version persists in Palette untouched; clusters referencing it are unaffected
5. If other fields also changed (packs, values, description), they are applied to the new/adopted version, followed by an explicit publish

Note: newly created versions are not immutable. They can be updated further via the API, UI, or subsequent Terraform applies, just like any other version.

---

## Design Notes

### Alignment with Palette UI behavior

The Palette UI never mutates a published version. The workflow is: create -> edit draft -> publish (immutable) -> clone to create next version. The `/clone` endpoint is what the UI calls when a user clicks "Create new version." This PR makes the Terraform provider use the same endpoint, aligning the Terraform workflow with the UI workflow.

The UI also doesn't have a shared-ownership problem because there's one source of truth (the UI itself). There's no concept of two separate state files claiming to own the same profile object.

### Idempotency considerations

Terraform providers should be idempotent. Running `apply` twice with the same config should converge to the same state. The current upstream behavior is not idempotent in two ways:

1. **Create:** fails on second apply if profile already exists (e.g. after state loss)
2. **Update with version change:** mutates in place, so the second apply sees a different profile than expected

This PR fixes both. The adopt-on-create pattern is intentionally broad, it catches any create failure and falls back to a name+version lookup, returning the original error if the lookup also fails. This means it handles `ClusterProfileAlreadyExists` without string-matching on the error code, which is more resilient to API error message changes.

### Shared ownership tradeoff

The adopt pattern means multiple Terraform root modules in the same project scope can adopt the same profile UID. This is a conscious tradeoff:

- **Pro:** Enables multi-workspace patterns (e.g. separate root modules for dev/stage/prod in the same Palette project)
- **Con:** `terraform destroy` from any root module deletes the profile for all of them. The other root modules' next `plan` will detect drift (Read returns 404 → resource removed from state → plan to recreate).
- **Con:** No "ownership" -- any adopter can mutate the profile

For production use, the Palette team may want to consider:
- A `lifecycle { prevent_destroy = true }` recommendation in docs for shared profiles
- Using `data "spectrocloud_cluster_profile"` for read-only consumers instead of `resource` blocks
- Separate Palette projects per environment for full isolation

### `inUseClusters` and delete safety

The `V1ClusterProfileStatus` exposes `inUseClusters` (list of clusters referencing the profile) and `inUseClusterTemplates`. The SDK's `DeleteClusterProfile` does not check these before calling `DELETE`. It may be worth considering a pre-delete check in the provider that warns or fails if the profile version is attached to clusters. Similar to how the Palette UI surfaces this information before allowing deletion.

---

**Depends on:** [spectrocloud/palette-sdk-go#205](https://github.com/spectrocloud/palette-sdk-go/pull/205) `CloneClusterProfile` and `GetClusterProfileUID` client methods