### PR TITLE
PE-8086: add skip_k8s_upgrade attribute to edge-native cluster resource

### DIFF
--- a/spectrocloud/cluster_common_hash.go
+++ b/spectrocloud/cluster_common_hash.go
@@ -660,6 +660,9 @@ func resourceMachinePoolEdgeNativeHash(v interface{}) int {
 	if val, ok := m["override_kubeadm_configuration"].(string); ok && val != "" {
 		fmt.Fprintf(buf, "%s-", val)
 	}
+	if val, ok := m["skip_k8s_upgrade"].(string); ok && val != "" {
+		fmt.Fprintf(buf, "%s-", val)
+	}
 
 	if edgeHosts, found := m["edge_host"]; found {
 		var edgeHostList []interface{}

--- a/spectrocloud/resource_cluster_edge_native.go
+++ b/spectrocloud/resource_cluster_edge_native.go
@@ -247,6 +247,13 @@ func resourceClusterEdgeNative() *schema.Resource {
 							Default:     0,
 							Description: "Minimum number of seconds node should be Ready, before the next node is selected for repave. Default value is `0`, Applicable only for worker pools.",
 						},
+						"skip_k8s_upgrade": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							Default:      "disabled",
+							ValidateFunc: validation.StringInSlice([]string{"enabled", "disabled"}, false),
+							Description:  "Skip Kubernetes version upgrade for this worker pool. Use 'enabled' to skip OS/K8s update on profile upgrade (N-3 skew allowed); 'disabled' to upgrade with profile (default). Applicable only for worker pools.",
+						},
 						"update_strategy": {
 							Type:         schema.TypeString,
 							Optional:     true,
@@ -535,6 +542,13 @@ func flattenMachinePoolConfigsEdgeNative(machinePools []*models.V1EdgeNativeMach
 			oi["override_kubeadm_configuration"] = machinePool.OverrideKubeadmConfiguration
 		}
 
+		// Flatten skip_k8s_upgrade (worker pools only); default "disabled" for backward compat when API omits field
+		skipK8sUpgrade := "disabled"
+		if machinePool.SkipK8sUpgrade != nil && *machinePool.SkipK8sUpgrade != "" {
+			skipK8sUpgrade = *machinePool.SkipK8sUpgrade
+		}
+		oi["skip_k8s_upgrade"] = skipK8sUpgrade
+
 		var hosts []interface{}
 		for _, host := range machinePool.Hosts {
 			rawHost := map[string]interface{}{
@@ -821,6 +835,16 @@ func toMachinePoolEdgeNative(machinePool interface{}) (*models.V1EdgeNativeMachi
 		if overrideKubeadm, ok := m["override_kubeadm_configuration"].(string); ok && overrideKubeadm != "" {
 			mp.PoolConfig.OverrideKubeadmConfiguration = overrideKubeadm
 		}
+	}
+
+	// Handle skip_k8s_upgrade (worker pools only); write-path uses the shared
+	// V1MachinePoolConfigEntity.SkipK8sUpgrade field already exposed in the SDK.
+	if !controlPlane {
+		skipK8sUpgrade := "disabled"
+		if v, ok := m["skip_k8s_upgrade"].(string); ok && v != "" {
+			skipK8sUpgrade = v
+		}
+		mp.PoolConfig.SkipK8sUpgrade = &skipK8sUpgrade
 	}
 
 	nodeRepaveInterval := 0

--- a/spectrocloud/resource_cluster_edge_native_test.go
+++ b/spectrocloud/resource_cluster_edge_native_test.go
@@ -432,6 +432,7 @@ func TestFlattenMachinePoolConfigsEdgeNative(t *testing.T) {
 					"control_plane_as_worker": false,
 					"control_plane":           false,
 					"node_repave_interval":    int32(0),
+					"skip_k8s_upgrade":        "disabled",
 					"name":                    "pool1",
 					"edge_host": schema.NewSet(resourceEdgeHostHash, []interface{}{
 						map[string]interface{}{
@@ -461,6 +462,7 @@ func TestFlattenMachinePoolConfigsEdgeNative(t *testing.T) {
 					"control_plane_as_worker": true,
 					"control_plane":           false,
 					"node_repave_interval":    int32(0),
+					"skip_k8s_upgrade":        "disabled",
 					"name":                    "pool2",
 					"edge_host": schema.NewSet(resourceEdgeHostHash, []interface{}{
 						map[string]interface{}{


### PR DESCRIPTION
Closes spectrocloud/terraform-provider-spectrocloud#892
Parent: spectrocloud/luma#68
Target release: Palette 4.9.a

## Summary

Adds the `skip_k8s_upgrade` string attribute (enum `"enabled"|"disabled"`, default `"disabled"`, worker-only) to the `resource_cluster_edge_native` Terraform resource at parity with AWS (landed via PCP-5747).

## Three edit points

Mirrors AWS pattern byte-for-byte:

| Change | Edge-native file:lines | AWS analog |
|---|---|---|
| Schema declaration | `resource_cluster_edge_native.go:250-256` | `resource_cluster_aws.go:269-275` |
| Flatten (read) | `resource_cluster_edge_native.go:545-550` | `resource_cluster_aws.go:566-571` |
| toApi (write) | `resource_cluster_edge_native.go:840-848` | `resource_cluster_aws.go:885-891` |
| Hash compute | `cluster_common_hash.go:663-665` | `cluster_common_hash.go:250` |

Write-side uses `mp.PoolConfig.SkipK8sUpgrade` — the already-existing shared `V1MachinePoolConfigEntity.SkipK8sUpgrade` field (`hapi/models/v1_machine_pool_config_entity.go:72`). No hapi entity edit needed. This is the plan-review Major-3 clarification.

## ⚠ Known build failure (expected, DRAFT until palette-sdk-go regen)

```
spectrocloud/resource_cluster_edge_native.go:547:18: machinePool.SkipK8sUpgrade undefined
  (type *models.V1EdgeNativeMachinePoolConfig has no field or method SkipK8sUpgrade)
```

**Root cause**: TF imports `github.com/spectrocloud/palette-sdk-go` (the generated SDK). The read-side `V1EdgeNativeMachinePoolConfig` does not yet carry `SkipK8sUpgrade`; it will be added when palette-sdk-go is regenerated from hapi#2129 after that PR merges.

**Write-side already compiles** because `V1MachinePoolConfigEntity.SkipK8sUpgrade` (shared entity) is already present in the SDK (landed via PCP-5747 for AWS).

**Unblock sequence**:
1. hapi#2129 merges
2. palette-sdk-go regenerates + tags
3. Rebase this branch, bump `go.mod` pin to the new palette-sdk-go
4. `go build` + tests go green → mark ready for review

## Planning artifacts

- SD: spectrocloud/luma#68
- TD: `plans/PE-8086/plan-terraform-provider-spectrocloud-4.md`
- Plan review: `plans/PE-8086/plan-review-4.md` §3.2 Major-3