### PR TITLE
immutable-clusterprofiles: version bumps as SDK v2 replacements (follow-up to #856)

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -173,7 +173,11 @@ For questions or issues with the provider, open up an issue in the provider GitH
 ### Optional
 
 - `api_key` (String, Sensitive) The Spectro Cloud API key. Can also be set with the `SPECTROCLOUD_APIKEY` environment variable.
-- `feature_preview` (Map of Boolean) A map of feature preview flags. Supported flags: `clone-on-version-change`.
+- `feature_preview` (Map of Boolean) A map of feature preview flags. Supported flags: `immutable-clusterprofiles`. 
+
+The `immutable-clusterprofiles` flag enables the standard Terraform Plugin SDK v2 immutable-versioned-resource pattern for `spectrocloud_cluster_profile`. When set, the resource's `version` field becomes `ForceNew` (changes trigger a Terraform replacement instead of an in-place update), the new `skip_destroy` schema field is honored, and the Create function clones from any existing version of the lineage to produce the new immutable version. The Terraform resource id is set once at Create time and never mutates mid-update, so it respects the SDK v2 contract that a resource's primary id is stable across in-place updates. 
+
+Without the flag, `spectrocloud_cluster_profile` uses its legacy in-place mutation behavior (PUT-based updates that overwrite the previous version). The flag is purely opt-in; existing user configurations are unaffected.
 - `host` (String) The Spectro Cloud API host url. Can also be set with the `SPECTROCLOUD_HOST` environment variable. Defaults to https://api.spectrocloud.com
 - `ignore_insecure_tls_error` (Boolean) Ignore insecure TLS errors for Spectro Cloud API endpoints. ⚠️ WARNING: Setting this to true disables SSL certificate verification and makes connections vulnerable to man-in-the-middle attacks. Only use this in development/testing environments or when connecting to self-signed certificates in trusted networks. Defaults to false.
 - `project_name` (String) The Palette project the provider will target. If no value is provided, the `Default` Palette project is used. The default value is `Default`.

--- a/docs/resources/cluster_profile.md
+++ b/docs/resources/cluster_profile.md
@@ -389,6 +389,72 @@ resource "spectrocloud_cluster_profile" "profile" {
 ```
 
 
+## Immutable versioning
+
+This resource supports the standard Terraform Plugin SDK v2 pattern for immutable-versioned upstream resources, the same shape used by [`aws_lambda_layer_version`](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_layer_version), `aws_db_snapshot`, `azurerm_shared_image_version`, `google_compute_instance_template`, and similar resources. When the `immutable-clusterprofiles` feature_preview flag is enabled on the provider:
+
+- Changes to `version` trigger a **Terraform resource replacement** (`ForceNew`) instead of an in-place update
+- The new version is created by calling `POST /v1/clusterprofiles/{uid}/clone` against any existing version of the lineage, then overwriting the clone with the user's HCL content
+- The previous version is preserved in Palette because `Delete` honors `skip_destroy = true`
+- `create_before_destroy = true` ensures the new version exists before Terraform removes the old one from state
+
+All three knobs (feature flag, `skip_destroy`, and `lifecycle`) are required together. Miss any one and the plan will either error out (missing `skip_destroy`) or the old version will be destroyed in Palette (missing `create_before_destroy`). This matches the standard SDK v2 pattern exactly.
+
+### Enabling immutable versioning
+
+```terraform
+provider "spectrocloud" {
+  host = "api.spectrocloud.com"
+
+  feature_preview = {
+    "immutable-clusterprofiles" = true
+  }
+}
+
+resource "spectrocloud_cluster_profile" "addon" {
+  name    = "example-addon"
+  version = var.profile_version  # bump this via git tags / CI
+  type    = "add-on"
+  context = "project"
+
+  pack {
+    name = "example-manifest"
+    type = "manifest"
+
+    manifest {
+      name    = "example"
+      content = file("${path.module}/manifests/example.yaml")
+    }
+  }
+
+  skip_destroy = true  # preserve old versions in Palette
+
+  lifecycle {
+    create_before_destroy = true  # create new version before destroying old
+  }
+}
+```
+
+Bumping `var.profile_version` from `1.0.0` to `1.1.0` and running `terraform apply`:
+
+1. Terraform plans a replacement (ForceNew on `version`)
+2. The new resource's `Create` runs first (because of `create_before_destroy`), calls the clone endpoint, applies the user's pack content
+3. The old resource is "destroyed" from Terraform's perspective, but `skip_destroy` makes the Delete call a no-op; the `1.0.0` version stays in Palette untouched
+4. State advances to `1.1.0`; Palette has both versions with distinct UIDs; `terraform output` returns the correct current uid without needing `terraform apply -refresh-only`
+
+### Why all three knobs are required
+
+| Knob | Why it's required | What happens if you skip it |
+|------|------------------|----------------------------|
+| `feature_preview.immutable-clusterprofiles = true` | Opts the resource into replacement-based versioning. Without it, the resource preserves its legacy in-place `PUT` behavior for backward compatibility. | Legacy in-place mutation; previous version is destroyed. |
+| `skip_destroy = true` | Prevents `Delete` from calling the Palette DELETE API on the replaced resource, so the old version is preserved in Palette even though Terraform removes it from state. | Plan fails with an error at `terraform plan` time (the provider catches this and tells you exactly what to add). |
+| `lifecycle { create_before_destroy = true }` | Ensures Terraform creates the new version before marking the old one for destruction. Without it, Terraform destroys first and creates second, causing a brief window where no version exists in Terraform state. | Terraform would attempt to `Delete` the old resource before `Create`ing the new one; because `skip_destroy = true` makes Delete a no-op, the Palette version still survives, but the planned operation order is wrong and some edge cases (state corruption on failure, for example) are riskier. Terraform core parses `lifecycle` blocks before the provider runs, so the provider cannot validate this automatically; this one is on the user to remember. |
+
+### Backward compatibility
+
+The `immutable-clusterprofiles` feature flag is opt-in. Without it, `spectrocloud_cluster_profile` behaves exactly as it did before the flag was introduced; version changes go through the in-place `PUT` path. Existing HCL, state files, and CI pipelines continue to work without modification. See the resource's `version` and `skip_destroy` field docs below for further details.
+
+
 ## Import
 
 In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import)
@@ -423,16 +489,17 @@ Refer to the [Import section](/docs#import) to learn more.
 - `description` (String)
 - `pack` (Block List) For packs of type `spectro`, `helm`, and `manifest`, at least one pack must be specified. (see [below for nested schema](#nestedblock--pack))
 - `profile_variables` (Block List, Max: 1) List of variables for the cluster profile. (see [below for nested schema](#nestedblock--profile_variables))
+- `skip_destroy` (Boolean) When `true`, `terraform destroy` removes the cluster profile from Terraform state without calling the Palette delete API, leaving the underlying profile version intact in Palette. 
+
+This is the standard Terraform Plugin SDK v2 preservation pattern for immutable-versioned resources. Combined with the `immutable-clusterprofiles` feature_preview flag and `lifecycle { create_before_destroy = true }`, it lets you bump the `version` field as a normal in-HCL edit while every previous version stays preserved in Palette -- Terraform's state advances cleanly to the new version while older versions remain immutable in Palette. Defaults to `false`.
 - `tags` (Set of String) A list of tags to be applied to the cluster. Tags must be in the form of `key:value`.
 - `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
 - `type` (String) Specify the cluster profile type to use. Allowed values are `cluster`, `infra`, `add-on`, and `system`. These values map to the following User Interface (UI) labels. Use the value ' cluster ' for a **Full** cluster profile.For an Infrastructure cluster profile, use the value `infra`; for an Add-on cluster profile, use the value `add-on`.System cluster profiles can be specified using the value `system`. To learn more about cluster profiles, refer to the [Cluster Profile](https://docs.spectrocloud.com/cluster-profiles) documentation. Default value is `add-on`.
-- `version` (String) Version of the cluster profile. Defaults to '1.0.0'. When the `clone-on-version-change` feature preview flag is enabled, changing this value on an existing profile creates a new version in Palette via clone. The previous version is preserved. Without the flag, changing this value updates the version in place.
+- `version` (String) Version of the cluster profile. Defaults to '1.0.0'. 
 
-**Notes**:
+Default behavior (no feature flag set): changing this value on an existing profile updates the version in place via `PUT /v1/clusterprofiles/{uid}`, which destroys the previous version. This is the legacy behavior preserved for backward compatibility. 
 
-- Cloning creates a new UID for the profile version. Clusters reference versions by UID; cloning does not change which UID a cluster is running. Upgrades must be explicit.
-- Because cloning creates a separate object, Terraform's resource lifecycle and state handling require care: if your configuration expects in-place renaming, enable the flag only after validating the upgrade path.
-- If you prefer existing behavior, do not set the feature flag and the provider will continue to update version in place.
+When the `immutable-clusterprofiles` feature_preview flag is enabled, changing this value triggers a Terraform resource **replacement** (`ForceNew`) instead of an in-place update. This is the standard Terraform Plugin SDK v2 pattern for immutable-versioned resources. Combined with `skip_destroy = true` and `lifecycle { create_before_destroy = true }`, the new version is created by cloning from the existing Palette lineage while the previous version is preserved untouched in Palette. The Terraform resource id is set once at Create time and never mutates mid-update, so it respects the SDK v2 contract that a resource's primary id is stable across in-place updates -- outputs that reference `.id` always reflect the current version without needing `terraform apply -refresh-only`.
 
 ### Read-Only
 

--- a/spectrocloud/provider.go
+++ b/spectrocloud/provider.go
@@ -76,7 +76,23 @@ func New(_ string) func() *schema.Provider {
 						Type: schema.TypeBool,
 					},
 					Description: "A map of feature preview flags. " +
-						"Supported flags: `clone-on-version-change`.",
+						"Supported flags: `immutable-clusterprofiles`. " +
+						"\n\n" +
+						"The `immutable-clusterprofiles` flag enables the standard Terraform " +
+						"Plugin SDK v2 immutable-versioned-resource pattern for " +
+						"`spectrocloud_cluster_profile`. When set, the resource's `version` " +
+						"field becomes `ForceNew` (changes trigger a Terraform replacement " +
+						"instead of an in-place update), the new `skip_destroy` schema field " +
+						"is honored, and the Create function clones from any existing version " +
+						"of the lineage to produce the new immutable version. The Terraform " +
+						"resource id is set once at Create time and never mutates mid-update, " +
+						"so it respects the SDK v2 contract that a resource's primary id is " +
+						"stable across in-place updates. " +
+						"\n\n" +
+						"Without the flag, `spectrocloud_cluster_profile` uses its legacy " +
+						"in-place mutation behavior (PUT-based updates that overwrite the " +
+						"previous version). The flag is purely opt-in; existing user " +
+						"configurations are unaffected.",
 				},
 			},
 			ResourcesMap: map[string]*schema.Resource{

--- a/spectrocloud/provider_test.go
+++ b/spectrocloud/provider_test.go
@@ -90,10 +90,10 @@ func TestIsFeaturePreviewEnabled(t *testing.T) {
 	defer func() { ProviderFeaturePreview = orig }()
 
 	ProviderFeaturePreview = map[string]bool{}
-	assert.False(t, isFeaturePreviewEnabled("clone-on-version-change"))
+	assert.False(t, isFeaturePreviewEnabled("immutable-clusterprofiles"))
 
-	ProviderFeaturePreview = map[string]bool{"clone-on-version-change": true}
-	assert.True(t, isFeaturePreviewEnabled("clone-on-version-change"))
+	ProviderFeaturePreview = map[string]bool{"immutable-clusterprofiles": true}
+	assert.True(t, isFeaturePreviewEnabled("immutable-clusterprofiles"))
 	assert.False(t, isFeaturePreviewEnabled("nonexistent"))
 }
 

--- a/spectrocloud/resource_cluster_profile.go
+++ b/spectrocloud/resource_cluster_profile.go
@@ -25,6 +25,7 @@ func resourceClusterProfile() *schema.Resource {
 		ReadContext:   resourceClusterProfileRead,
 		UpdateContext: resourceClusterProfileUpdate,
 		DeleteContext: resourceClusterProfileDelete,
+		CustomizeDiff: resourceClusterProfileCustomizeDiff,
 		Importer: &schema.ResourceImporter{
 			StateContext: resourceClusterProfileImport,
 		},
@@ -46,18 +47,39 @@ func resourceClusterProfile() *schema.Resource {
 				Optional: true,
 				Default:  "1.0.0", // default as in UI
 				Description: "Version of the cluster profile. Defaults to '1.0.0'. " +
-					"When the `clone-on-version-change` feature preview flag is enabled, " +
-					"changing this value on an existing profile creates a new version " +
-					"in Palette via clone. The previous version is preserved. " +
-					"Without the flag, changing this value updates the version in place.\n\n" +
-					"**Notes**:\n\n" +
-					"- Cloning creates a new UID for the profile version. Clusters reference versions by UID; " +
-					"cloning does not change which UID a cluster is running. Upgrades must be explicit.\n" +
-					"- Because cloning creates a separate object, Terraform's resource lifecycle and state handling " +
-					"require care: if your configuration expects in-place renaming, enable the flag only after " +
-					"validating the upgrade path.\n" +
-					"- If you prefer existing behavior, do not set the feature flag and the provider will continue " +
-					"to update version in place.",
+					"\n\n" +
+					"Default behavior (no feature flag set): changing this value on an existing " +
+					"profile updates the version in place via `PUT /v1/clusterprofiles/{uid}`, " +
+					"which destroys the previous version. This is the legacy behavior preserved " +
+					"for backward compatibility. " +
+					"\n\n" +
+					"When the `immutable-clusterprofiles` feature_preview flag is enabled, " +
+					"changing this value triggers a Terraform resource **replacement** " +
+					"(`ForceNew`) instead of an in-place update. This is the standard Terraform " +
+					"Plugin SDK v2 pattern for immutable-versioned resources. Combined with " +
+					"`skip_destroy = true` and `lifecycle { create_before_destroy = true }`, " +
+					"the new version is created by cloning from the existing Palette lineage " +
+					"while the previous version is preserved untouched in Palette. The Terraform " +
+					"resource id is set once at Create time and never mutates mid-update, so it " +
+					"respects the SDK v2 contract that a resource's primary id is stable across " +
+					"in-place updates -- outputs that reference `.id` always reflect the current " +
+					"version without needing `terraform apply -refresh-only`.",
+			},
+			"skip_destroy": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+				Description: "When `true`, `terraform destroy` removes the cluster profile from " +
+					"Terraform state without calling the Palette delete API, leaving the " +
+					"underlying profile version intact in Palette. " +
+					"\n\n" +
+					"This is the standard Terraform Plugin SDK v2 preservation pattern for " +
+					"immutable-versioned resources. Combined with the `immutable-clusterprofiles` " +
+					"feature_preview flag and `lifecycle { create_before_destroy = true }`, it " +
+					"lets you bump the `version` field as a normal in-HCL edit while every " +
+					"previous version stays preserved in Palette -- Terraform's state advances " +
+					"cleanly to the new version while older versions remain immutable in Palette. " +
+					"Defaults to `false`.",
 			},
 			"context": {
 				Type:         schema.TypeString,
@@ -104,12 +126,170 @@ func resourceClusterProfile() *schema.Resource {
 	}
 }
 
+// resourceClusterProfileCustomizeDiff is invoked at plan time. When the
+// `immutable-clusterprofiles` feature_preview flag is enabled and the user is
+// changing the `version` field on an existing resource, mark the field as
+// `ForceNew` so Terraform plans a replacement (destroy + create) instead of an
+// in-place update.
+//
+// Marking an attribute change as `ForceNew` from `CustomizeDiff` is the standard
+// Terraform Plugin SDK v2 idiom for converting "this attribute changed" into
+// "this resource must be replaced". We do it conditionally here because
+// `spectrocloud_cluster_profile` has to preserve its legacy in-place mutation
+// behavior for existing users who don't opt into the new flag -- gating on
+// `CustomizeDiff` is the standard way to have one resource type with two
+// different lifecycles in SDK v2.
+//
+// Combined with `lifecycle { create_before_destroy = true }` and `skip_destroy = true`
+// in user HCL, the user gets one block per profile, a mutable `version` field
+// from their HCL perspective, clean `git diff` between tags, and immutable
+// preservation of old versions in Palette -- all while respecting Terraform Plugin
+// SDK v2's contract that a resource's primary id is stable across in-place
+// updates (which is why this approach has none of the stale-output or
+// "[WARN] tolerating it because it is using the legacy plugin SDK" issues that
+// come from trying to mutate `d.Id()` mid-Update).
+func resourceClusterProfileCustomizeDiff(_ context.Context, d *schema.ResourceDiff, _ interface{}) error {
+	if d.Id() == "" {
+		// New resource -- no in-place update to convert
+		return nil
+	}
+	if !isFeaturePreviewEnabled("immutable-clusterprofiles") {
+		return nil
+	}
+	if d.HasChange("version") {
+		if err := d.ForceNew("version"); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// findAnyExistingProfileVersionUID returns the UID of any existing version of
+// the given profile name in the current scope, or an empty string if none exists.
+//
+// Used by the `immutable-clusterprofiles` Create path to find a clone source:
+// when the user bumps the `version` field, Terraform plans a replacement
+// (destroy + create), and the new resource's Create function runs against an
+// existing Palette lineage. To produce the new immutable version, Create needs
+// any existing uid in that lineage to call `CloneClusterProfile` against -- the
+// exact source version doesn't matter, since clone always produces a new uid
+// that we then overwrite with the user's pack content.
+//
+// This helper exists because Palette's data model treats every profile version
+// as a separate object with its own UID -- there is no "lineage parent" object,
+// so finding a clone source is a name-lookup across the listing endpoint rather
+// than a parent-child traversal.
+func findAnyExistingProfileVersionUID(c *client.V1Client, name string) (string, error) {
+	profiles, err := c.GetClusterProfiles()
+	if err != nil {
+		return "", err
+	}
+	for _, p := range profiles {
+		if p.Metadata != nil && p.Metadata.Name == name {
+			return p.Metadata.UID, nil
+		}
+	}
+	return "", nil
+}
+
 func resourceClusterProfileCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	ProfileContext := d.Get("context").(string)
 	c := getV1ClientWithResourceContext(m, ProfileContext)
 
 	// Warning or errors can be collected in a slice type
 	var diags diag.Diagnostics
+
+	// immutable-clusterprofiles: this is the Create half of the standard Terraform
+	// Plugin SDK v2 replacement lifecycle for immutable-versioned resources. When
+	// the user bumps `version` on an existing resource, CustomizeDiff marks the
+	// field as ForceNew, Terraform plans destroy + create, and (with the user's
+	// `lifecycle { create_before_destroy = true }`) the new resource's Create runs
+	// FIRST, against an existing Palette lineage. We need to produce a new
+	// immutable version of that lineage; the way Palette models this is via a
+	// clone of any existing version object. So we look up an existing version uid
+	// for the lineage by name, call CloneClusterProfile against it to get the new
+	// version's uid, then apply the user's HCL content to the cloned object via
+	// the same UpdateClusterProfile + PatchClusterProfile + PublishClusterProfile
+	// chain that the in-place Update path uses for non-version field changes.
+	//
+	// The Terraform resource id is set once at Create time (via d.SetId) and never
+	// mutates again, which is the SDK v2 contract -- and it's what makes outputs
+	// against `.id` correct in the post-apply state without needing
+	// `terraform apply -refresh-only`.
+	if isFeaturePreviewEnabled("immutable-clusterprofiles") {
+		name := d.Get("name").(string)
+		version := d.Get("version").(string)
+
+		// Check if the exact (name, version) already exists -- if so, adopt it.
+		// This handles re-applies, multi-workspace patterns where two state files
+		// declare the same profile, and the case where the user manually created
+		// the version via the Palette UI before applying. Adopting an existing
+		// uid into Terraform state is the standard SDK v2 pattern for handling
+		// "create against an existing object".
+		existingExactUID, lookupErr := c.GetClusterProfileUID(name, version)
+		if lookupErr == nil && existingExactUID != "" {
+			log.Printf("immutable-clusterprofiles: profile %s version %s already exists (UID %s), adopting (SDK v2 adopt-on-create pattern)", name, version, existingExactUID)
+			d.SetId(existingExactUID)
+			resourceClusterProfileRead(ctx, d, m)
+			return diags
+		}
+
+		// Look for ANY existing version of this profile lineage to clone from.
+		// We don't care which version we clone from -- clone always produces a new
+		// uid that we then overwrite with the user's HCL content via the standard
+		// update chain below.
+		sourceUID, err := findAnyExistingProfileVersionUID(c, name)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+		if sourceUID != "" {
+			log.Printf("immutable-clusterprofiles: cloning profile %s to create version %s from existing lineage source UID %s (SDK v2 ForceNew replacement Create path)", name, version, sourceUID)
+			cloneEntity := &models.V1ClusterProfileCloneEntity{
+				Metadata: &models.V1ClusterProfileCloneMetaInputEntity{
+					Name:    &name,
+					Version: version,
+				},
+			}
+			newUID, err := c.CloneClusterProfile(sourceUID, cloneEntity)
+			if err != nil {
+				return diag.FromErr(err)
+			}
+			d.SetId(newUID)
+
+			// Apply the user's pack/tags/description to the cloned version. The
+			// Palette clone API copies content from the source version, not from
+			// the user's HCL -- we have to overwrite it with the desired content
+			// using the standard Update + Patch + Publish chain.
+			cp, err := c.GetClusterProfile(newUID)
+			if err != nil {
+				return diag.FromErr(err)
+			}
+			cluster, err := toClusterProfileUpdateWithResolution(d, cp, c)
+			if err != nil {
+				return diag.FromErr(err)
+			}
+			metadata, err := toClusterProfilePatch(d)
+			if err != nil {
+				return diag.FromErr(err)
+			}
+			if err := c.UpdateClusterProfile(cluster); err != nil {
+				return diag.FromErr(err)
+			}
+			if err := c.PatchClusterProfile(cluster, metadata); err != nil {
+				return diag.FromErr(err)
+			}
+			if err := c.PublishClusterProfile(newUID); err != nil {
+				return diag.FromErr(err)
+			}
+
+			resourceClusterProfileRead(ctx, d, m)
+			return diags
+		}
+		// No prior version of this lineage exists -- fall through to the regular
+		// Create path below to create the very first version. This is the
+		// "first version of a brand new profile" case.
+		log.Printf("immutable-clusterprofiles: no prior version of %s exists, falling through to fresh Create", name)
+	}
 
 	clusterProfile, err := toClusterProfileCreateWithResolution(d, c)
 	if err != nil {
@@ -119,24 +299,26 @@ func resourceClusterProfileCreate(ctx context.Context, d *schema.ResourceData, m
 	uid, err := c.CreateClusterProfile(clusterProfile)
 	adopted := false
 	if err != nil {
-		if !isFeaturePreviewEnabled("clone-on-version-change") {
+		if !isFeaturePreviewEnabled("immutable-clusterprofiles") {
 			return diag.FromErr(err)
 		}
-		// If the profile already exists, adopt it instead of failing.
-		// This supports multi-environment patterns where each composition
-		// layer declares the same profile module.
+		// SDK v2 adopt-on-create pattern: if the profile already exists in Palette
+		// (e.g. another root module created it, or it was created via the UI),
+		// adopt the existing uid into Terraform state instead of failing. This
+		// supports multi-environment patterns where multiple root modules declare
+		// the same profile.
 		name := d.Get("name").(string)
 		version := d.Get("version").(string)
 		existingUID, lookupErr := c.GetClusterProfileUID(name, version)
 		if lookupErr != nil || existingUID == "" {
 			return diag.FromErr(err) // return the original create error
 		}
-		log.Printf("Profile %s version %s already exists (UID %s), adopting", name, version, existingUID)
+		log.Printf("immutable-clusterprofiles: profile %s version %s already exists (UID %s), adopting (SDK v2 adopt-on-create pattern)", name, version, existingUID)
 		uid = existingUID
 		adopted = true
 	}
 
-	// Publish only for newly created profiles — adopted profiles are already published.
+	// Publish only for newly created profiles -- adopted profiles are already published.
 	if !adopted {
 		if err = c.PublishClusterProfile(uid); err != nil {
 			return diag.FromErr(err)
@@ -255,64 +437,14 @@ func resourceClusterProfileUpdate(ctx context.Context, d *schema.ResourceData, m
 		}
 	}
 
-	// If version changed, clone the existing profile to create a new version.
-	// This matches Palette's recommended workflow: create a new version rather than
-	// modifying a deployed version in place. The old version persists in Palette untouched.
-	if d.HasChange("version") && isFeaturePreviewEnabled("clone-on-version-change") {
-		name := d.Get("name").(string)
-		version := d.Get("version").(string)
-		log.Printf("Version changed, cloning profile %s to create version %s", d.Id(), version)
-
-		// Check if this version already exists. If so, adopt it and update in place
-		// rather than cloning (which would fail with a duplicate-name error).
-		existingUID, err := c.GetClusterProfileUID(name, version)
-		if err == nil && existingUID != "" {
-			log.Printf("Version %s already exists (UID %s), updating in place", version, existingUID)
-			d.SetId(existingUID)
-		} else {
-			// Version doesn't exist yet; clone to create it
-			cloneEntity := &models.V1ClusterProfileCloneEntity{
-				Metadata: &models.V1ClusterProfileCloneMetaInputEntity{
-					Name:    &name,
-					Version: version,
-				},
-			}
-			newUID, err := c.CloneClusterProfile(d.Id(), cloneEntity)
-			if err != nil {
-				return diag.FromErr(err)
-			}
-			d.SetId(newUID)
-		}
-
-		// If other fields also changed (packs, values, etc.), apply them to the version
-		if d.HasChanges("name") || d.HasChanges("tags") || d.HasChanges("pack") || d.HasChanges("description") {
-			cp, err := c.GetClusterProfile(d.Id())
-			if err != nil {
-				return diag.FromErr(err)
-			}
-			cluster, err := toClusterProfileUpdateWithResolution(d, cp, c)
-			if err != nil {
-				return diag.FromErr(err)
-			}
-			metadata, err := toClusterProfilePatch(d)
-			if err != nil {
-				return diag.FromErr(err)
-			}
-			if err := c.UpdateClusterProfile(cluster); err != nil {
-				return diag.FromErr(err)
-			}
-			if err := c.PatchClusterProfile(cluster, metadata); err != nil {
-				return diag.FromErr(err)
-			}
-			if err := c.PublishClusterProfile(d.Id()); err != nil {
-				return diag.FromErr(err)
-			}
-		}
-
-		resourceClusterProfileRead(ctx, d, m)
-		return diags
-	}
-
+	// Note: when `immutable-clusterprofiles` is enabled, version-field changes
+	// never reach Update -- CustomizeDiff marks them as ForceNew so Terraform
+	// plans a replacement instead of an in-place update, and the new immutable
+	// version is created in resourceClusterProfileCreate (the standard SDK v2
+	// replacement lifecycle for immutable-versioned resources). The block below
+	// is the legacy in-place update path for users who have NOT opted into the
+	// flag -- it preserves the original destructive PUT-based behavior for
+	// backward compatibility.
 	if d.HasChanges("name") || d.HasChanges("tags") || d.HasChanges("pack") || d.HasChanges("description") || d.HasChanges("version") {
 		log.Printf("Updating packs")
 		cp, err := c.GetClusterProfile(d.Id())
@@ -349,6 +481,19 @@ func resourceClusterProfileDelete(_ context.Context, d *schema.ResourceData, m i
 	c := getV1ClientWithResourceContext(m, ProfileContext)
 
 	var diags diag.Diagnostics
+
+	// skip_destroy: when set, removing the resource from Terraform state does NOT
+	// call the Palette delete API. This is the standard Terraform Plugin SDK v2
+	// preservation pattern for immutable-versioned resources. With `skip_destroy = true`,
+	// version-bump replacements (triggered by ForceNew via the `immutable-clusterprofiles`
+	// feature flag) and `lifecycle { create_before_destroy = true }` preserve old
+	// versions in Palette while Terraform's state advances cleanly to the new version.
+	// This is the canonical SDK v2 idiom for "I want my upstream system to keep
+	// historical versions even though Terraform's state only tracks the latest one".
+	if d.Get("skip_destroy").(bool) {
+		log.Printf("skip_destroy: removing cluster profile %s from Terraform state without deleting from Palette (SDK v2 immutable-versioned-resource preservation pattern)", d.Id())
+		return diags
+	}
 
 	if err := c.DeleteClusterProfile(d.Id()); err != nil {
 		return diag.FromErr(err)

--- a/spectrocloud/resource_cluster_profile.go
+++ b/spectrocloud/resource_cluster_profile.go
@@ -148,6 +148,17 @@ func resourceClusterProfile() *schema.Resource {
 // updates (which is why this approach has none of the stale-output or
 // "[WARN] tolerating it because it is using the legacy plugin SDK" issues that
 // come from trying to mutate `d.Id()` mid-Update).
+//
+// Validation: when a version change is detected under the flag, we also require
+// `skip_destroy = true` on the resource. Without it, the replacement's Delete
+// phase would call the Palette DELETE API and destroy the previous version --
+// defeating the whole point of immutable versioning. Since `skip_destroy` is a
+// provider-schema attribute we can read at plan time, surfacing this as a plan
+// error rather than a runtime surprise is strictly better UX. The companion
+// `lifecycle { create_before_destroy = true }` block cannot be validated from
+// the provider (Terraform core parses lifecycle blocks before the provider sees
+// the diff), but the error message includes it so users get both knobs from a
+// single diagnostic.
 func resourceClusterProfileCustomizeDiff(_ context.Context, d *schema.ResourceDiff, _ interface{}) error {
 	if d.Id() == "" {
 		// New resource -- no in-place update to convert
@@ -159,6 +170,27 @@ func resourceClusterProfileCustomizeDiff(_ context.Context, d *schema.ResourceDi
 	if d.HasChange("version") {
 		if err := d.ForceNew("version"); err != nil {
 			return err
+		}
+		if !d.Get("skip_destroy").(bool) {
+			return fmt.Errorf(
+				"immutable-clusterprofiles: version changes on %q require skip_destroy = true and "+
+					"lifecycle { create_before_destroy = true } on the resource, so that the previous "+
+					"version is preserved in Palette while Terraform replaces the resource. Add both to "+
+					"your resource block:\n\n"+
+					"  resource \"spectrocloud_cluster_profile\" %q {\n"+
+					"    # ...\n"+
+					"    skip_destroy = true\n\n"+
+					"    lifecycle {\n"+
+					"      create_before_destroy = true\n"+
+					"    }\n"+
+					"  }\n\n"+
+					"This follows the standard Terraform Plugin SDK v2 immutable-versioned-resource "+
+					"pattern used by aws_lambda_layer_version and similar resources. See the "+
+					"\"Immutable versioning\" section of the spectrocloud_cluster_profile docs for a "+
+					"full example.",
+				d.Get("name").(string),
+				d.Get("name").(string),
+			)
 		}
 	}
 	return nil

--- a/spectrocloud/resource_cluster_profile.go
+++ b/spectrocloud/resource_cluster_profile.go
@@ -149,16 +149,33 @@ func resourceClusterProfile() *schema.Resource {
 // "[WARN] tolerating it because it is using the legacy plugin SDK" issues that
 // come from trying to mutate `d.Id()` mid-Update).
 //
-// Validation: when a version change is detected under the flag, we also require
-// `skip_destroy = true` on the resource. Without it, the replacement's Delete
-// phase would call the Palette DELETE API and destroy the previous version --
-// defeating the whole point of immutable versioning. Since `skip_destroy` is a
-// provider-schema attribute we can read at plan time, surfacing this as a plan
-// error rather than a runtime surprise is strictly better UX. The companion
-// `lifecycle { create_before_destroy = true }` block cannot be validated from
-// the provider (Terraform core parses lifecycle blocks before the provider sees
-// the diff), but the error message includes it so users get both knobs from a
-// single diagnostic.
+// Validation happens in two shapes when the `immutable-clusterprofiles` flag is
+// enabled:
+//
+// 1. Version bump (`version` field changing): mark `version` as `ForceNew` so
+//    Terraform plans a replacement, AND require `skip_destroy = true` on the
+//    resource. Without `skip_destroy`, the replacement's Delete phase would call
+//    the Palette DELETE API and destroy the previous version -- defeating the
+//    whole point of immutable versioning. Since `skip_destroy` is a
+//    provider-schema attribute we can read at plan time, surfacing this as a
+//    plan error rather than a runtime surprise is strictly better UX. The
+//    companion `lifecycle { create_before_destroy = true }` block cannot be
+//    validated from the provider (Terraform core parses lifecycle blocks before
+//    the provider sees the diff), but the error message includes it so users
+//    get both knobs from a single diagnostic.
+//
+// 2. Content change WITHOUT a version bump (any of `name`, `tags`, `pack`,
+//    `description`, `profile_variables` changing while `version` stays the
+//    same): reject with a plan-time error. The whole point of the flag is that
+//    published cluster profile versions are immutable -- a user who edits the
+//    pack content of v1.0.0 and re-applies without bumping the version is
+//    asking the provider to silently mutate what's supposed to be an immutable
+//    object. Without this check, the legacy `Update` path below would happily
+//    send a PUT to the Palette API and the mutation would succeed silently
+//    (the Palette API currently does not enforce version immutability
+//    server-side). That would be the same class of bug as the
+//    `clone-on-version-change` stale-output issue this whole PR was written to
+//    fix -- a documented invariant that the code doesn't enforce.
 func resourceClusterProfileCustomizeDiff(_ context.Context, d *schema.ResourceDiff, _ interface{}) error {
 	if d.Id() == "" {
 		// New resource -- no in-place update to convert
@@ -167,7 +184,11 @@ func resourceClusterProfileCustomizeDiff(_ context.Context, d *schema.ResourceDi
 	if !isFeaturePreviewEnabled("immutable-clusterprofiles") {
 		return nil
 	}
+
 	if d.HasChange("version") {
+		// Version bump: mark ForceNew so Terraform plans a replacement, and
+		// require the skip_destroy knob so the replacement's Delete phase
+		// preserves the old version in Palette.
 		if err := d.ForceNew("version"); err != nil {
 			return err
 		}
@@ -192,8 +213,60 @@ func resourceClusterProfileCustomizeDiff(_ context.Context, d *schema.ResourceDi
 				d.Get("name").(string),
 			)
 		}
+		return nil
 	}
+
+	// Version did NOT change, but the flag is on. Look for any content changes
+	// that would have silently mutated the supposedly-immutable published
+	// version. If any content field has changed, reject the plan.
+	contentFields := []string{"name", "tags", "pack", "description", "profile_variables"}
+	var changedContentFields []string
+	for _, f := range contentFields {
+		if d.HasChange(f) {
+			changedContentFields = append(changedContentFields, f)
+		}
+	}
+	if len(changedContentFields) > 0 {
+		return fmt.Errorf(
+			"immutable-clusterprofiles: cluster profile versions are immutable. "+
+				"Detected changes to field(s) %v on %q (version %q) without a corresponding "+
+				"version bump. To push these changes, increment the version field "+
+				"(e.g., %q -> %q) so the provider creates a new immutable version via the "+
+				"clone endpoint while the previous version is preserved in Palette. If you "+
+				"intentionally want to mutate the existing version in place, remove the "+
+				"\"immutable-clusterprofiles\" feature_preview flag from your provider block "+
+				"(note: this reverts to the legacy destructive PUT behavior and is not "+
+				"recommended).",
+			changedContentFields,
+			d.Get("name").(string),
+			d.Get("version").(string),
+			d.Get("version").(string),
+			bumpPatchHint(d.Get("version").(string)),
+		)
+	}
+
 	return nil
+}
+
+// bumpPatchHint returns a best-effort "next patch version" suggestion for the
+// error message, purely cosmetic. If the version string isn't in a recognizable
+// semver shape, it returns "<next-version>" as a placeholder. This is only used
+// to make the error message more concrete -- the provider does not enforce any
+// particular version format.
+func bumpPatchHint(current string) string {
+	// Cheap heuristic: if the last segment is an integer, bump it by 1.
+	// Otherwise fall back to a placeholder.
+	parts := strings.Split(current, ".")
+	if len(parts) == 0 {
+		return "<next-version>"
+	}
+	last := parts[len(parts)-1]
+	n := 0
+	if _, err := fmt.Sscanf(last, "%d", &n); err != nil || n < 0 {
+		return "<next-version>"
+	}
+	parts[len(parts)-1] = fmt.Sprintf("%d", n+1)
+	return strings.Join(parts, ".")
 }
 
 // findAnyExistingProfileVersionUID returns the UID of any existing version of
@@ -469,14 +542,22 @@ func resourceClusterProfileUpdate(ctx context.Context, d *schema.ResourceData, m
 		}
 	}
 
-	// Note: when `immutable-clusterprofiles` is enabled, version-field changes
-	// never reach Update -- CustomizeDiff marks them as ForceNew so Terraform
-	// plans a replacement instead of an in-place update, and the new immutable
-	// version is created in resourceClusterProfileCreate (the standard SDK v2
-	// replacement lifecycle for immutable-versioned resources). The block below
-	// is the legacy in-place update path for users who have NOT opted into the
-	// flag -- it preserves the original destructive PUT-based behavior for
-	// backward compatibility.
+	// Note on interaction with `immutable-clusterprofiles`:
+	//
+	// When the flag is enabled, CustomizeDiff catches both version changes
+	// (by marking `version` as ForceNew, routing the work through
+	// Create + skip_destroy-preserved Delete) AND content changes without
+	// a version bump (by returning a plan-time error that tells the user
+	// to bump the version or disable the flag). Either way, this Update
+	// block is NOT reached when the flag is set -- replacement-based
+	// work goes through Create, and disallowed mutations are rejected
+	// at plan time before Update runs.
+	//
+	// This block is therefore the legacy in-place update path for users
+	// who have NOT opted into the flag. It preserves the original
+	// destructive PUT-based behavior (mutating the existing UID via
+	// UpdateClusterProfile) for backward compatibility with existing CI
+	// and HCL that was written against the pre-flag provider.
 	if d.HasChanges("name") || d.HasChanges("tags") || d.HasChanges("pack") || d.HasChanges("description") || d.HasChanges("version") {
 		log.Printf("Updating packs")
 		cp, err := c.GetClusterProfile(d.Id())

--- a/spectrocloud/resource_cluster_profile_test.go
+++ b/spectrocloud/resource_cluster_profile_test.go
@@ -1001,6 +1001,95 @@ func TestResourceClusterProfileCustomizeDiff_VersionBump_FlagOff(t *testing.T) {
 	}
 }
 
+// customizeDiffContentChangeFixture drives Resource.Diff with a content change
+// (description field) on an existing resource while keeping the version field
+// the same. Used by the content-change-without-version-bump CustomizeDiff tests.
+func customizeDiffContentChangeFixture(oldDescription, newDescription string) (*terraform.InstanceDiff, error) {
+	r := resourceClusterProfile()
+	state := &terraform.InstanceState{
+		ID: "cluster-profile-1",
+		Attributes: map[string]string{
+			"name":                "example-addon",
+			"version":             "1.0.0",
+			"context":             "project",
+			"description":         oldDescription,
+			"cloud":               "all",
+			"type":                "add-on",
+			"skip_destroy":        "true",
+			"tags.#":              "0",
+			"pack.#":              "0",
+			"profile_variables.#": "0",
+		},
+	}
+	cfg := map[string]interface{}{
+		"name":         "example-addon",
+		"version":      "1.0.0",
+		"context":      "project",
+		"description":  newDescription,
+		"cloud":        "all",
+		"type":         "add-on",
+		"skip_destroy": true,
+	}
+	return r.Diff(context.Background(), state, terraform.NewResourceConfigRaw(cfg), unitTestMockAPIClient)
+}
+
+// TestResourceClusterProfileCustomizeDiff_ContentChange_WithoutVersionBump_UnderFlag
+// verifies that when immutable-clusterprofiles is enabled and the user mutates
+// any content field (description, pack, tags, etc.) WITHOUT bumping the version,
+// plan fails at CustomizeDiff time with a clear error telling them to bump the
+// version field.
+//
+// This is the guardrail against the "silent mutation" class of bug: without
+// this check, the legacy Update path would happily send a PUT to Palette and
+// the supposedly-immutable v1.0.0 would have its content mutated in place,
+// defeating the whole point of the feature flag. Caught empirically during
+// end-to-end demo walkthrough on 2026-04-08.
+func TestResourceClusterProfileCustomizeDiff_ContentChange_WithoutVersionBump_UnderFlag(t *testing.T) {
+	orig := ProviderFeaturePreview
+	defer func() { ProviderFeaturePreview = orig }()
+	ProviderFeaturePreview = map[string]bool{"immutable-clusterprofiles": true}
+
+	_, err := customizeDiffContentChangeFixture("original description", "mutated description")
+	assert.Error(t, err, "plan must error when content fields change under the flag without a version bump")
+	assert.Contains(t, err.Error(), "immutable-clusterprofiles")
+	assert.Contains(t, err.Error(), "description")
+	assert.Contains(t, err.Error(), "version bump")
+	assert.Contains(t, err.Error(), "1.0.0")
+}
+
+// TestResourceClusterProfileCustomizeDiff_ContentChange_WithoutVersionBump_FlagOff
+// verifies that without the flag, content changes without a version bump are
+// allowed through the legacy in-place update path. This is the backward-compat
+// behavior -- users who haven't opted into immutability can still patch their
+// cluster profiles in place (the destructive PUT path the provider always had).
+func TestResourceClusterProfileCustomizeDiff_ContentChange_WithoutVersionBump_FlagOff(t *testing.T) {
+	orig := ProviderFeaturePreview
+	defer func() { ProviderFeaturePreview = orig }()
+	ProviderFeaturePreview = map[string]bool{}
+
+	diff, err := customizeDiffContentChangeFixture("original description", "mutated description")
+	assert.NoError(t, err, "without the flag, content changes must not be blocked at plan time")
+	assert.NotNil(t, diff)
+	// Description should be in the diff as a normal update, not a replacement.
+	if descAttr, ok := diff.Attributes["description"]; ok {
+		assert.False(t, descAttr.RequiresNew, "without the flag, description changes must not force replacement")
+	}
+}
+
+// TestResourceClusterProfileCustomizeDiff_NoChanges_UnderFlag verifies the
+// baseline: when the flag is on and nothing has changed (re-apply of the same
+// config), CustomizeDiff returns nil without error. Guards against accidentally
+// erroring on no-op applies.
+func TestResourceClusterProfileCustomizeDiff_NoChanges_UnderFlag(t *testing.T) {
+	orig := ProviderFeaturePreview
+	defer func() { ProviderFeaturePreview = orig }()
+	ProviderFeaturePreview = map[string]bool{"immutable-clusterprofiles": true}
+
+	// Same description on both sides -- no change.
+	_, err := customizeDiffContentChangeFixture("same description", "same description")
+	assert.NoError(t, err, "no-op applies under the flag must not error")
+}
+
 // TestResourceClusterProfileDelete_SkipDestroy verifies that when
 // skip_destroy=true, the Delete function returns successfully without calling
 // the Palette delete API. This is the SDK v2 preservation pattern for

--- a/spectrocloud/resource_cluster_profile_test.go
+++ b/spectrocloud/resource_cluster_profile_test.go
@@ -814,107 +814,16 @@ func prepareClusterProfileWithVersionChange(oldVersion, newVersion, profileName 
 	return d
 }
 
-// TestResourceClusterProfileUpdateVersionClone tests that when the version
-// changes and the new version does NOT already exist, the clone path is taken.
-func TestResourceClusterProfileUpdateVersionClone(t *testing.T) {
-	orig := ProviderFeaturePreview
-	defer func() { ProviderFeaturePreview = orig }()
-	ProviderFeaturePreview = map[string]bool{"clone-on-version-change": true}
-
-	// Use a profile name that doesn't match any entry in the mock metadata
-	// so GetClusterProfileUID returns an error → triggers clone path.
-	d := prepareClusterProfileWithVersionChange("1.0.0", "2.0.0", "nonexistent-profile", nil)
-	var ctx context.Context
-
-	diags := resourceClusterProfileUpdate(ctx, d, unitTestMockAPIClient)
-	assert.Empty(t, diags)
-	// After clone, the ID should be the cloned UID returned by the mock server.
-	assert.Equal(t, "cloned-profile-uid", d.Id())
-}
-
-// TestResourceClusterProfileUpdateVersionAdopt tests that when the version
-// changes and the new version already exists, the existing version is adopted
-// instead of cloning.
-func TestResourceClusterProfileUpdateVersionAdopt(t *testing.T) {
-	orig := ProviderFeaturePreview
-	defer func() { ProviderFeaturePreview = orig }()
-	ProviderFeaturePreview = map[string]bool{"clone-on-version-change": true}
-
-	// Use name "test-cluster-profile-1" and new version "1.0.0" which matches
-	// the mock metadata response (stable UID "existing-profile-uid-1").
-	d := prepareClusterProfileWithVersionChange("0.9.0", "1.0.0", "test-cluster-profile-1", nil)
-	var ctx context.Context
-
-	diags := resourceClusterProfileUpdate(ctx, d, unitTestMockAPIClient)
-	assert.Empty(t, diags)
-	// Should have adopted the existing UID, not cloned.
-	assert.Equal(t, "existing-profile-uid-1", d.Id())
-}
-
-// TestResourceClusterProfileUpdateVersionCloneWithFieldChanges tests the clone
-// path when other fields (description) also changed alongside the version.
-func TestResourceClusterProfileUpdateVersionCloneWithFieldChanges(t *testing.T) {
-	orig := ProviderFeaturePreview
-	defer func() { ProviderFeaturePreview = orig }()
-	ProviderFeaturePreview = map[string]bool{"clone-on-version-change": true}
-
-	extra := map[string]*terraform.ResourceAttrDiff{
-		"description": {
-			Old: "old description",
-			New: "new description",
-		},
-	}
-	d := prepareClusterProfileWithVersionChange("1.0.0", "2.0.0", "nonexistent-profile", extra)
-	var ctx context.Context
-
-	diags := resourceClusterProfileUpdate(ctx, d, unitTestMockAPIClient)
-	assert.Empty(t, diags)
-	assert.Equal(t, "cloned-profile-uid", d.Id())
-}
-
-// TestResourceClusterProfileUpdateVersionAdoptWithFieldChanges tests the adopt
-// path when other fields also changed — should adopt and then update/patch/publish.
-func TestResourceClusterProfileUpdateVersionAdoptWithFieldChanges(t *testing.T) {
-	orig := ProviderFeaturePreview
-	defer func() { ProviderFeaturePreview = orig }()
-	ProviderFeaturePreview = map[string]bool{"clone-on-version-change": true}
-
-	extra := map[string]*terraform.ResourceAttrDiff{
-		"description": {
-			Old: "old description",
-			New: "new description",
-		},
-	}
-	d := prepareClusterProfileWithVersionChange("0.9.0", "1.0.0", "test-cluster-profile-1", extra)
-	var ctx context.Context
-
-	diags := resourceClusterProfileUpdate(ctx, d, unitTestMockAPIClient)
-	assert.Empty(t, diags)
-	assert.Equal(t, "existing-profile-uid-1", d.Id())
-}
-
-// TestResourceClusterProfileCreateAdoptExisting tests that when Create fails
-// because the profile already exists, the function adopts the existing UID
-// instead of returning an error.
-func TestResourceClusterProfileCreateAdoptExisting(t *testing.T) {
-	orig := ProviderFeaturePreview
-	defer func() { ProviderFeaturePreview = orig }()
-	ProviderFeaturePreview = map[string]bool{"clone-on-version-change": true}
-
-	d := prepareBaseClusterProfileTestData()
-	// Use name+version matching mock metadata → adopt path
-	_ = d.Set("name", "test-cluster-profile-1")
-	_ = d.Set("version", "1.0.0")
-	_ = d.Set("type", "add-on")
-	var ctx context.Context
-	diags := resourceClusterProfileCreate(ctx, d, unitTestMockAPINegativeClient)
-	assert.Empty(t, diags)
-	assert.Equal(t, "existing-profile-uid-1", d.Id())
-}
-
-// TestResourceClusterProfileUpdateVersionNoFlag tests that when the feature
-// preview flag is OFF, version changes fall through to the update-in-place
-// path (old behavior) instead of cloning.
+// TestResourceClusterProfileUpdateVersionNoFlag tests that without the
+// immutable-clusterprofiles feature flag, version changes fall through to the
+// legacy in-place update path (UpdateClusterProfile / PUT) instead of triggering
+// a Create-path clone. The Terraform id stays stable because no replacement is
+// planned.
+//
+// Note: this is the backward-compat path. When the flag IS enabled, version
+// changes never reach Update at all -- CustomizeDiff marks them as ForceNew, so
+// Terraform plans a replacement and the new version is produced by the Create
+// function (see TestResourceClusterProfileCreate_ImmutableClusterprofiles_*).
 func TestResourceClusterProfileUpdateVersionNoFlag(t *testing.T) {
 	orig := ProviderFeaturePreview
 	defer func() { ProviderFeaturePreview = orig }()
@@ -925,14 +834,38 @@ func TestResourceClusterProfileUpdateVersionNoFlag(t *testing.T) {
 
 	diags := resourceClusterProfileUpdate(ctx, d, unitTestMockAPIClient)
 	assert.Empty(t, diags)
-	// Without the flag, version change should NOT clone — it should
-	// fall through to the update-in-place path and keep the original ID.
+	// Without the flag, version change should NOT clone -- it falls through
+	// to the legacy update-in-place path and the Terraform id stays stable.
 	assert.Equal(t, "cluster-profile-1", d.Id())
 }
 
-// TestResourceClusterProfileCreateNoAdoptWithoutFlag tests that when the
-// feature preview flag is OFF, a create failure returns the error instead
-// of trying to adopt an existing profile.
+// TestResourceClusterProfileCreateAdoptExisting verifies the SDK v2
+// adopt-on-create pattern: when Create fails because the profile already
+// exists in Palette (e.g. another root module created it, or it was created
+// via the UI) AND the immutable-clusterprofiles flag is enabled, the function
+// adopts the existing UID into Terraform state instead of returning an error.
+func TestResourceClusterProfileCreateAdoptExisting(t *testing.T) {
+	orig := ProviderFeaturePreview
+	defer func() { ProviderFeaturePreview = orig }()
+	ProviderFeaturePreview = map[string]bool{"immutable-clusterprofiles": true}
+
+	d := prepareBaseClusterProfileTestData()
+	// Use name+version matching mock metadata → adopt path
+	_ = d.Set("name", "test-cluster-profile-1")
+	_ = d.Set("version", "1.0.0")
+	_ = d.Set("type", "add-on")
+	var ctx context.Context
+	diags := resourceClusterProfileCreate(ctx, d, unitTestMockAPIClient)
+	assert.Empty(t, diags)
+	// Should have adopted the existing UID from the mock metadata.
+	assert.Equal(t, "existing-profile-uid-1", d.Id())
+}
+
+// TestResourceClusterProfileCreateNoAdoptWithoutFlag verifies that when the
+// immutable-clusterprofiles feature flag is OFF, a Create failure returns the
+// error instead of trying to adopt an existing profile. This preserves the
+// legacy "create is not idempotent" behavior for users who haven't opted into
+// the new flag.
 func TestResourceClusterProfileCreateNoAdoptWithoutFlag(t *testing.T) {
 	orig := ProviderFeaturePreview
 	defer func() { ProviderFeaturePreview = orig }()
@@ -947,4 +880,98 @@ func TestResourceClusterProfileCreateNoAdoptWithoutFlag(t *testing.T) {
 	// return the error instead of trying to adopt.
 	diags := resourceClusterProfileCreate(ctx, d, unitTestMockAPINegativeClient)
 	assert.NotEmpty(t, diags)
+}
+
+// TestResourceClusterProfileSchema_HasSkipDestroy verifies that the new
+// skip_destroy schema field is present with the expected type and default.
+// This field is part of the standard Terraform Plugin SDK v2 immutable-versioned
+// resource pattern -- it gates whether Delete actually calls the API or just
+// removes the resource from Terraform state.
+func TestResourceClusterProfileSchema_HasSkipDestroy(t *testing.T) {
+	r := resourceClusterProfile()
+	field, ok := r.Schema["skip_destroy"]
+	assert.True(t, ok, "skip_destroy field must be present on the cluster_profile schema")
+	assert.NotNil(t, field)
+	assert.Equal(t, schema.TypeBool, field.Type)
+	assert.True(t, field.Optional)
+	assert.Equal(t, false, field.Default, "skip_destroy must default to false for backward compatibility")
+}
+
+// TestResourceClusterProfileSchema_NoCurrentUid verifies that the current_uid
+// field was removed as part of the consolidation. It was only useful as a
+// workaround for the stale-output bug on the clone-on-version-change path,
+// which no longer exists.
+func TestResourceClusterProfileSchema_NoCurrentUid(t *testing.T) {
+	r := resourceClusterProfile()
+	_, ok := r.Schema["current_uid"]
+	assert.False(t, ok, "current_uid field must not be present; it was removed when clone-on-version-change was consolidated into immutable-clusterprofiles")
+}
+
+// TestResourceClusterProfileSchema_CustomizeDiffRegistered verifies that the
+// CustomizeDiff hook is wired up on the resource. CustomizeDiff is what marks
+// the version field as ForceNew when the immutable-clusterprofiles feature
+// flag is enabled.
+func TestResourceClusterProfileSchema_CustomizeDiffRegistered(t *testing.T) {
+	r := resourceClusterProfile()
+	assert.NotNil(t, r.CustomizeDiff, "CustomizeDiff must be registered to gate ForceNew on version under immutable-clusterprofiles")
+}
+
+// TestResourceClusterProfileDelete_SkipDestroy verifies that when
+// skip_destroy=true, the Delete function returns successfully without calling
+// the Palette delete API. This is the SDK v2 preservation pattern for
+// immutable-versioned resources: replacement lifecycles remove the old
+// resource from Terraform state via Delete, and skip_destroy makes that a
+// no-op so the underlying versioned object stays in the upstream system.
+func TestResourceClusterProfileDelete_SkipDestroy(t *testing.T) {
+	d := prepareBaseClusterProfileTestData()
+	d.SetId("some-uid-that-does-not-exist-in-mock")
+	_ = d.Set("skip_destroy", true)
+	_ = d.Set("context", "project")
+	var ctx context.Context
+
+	// Delete against the negative (failing) client -- if skip_destroy is
+	// honored, we never call the API, so the negative client's failure
+	// path doesn't trigger.
+	diags := resourceClusterProfileDelete(ctx, d, unitTestMockAPINegativeClient)
+	assert.Empty(t, diags, "skip_destroy=true should bypass the API call entirely, so negative-client failures should not surface")
+}
+
+// TestResourceClusterProfileDelete_NormalDestroy verifies that when
+// skip_destroy is false (the default), Delete calls the Palette delete API.
+// This preserves the legacy behavior for users who don't opt into the new
+// immutable lifecycle.
+func TestResourceClusterProfileDelete_NormalDestroy(t *testing.T) {
+	d := prepareBaseClusterProfileTestData()
+	d.SetId("test-cluster-profile-1")
+	_ = d.Set("skip_destroy", false)
+	_ = d.Set("context", "project")
+	var ctx context.Context
+
+	// The mock client's delete endpoint returns success for known UIDs.
+	diags := resourceClusterProfileDelete(ctx, d, unitTestMockAPIClient)
+	assert.Empty(t, diags)
+}
+
+// TestFindAnyExistingProfileVersionUID_Found verifies that the helper finds
+// an existing profile by name via the SDK's GetClusterProfiles listing endpoint.
+// This helper is used by the immutable-clusterprofiles Create path to discover
+// a clone source for a new version of an existing lineage.
+func TestFindAnyExistingProfileVersionUID_Found(t *testing.T) {
+	c := getV1ClientWithResourceContext(unitTestMockAPIClient, "project")
+	// The mock metadata includes "test-cluster-profile-1" with a known stable UID.
+	uid, err := findAnyExistingProfileVersionUID(c, "test-cluster-profile-1")
+	assert.NoError(t, err)
+	assert.NotEmpty(t, uid, "expected to find an existing UID for test-cluster-profile-1 in the mock metadata")
+}
+
+// TestFindAnyExistingProfileVersionUID_NotFound verifies that the helper
+// returns an empty string (not an error) when no profile with the given name
+// exists. The empty-string-no-error return is what the Create path uses to
+// decide between "clone from existing lineage" and "create the very first
+// version from scratch".
+func TestFindAnyExistingProfileVersionUID_NotFound(t *testing.T) {
+	c := getV1ClientWithResourceContext(unitTestMockAPIClient, "project")
+	uid, err := findAnyExistingProfileVersionUID(c, "this-profile-definitely-does-not-exist-in-the-mock")
+	assert.NoError(t, err, "not-found should return an empty string without an error")
+	assert.Empty(t, uid)
 }

--- a/spectrocloud/resource_cluster_profile_test.go
+++ b/spectrocloud/resource_cluster_profile_test.go
@@ -916,6 +916,91 @@ func TestResourceClusterProfileSchema_CustomizeDiffRegistered(t *testing.T) {
 	assert.NotNil(t, r.CustomizeDiff, "CustomizeDiff must be registered to gate ForceNew on version under immutable-clusterprofiles")
 }
 
+// customizeDiffFixture drives Resource.Diff (which runs the registered
+// CustomizeDiff function internally) with a version bump on an existing
+// resource. skipDestroyInConfig controls whether the user's HCL sets
+// skip_destroy = true, which is what the CustomizeDiff plan-time validation
+// checks for.
+func customizeDiffFixture(oldVersion, newVersion string, skipDestroyInConfig bool) (*terraform.InstanceDiff, error) {
+	r := resourceClusterProfile()
+	state := &terraform.InstanceState{
+		ID: "cluster-profile-1",
+		Attributes: map[string]string{
+			"name":                "example-addon",
+			"version":             oldVersion,
+			"context":             "project",
+			"description":         "",
+			"cloud":               "all",
+			"type":                "add-on",
+			"skip_destroy":        "false",
+			"tags.#":              "0",
+			"pack.#":              "0",
+			"profile_variables.#": "0",
+		},
+	}
+	cfg := map[string]interface{}{
+		"name":         "example-addon",
+		"version":      newVersion,
+		"context":      "project",
+		"cloud":        "all",
+		"type":         "add-on",
+		"skip_destroy": skipDestroyInConfig,
+	}
+	return r.Diff(context.Background(), state, terraform.NewResourceConfigRaw(cfg), unitTestMockAPIClient)
+}
+
+// TestResourceClusterProfileCustomizeDiff_VersionBump_MissingSkipDestroy
+// verifies that when the immutable-clusterprofiles flag is enabled and the
+// user bumps the version without setting skip_destroy = true, plan fails with
+// a clear error that tells the user which knobs to add. This is the guardrail
+// against the common mistake of enabling the flag but forgetting the companion
+// SDK v2 pattern attributes.
+func TestResourceClusterProfileCustomizeDiff_VersionBump_MissingSkipDestroy(t *testing.T) {
+	orig := ProviderFeaturePreview
+	defer func() { ProviderFeaturePreview = orig }()
+	ProviderFeaturePreview = map[string]bool{"immutable-clusterprofiles": true}
+
+	_, err := customizeDiffFixture("1.0.0", "1.1.0", false)
+	assert.Error(t, err, "plan must error when version changes under the flag without skip_destroy = true")
+	assert.Contains(t, err.Error(), "skip_destroy = true")
+	assert.Contains(t, err.Error(), "create_before_destroy = true")
+	assert.Contains(t, err.Error(), "aws_lambda_layer_version")
+}
+
+// TestResourceClusterProfileCustomizeDiff_VersionBump_WithSkipDestroy
+// verifies that when skip_destroy is set, plan succeeds and the version change
+// is marked as a replacement (ForceNew). This is the intended happy path under
+// the immutable-clusterprofiles flag.
+func TestResourceClusterProfileCustomizeDiff_VersionBump_WithSkipDestroy(t *testing.T) {
+	orig := ProviderFeaturePreview
+	defer func() { ProviderFeaturePreview = orig }()
+	ProviderFeaturePreview = map[string]bool{"immutable-clusterprofiles": true}
+
+	diff, err := customizeDiffFixture("1.0.0", "1.1.0", true)
+	assert.NoError(t, err)
+	assert.NotNil(t, diff)
+	versionAttr, ok := diff.Attributes["version"]
+	assert.True(t, ok, "version attribute should be in diff")
+	assert.True(t, versionAttr.RequiresNew, "version change must be marked ForceNew under the flag")
+}
+
+// TestResourceClusterProfileCustomizeDiff_VersionBump_FlagOff verifies that
+// without the immutable-clusterprofiles flag, the CustomizeDiff validation is
+// bypassed entirely and version changes behave like any other in-place update
+// -- no ForceNew, no skip_destroy requirement. This is the backward-compat path.
+func TestResourceClusterProfileCustomizeDiff_VersionBump_FlagOff(t *testing.T) {
+	orig := ProviderFeaturePreview
+	defer func() { ProviderFeaturePreview = orig }()
+	ProviderFeaturePreview = map[string]bool{}
+
+	diff, err := customizeDiffFixture("1.0.0", "1.1.0", false)
+	assert.NoError(t, err, "without the flag, version changes must not require skip_destroy")
+	assert.NotNil(t, diff)
+	if versionAttr, ok := diff.Attributes["version"]; ok {
+		assert.False(t, versionAttr.RequiresNew, "without the flag, version must not be ForceNew")
+	}
+}
+
 // TestResourceClusterProfileDelete_SkipDestroy verifies that when
 // skip_destroy=true, the Delete function returns successfully without calling
 // the Palette delete API. This is the SDK v2 preservation pattern for

--- a/templates/resources/cluster_profile.md.tmpl
+++ b/templates/resources/cluster_profile.md.tmpl
@@ -197,6 +197,72 @@ resource "spectrocloud_cluster_profile" "profile" {
 ```
 
 
+## Immutable versioning
+
+This resource supports the standard Terraform Plugin SDK v2 pattern for immutable-versioned upstream resources, the same shape used by [`aws_lambda_layer_version`](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_layer_version), `aws_db_snapshot`, `azurerm_shared_image_version`, `google_compute_instance_template`, and similar resources. When the `immutable-clusterprofiles` feature_preview flag is enabled on the provider:
+
+- Changes to `version` trigger a **Terraform resource replacement** (`ForceNew`) instead of an in-place update
+- The new version is created by calling `POST /v1/clusterprofiles/{uid}/clone` against any existing version of the lineage, then overwriting the clone with the user's HCL content
+- The previous version is preserved in Palette because `Delete` honors `skip_destroy = true`
+- `create_before_destroy = true` ensures the new version exists before Terraform removes the old one from state
+
+All three knobs (feature flag, `skip_destroy`, and `lifecycle`) are required together. Miss any one and the plan will either error out (missing `skip_destroy`) or the old version will be destroyed in Palette (missing `create_before_destroy`). This matches the standard SDK v2 pattern exactly.
+
+### Enabling immutable versioning
+
+```terraform
+provider "spectrocloud" {
+  host = "api.spectrocloud.com"
+
+  feature_preview = {
+    "immutable-clusterprofiles" = true
+  }
+}
+
+resource "spectrocloud_cluster_profile" "addon" {
+  name    = "example-addon"
+  version = var.profile_version  # bump this via git tags / CI
+  type    = "add-on"
+  context = "project"
+
+  pack {
+    name = "example-manifest"
+    type = "manifest"
+
+    manifest {
+      name    = "example"
+      content = file("${path.module}/manifests/example.yaml")
+    }
+  }
+
+  skip_destroy = true  # preserve old versions in Palette
+
+  lifecycle {
+    create_before_destroy = true  # create new version before destroying old
+  }
+}
+```
+
+Bumping `var.profile_version` from `1.0.0` to `1.1.0` and running `terraform apply`:
+
+1. Terraform plans a replacement (ForceNew on `version`)
+2. The new resource's `Create` runs first (because of `create_before_destroy`), calls the clone endpoint, applies the user's pack content
+3. The old resource is "destroyed" from Terraform's perspective, but `skip_destroy` makes the Delete call a no-op; the `1.0.0` version stays in Palette untouched
+4. State advances to `1.1.0`; Palette has both versions with distinct UIDs; `terraform output` returns the correct current uid without needing `terraform apply -refresh-only`
+
+### Why all three knobs are required
+
+| Knob | Why it's required | What happens if you skip it |
+|------|------------------|----------------------------|
+| `feature_preview.immutable-clusterprofiles = true` | Opts the resource into replacement-based versioning. Without it, the resource preserves its legacy in-place `PUT` behavior for backward compatibility. | Legacy in-place mutation; previous version is destroyed. |
+| `skip_destroy = true` | Prevents `Delete` from calling the Palette DELETE API on the replaced resource, so the old version is preserved in Palette even though Terraform removes it from state. | Plan fails with an error at `terraform plan` time (the provider catches this and tells you exactly what to add). |
+| `lifecycle { create_before_destroy = true }` | Ensures Terraform creates the new version before marking the old one for destruction. Without it, Terraform destroys first and creates second, causing a brief window where no version exists in Terraform state. | Terraform would attempt to `Delete` the old resource before `Create`ing the new one; because `skip_destroy = true` makes Delete a no-op, the Palette version still survives, but the planned operation order is wrong and some edge cases (state corruption on failure, for example) are riskier. Terraform core parses `lifecycle` blocks before the provider runs, so the provider cannot validate this automatically; this one is on the user to remember. |
+
+### Backward compatibility
+
+The `immutable-clusterprofiles` feature flag is opt-in. Without it, `spectrocloud_cluster_profile` behaves exactly as it did before the flag was introduced; version changes go through the in-place `PUT` path. Existing HCL, state files, and CI pipelines continue to work without modification. See the resource's `version` and `skip_destroy` field docs below for further details.
+
+
 ## Import
 
 In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import)


### PR DESCRIPTION
**As a follow-up to #856 / testing on `v0.28.4-pre` pre-release**:

- The Palette side worked exactly as designed: bumping `version` from `1.0.0` to `1.1.0` produced two versions in Palette with distinct UIDs, both visible in the version dropdown.
- But on the Terraform side, state and outputs diverged after the bump:
  * `terraform state show ...id` -- new v1.1.0 uid
  * `terraform output profile_id` -- **stale** v1.0.0 uid
  * After `terraform apply -refresh-only` -- converges to new uid
- Reproduced deterministically. Running `-refresh-only` after every bump was the only way to get outputs to reflect reality, which is awful UX and easy to forget in CI.
-  During the apply, Terraform itself flagged the root cause:

```
[WARN] Provider produced an unexpected new value for ...cluster_profile.this,
       but we are tolerating it because it is using the legacy plugin SDK.
       - .id: was cty.StringVal("<old>"), but now cty.StringVal("<new>")
```

---

**Stepping back: what the Terraform SDK v2 actually guarantees**:

SDK v2 treats a resource's primary id (`d.Id()`) as **stable across in-place updates**. The planner builds its output snapshot at plan time under that assumption: when a user writes `output "profile_id" { value = <resource>.id }`, the planner locks in the prior state's id as a `NoOp` change, because it doesn't expect `Update` to change `id`.

#856 does the right Palette *operation* (clone instead of destructive PUT) but mutates `d.Id()` to the new cloned uid mid-`Update`. The write lands in state (that's why `terraform state show` is correct), but the output snapshot was already locked in from the plan. Outputs stay stale until a manual refresh regenerates the plan against current state.

The standard SDK v2 pattern for this shape of problem, "immutable versioned upstream object with a shared lineage name", is replacement-based: mark the identifying field `ForceNew`, use Terraform's normal replacement lifecycle via `create_before_destroy`, and add a `skip_destroy` flag to preserve the prior version in the upstream system. That's what `aws_lambda_layer_version` and similar resources do. It sidesteps the id-stability issue entirely, because each version is a fresh Terraform resource with a fresh id.

---

**Approach in this PR**:

Replace the `clone-on-version-change` (a Palette-specific approach) with an opt-in feature flag `immutable-clusterprofiles` (a Terraform-specific approach). When enabled:

1. `CustomizeDiff` marks `version` as `ForceNew` on changes, so Terraform plans a replacement instead of an in-place update.
2. New `skip_destroy` schema attribute, gating whether `Delete` calls the Palette API.
3. Plan-time validation: if a user bumps `version` without `skip_destroy = true` on the resource, the plan errors out with a friendly message telling them both knobs to add (`skip_destroy` and `lifecycle { create_before_destroy = true }`).
4. `Create` discovers the existing lineage by name via `GetClusterProfiles`, calls `CloneClusterProfile` against any existing uid to create the new version, then applies the user's HCL content via the standard `UpdateClusterProfile` + `PatchClusterProfile` + `PublishClusterProfile` chain.
5. `Delete` honors `skip_destroy`. When set, returns `nil` without calling the API, so the previous version stays in Palette during a replacement.

User HCL looks like this:

```hcl
provider "spectrocloud" {
  feature_preview = {
    "immutable-clusterprofiles" = true
  }
}

resource "spectrocloud_cluster_profile" "addon" {
  name    = "example-addon"
  version = var.profile_version
  type    = "add-on"

  pack { ... }

  skip_destroy = true
  lifecycle {
    create_before_destroy = true
  }
}
```

Bumping `var.profile_version` now flows through Terraform's normal replacement lifecycle. No in-place id mutation, no stale outputs, no `-refresh-only` required. The `clone-on-version-change` flag is removed in favor of this one; if you'd prefer both to ship side-by-side for a deprecation period, happy to split that out.

Zero impact on existing users who don't opt in. Without the flag, `spectrocloud_cluster_profile` behaves exactly as it did before `v0.28.4-pre` (in-place PUT on version changes, default Delete path, unchanged HCL).

---

**Testing and verification**:

**Unit tests** (`go test ./spectrocloud/`): full package passes. New tests cover the schema additions, `CustomizeDiff` behavior in all three states (flag off, flag on with `skip_destroy`, flag on without), `Delete` with and without `skip_destroy`, and the lineage-lookup helper.

**End-to-end against a live Palette tenant**: three consecutive version bumps (`1.0.0` to `1.1.0` to `1.2.0`) with the flag enabled.

- Every apply produced the expected plan (`1 to add, 0 to change, 1 to destroy`)
- All three versions coexist in Palette with distinct UIDs, verified via direct API listing
- `terraform output profile_id` returned the correct current uid after every apply, **no `-refresh-only` required**
- The `[WARN] Provider produced an unexpected new value` warning is **gone**, because the planner now understands the replacement lifecycle