### PR TITLE
PLT-2184:Adds a provider feature flag to disable spectrocloud_addon_deployment and manage addon profiles on spectrocloud_cluster_* resources via cluster_profile instead

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -90,6 +90,35 @@ export SPECTROCLOUD_APIKEY=5b7aad.........
 provider "spectrocloud" {}
 ```
 
+## Feature Flags
+
+The provider accepts optional feature flags through the `feature_flag` map argument in the provider block. Unknown keys are ignored.
+
+### disable_addon_deployment_resource
+
+When set to `true`, the provider disallows the [`spectrocloud_addon_deployment`](resources/addon_deployment.md) resource. Any configuration that references this resource fails during `terraform plan` (including refresh) and apply with an error indicating the feature flag is disabled. Defaults to `false`.
+
+`cluster_profile` and `cluster_template` are **mutually exclusive** on `spectrocloud_cluster_*` resources. The provider returns an error if both are set in the same resource.
+
+When this flag is enabled:
+
+- **`cluster_profile` only** — On read, the provider refreshes every profile attached to the cluster from the Palette API into the top-level `cluster_profile` block (including addon profiles previously managed by `spectrocloud_addon_deployment`). Pack and variable fields in state follow what you declare in configuration.
+- **`cluster_template` only** — The provider does **not** modify top-level `cluster_profile`. Profiles are managed inside `cluster_template` (nested `cluster_profile` blocks). Read continues to refresh `cluster_template` variables from the API via the existing template flow.
+- **Neither** — No profile sync from this flag.
+
+To destroy existing addon deployments still in Terraform state, set the flag back to `false`, run `terraform destroy` on those resources, then set the flag to `true` again if you want to keep `spectrocloud_addon_deployment` blocked.
+
+```terraform
+provider "spectrocloud" {
+  host    = var.sc_host
+  api_key = var.sc_api_key
+
+  feature_flag = {
+    disable_addon_deployment_resource = true
+  }
+}
+```
+
 ## Import
 Starting with Terraform v1.5.0 and later, you can use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import resources into your state file.
 
@@ -173,6 +202,7 @@ For questions or issues with the provider, open up an issue in the provider GitH
 ### Optional
 
 - `api_key` (String, Sensitive) The Spectro Cloud API key. Can also be set with the `SPECTROCLOUD_APIKEY` environment variable.
+- `feature_flag` (Map of Boolean) Optional provider feature flags (map of booleans). Unknown keys are ignored. Set `disable_addon_deployment_resource` to `true` to block the `spectrocloud_addon_deployment` resource during plan and apply.
 - `host` (String) The Spectro Cloud API host url. Can also be set with the `SPECTROCLOUD_HOST` environment variable. Defaults to https://api.spectrocloud.com
 - `ignore_insecure_tls_error` (Boolean) Ignore insecure TLS errors for Spectro Cloud API endpoints. ⚠️ WARNING: Setting this to true disables SSL certificate verification and makes connections vulnerable to man-in-the-middle attacks. Only use this in development/testing environments or when connecting to self-signed certificates in trusted networks. Defaults to false.
 - `project_name` (String) The Palette project the provider will target. If no value is provided, the `Default` Palette project is used. The default value is `Default`.

--- a/docs/resources/addon_deployment.md
+++ b/docs/resources/addon_deployment.md
@@ -9,6 +9,8 @@ description: |-
 
   Resource for attaching cluster profiles as addon deployments to an existing cluster.
 
+~> **Provider feature flag:** Set `feature_flag.disable_addon_deployment_resource = true` in the [provider configuration](../index.md#feature-flags) to disallow this resource during plan and apply.
+
 ## Example Usage
 
 ```hcl

--- a/spectrocloud/cluster_common_attachment.go
+++ b/spectrocloud/cluster_common_attachment.go
@@ -102,6 +102,10 @@ func resourceAddonDeploymentStateRefreshFunc(c *client.V1Client, cluster models.
 }
 
 func resourceAddonDeploymentDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	if addonDeploymentResourceDisabled() {
+		return diag.FromErr(addonDeploymentResourceDisabledError())
+	}
+
 	resourceContext := d.Get("context").(string)
 	c := getV1ClientWithResourceContext(m, resourceContext)
 

--- a/spectrocloud/cluster_common_fields.go
+++ b/spectrocloud/cluster_common_fields.go
@@ -138,6 +138,10 @@ func readCommonFields(c *client.V1Client, d *schema.ResourceData, cluster *model
 		}
 	}
 
+	if diags := syncClusterProfilesFromAPIWhenAddonDeploymentDisabled(c, d, cluster); diags.HasError() {
+		return diags, true
+	}
+
 	return diag.Diagnostics{}, false
 }
 

--- a/spectrocloud/cluster_common_profiles.go
+++ b/spectrocloud/cluster_common_profiles.go
@@ -413,71 +413,73 @@ func findAttachedProfileByName(cluster *models.V1SpectroCluster, profileName str
 	return ""
 }
 
-// getProfilesToDelete compares old and new cluster_profile state and returns
-// the UIDs of profiles that need to be deleted (profiles in old state but not in new state).
-// This is necessary when using PATCH since it doesn't automatically remove profiles.
-// Important: This compares by profile NAME, not just ID. If a profile ID changes but the
-// name stays the same (version upgrade), it's NOT a deletion - it's handled by ReplaceWithProfile.
-func getProfilesToDelete(c *client.V1Client, d *schema.ResourceData) []string {
+// isProfileAttachedToCluster reports whether profileUID is attached on the cluster document.
+func isProfileAttachedToCluster(cluster *models.V1SpectroCluster, profileUID string) bool {
+	if cluster == nil || cluster.Spec == nil || profileUID == "" {
+		return false
+	}
+	for _, template := range cluster.Spec.ClusterProfileTemplates {
+		if template != nil && template.UID == profileUID {
+			return true
+		}
+	}
+	return false
+}
+
+// getProfilesToDelete returns profile UIDs to remove from the cluster when they are no longer
+// in Terraform config. Comparison is by UID: an old profile UID that is still attached on the
+// cluster but absent from the new config is deleted via DeleteAddonDeployment.
+//
+// Previously deletion was skipped when another config profile shared the same profile name
+// (treating it as a version upgrade via ReplaceWithProfile). That left duplicate attachments
+// on the cluster when Palette attached a new profile version (new UID, same name) while the
+// old UID was removed from config.
+func getProfilesToDelete(c *client.V1Client, d *schema.ResourceData, cluster *models.V1SpectroCluster) []string {
 	oldProfilesRaw, newProfilesRaw := d.GetChange("cluster_profile")
 	oldProfiles := normalizeInterfaceSliceFromListOrSet(oldProfilesRaw)
 	newProfiles := normalizeInterfaceSliceFromListOrSet(newProfilesRaw)
 
-	// Build a set of new profile NAMES (not just IDs)
-	// This is important: version upgrades change the ID but keep the same name
-	newProfileNames := make(map[string]bool)
-	if len(newProfiles) > 0 {
-		for _, p := range newProfiles {
-			if p == nil {
-				continue
-			}
-			profile := p.(map[string]interface{})
-			if id, ok := profile["id"].(string); ok && id != "" {
-				// Get the profile name from the API
-				clusterProfile, err := c.GetClusterProfile(id)
-				if err != nil {
-					log.Printf("Warning: could not get profile %s to check name: %v", id, err)
-					continue
-				}
-				if clusterProfile != nil && clusterProfile.Metadata != nil {
-					newProfileNames[clusterProfile.Metadata.Name] = true
-				}
-			}
+	newProfileUIDs := make(map[string]bool, len(newProfiles))
+	for _, p := range newProfiles {
+		if p == nil {
+			continue
+		}
+		profile := p.(map[string]interface{})
+		if id, ok := profile["id"].(string); ok && id != "" {
+			newProfileUIDs[id] = true
 		}
 	}
 
-	// Find profiles in old state whose NAME is not in new state
-	// Only these are actual deletions; ID changes with same name are version upgrades
 	var profilesToDelete []string
-	if len(oldProfiles) > 0 {
-		for _, p := range oldProfiles {
-			if p == nil {
-				continue
-			}
-			profile := p.(map[string]interface{})
-			if id, ok := profile["id"].(string); ok && id != "" {
-				// Get the old profile name from the API
-				clusterProfile, err := c.GetClusterProfile(id)
-				if err != nil {
-					log.Printf("Warning: could not get old profile %s to check name: %v", id, err)
-					continue
-				}
-				if clusterProfile != nil && clusterProfile.Metadata != nil {
-					profileName := clusterProfile.Metadata.Name
-					if !newProfileNames[profileName] {
-						if clusterProfile.Spec.Published != nil && clusterProfile.Spec.Published.Type == "infra" {
-							log.Printf("Profile %s (name: %s) is infra - skip delete, will be replaced via PATCH", id, profileName)
-							continue
-						}
-						// This profile name is not in the new state - it's a real deletion
-						log.Printf("Profile %s (name: %s) will be deleted (name removed from cluster_profile)", id, profileName)
-						profilesToDelete = append(profilesToDelete, id)
-					} else {
-						log.Printf("Profile %s (name: %s) ID changed but name still exists - version upgrade, not deletion", id, profileName)
-					}
-				}
-			}
+	for _, p := range oldProfiles {
+		if p == nil {
+			continue
 		}
+		profile := p.(map[string]interface{})
+		oldUID, ok := profile["id"].(string)
+		if !ok || oldUID == "" || newProfileUIDs[oldUID] {
+			continue
+		}
+
+		if !isProfileAttachedToCluster(cluster, oldUID) {
+			log.Printf("Profile %s removed from config but not attached on cluster - skipping API delete", oldUID)
+			continue
+		}
+
+		clusterProfile, err := c.GetClusterProfile(oldUID)
+		if err != nil {
+			log.Printf("Warning: could not get profile %s for delete check: %v", oldUID, err)
+			profilesToDelete = append(profilesToDelete, oldUID)
+			continue
+		}
+		if clusterProfile != nil && clusterProfile.Spec != nil && clusterProfile.Spec.Published != nil &&
+			clusterProfile.Spec.Published.Type == "infra" {
+			log.Printf("Profile %s is infra - skip delete, will be replaced via PATCH", oldUID)
+			continue
+		}
+
+		log.Printf("Profile %s will be deleted (UID removed from cluster_profile but still attached on cluster)", oldUID)
+		profilesToDelete = append(profilesToDelete, oldUID)
 	}
 
 	return profilesToDelete
@@ -486,24 +488,22 @@ func getProfilesToDelete(c *client.V1Client, d *schema.ResourceData) []string {
 func updateProfiles(c *client.V1Client, d *schema.ResourceData) error {
 	log.Printf("Updating cluster_profile (not cluster_template)")
 
-	// Capture old cluster_profile value at the start to restore on any error
-	// This prevents Terraform state from getting out of sync with API when updates fail
+	// Capture old cluster_profile to restore on error (pre-apply snapshot, or API sync when flag is on).
 	oldProfileRaw, _ := d.GetChange("cluster_profile")
 	oldProfile := normalizeInterfaceSliceFromListOrSet(oldProfileRaw)
-	restoreOldProfile := func() {
-		_ = d.Set("cluster_profile", oldProfile)
+	rollbackProfiles := func() {
+		rollbackClusterProfileOnUpdateError(c, d, oldProfile)
 	}
 
 	profiles, err := toAddonDeplProfiles(c, d)
 	var variableEntity []*models.V1SpectroClusterVariableUpdateEntity
 	if err != nil {
-		// Restore old value on error
-		restoreOldProfile()
+		rollbackProfiles()
 		return err
 	}
 	settings, err := toSpcApplySettings(d)
 	if err != nil {
-		restoreOldProfile()
+		rollbackProfiles()
 		return err
 	}
 
@@ -516,14 +516,14 @@ func updateProfiles(c *client.V1Client, d *schema.ResourceData) error {
 	// Handle profile deletions: find profiles that were in old state but not in new state
 	// These need to be explicitly deleted since PATCH doesn't remove profiles
 	if d.HasChange("cluster_profile") {
-		profilesToDelete := getProfilesToDelete(c, d)
+		profilesToDelete := getProfilesToDelete(c, d, cluster)
 		if len(profilesToDelete) > 0 {
 			log.Printf("Deleting %d profiles that were removed from cluster_profile", len(profilesToDelete))
 			deleteBody := &models.V1SpectroClusterProfilesDeleteEntity{
 				ProfileUids: profilesToDelete,
 			}
 			if err := c.DeleteAddonDeployment(d.Id(), deleteBody); err != nil {
-				restoreOldProfile()
+				rollbackProfiles()
 				return fmt.Errorf("failed to delete removed profiles: %w", err)
 			}
 		}
@@ -537,6 +537,7 @@ func updateProfiles(c *client.V1Client, d *schema.ResourceData) error {
 	// Set ReplaceWithProfile for profiles that already exist on the cluster
 	// This ensures PATCH updates existing profiles instead of adding duplicates
 	if err := setReplaceWithProfileForExisting(c, cluster, profiles); err != nil {
+		rollbackProfiles()
 		return fmt.Errorf("failed to resolve profile replacements: %w", err)
 	}
 
@@ -547,9 +548,7 @@ func updateProfiles(c *client.V1Client, d *schema.ResourceData) error {
 	clusterContext := d.Get("context").(string)
 	// Use PATCH instead of PUT to preserve add-on profiles attached via spectrocloud_addon_deployment
 	if err := c.PatchClusterProfileValues(d.Id(), body); err != nil {
-		// Restore old value on API error (e.g., DuplicateClusterPacksForbidden)
-		// This ensures Terraform state stays in sync with actual API state
-		restoreOldProfile()
+		rollbackProfiles()
 		return err
 	}
 
@@ -559,7 +558,7 @@ func updateProfiles(c *client.V1Client, d *schema.ResourceData) error {
 
 	ctx := context.Background()
 	if err := waitForProfileDownload(ctx, c, clusterContext, d.Id(), d.Timeout(schema.TimeoutUpdate)); err != nil {
-		restoreOldProfile()
+		rollbackProfiles()
 		return err
 	}
 
@@ -610,7 +609,7 @@ func updateProfiles(c *client.V1Client, d *schema.ResourceData) error {
 	if len(variableEntity) != 0 {
 		err = c.UpdateClusterProfileVariableInCluster(d.Id(), variableEntity)
 		if err != nil {
-			restoreOldProfile()
+			rollbackProfiles()
 			return err
 		}
 	}
@@ -769,27 +768,57 @@ func shouldSyncClusterProfilesFromAPI(d *schema.ResourceData) bool {
 	return true
 }
 
+// setClusterProfilesFromAPI builds cluster_profile state from the cluster API document and writes it
+// to ResourceData (flatten, variable/pack enrichment, align with config). Used on read and on
+// update rollback when disable_addon_deployment_resource is true.
+func setClusterProfilesFromAPI(c *client.V1Client, d *schema.ResourceData, cluster *models.V1SpectroCluster) error {
+	if cluster == nil {
+		return fmt.Errorf("cluster is required to sync cluster_profile from API")
+	}
+
+	clusterProfiles, err := flattenClusterProfilesFromCluster(cluster)
+	if err != nil {
+		return err
+	}
+	clusterProfiles, err = enrichClusterProfilesWithVariables(c, d, d.Id(), clusterProfiles)
+	if err != nil {
+		return err
+	}
+	clusterProfiles, err = enrichClusterProfilesWithPacks(c, d, cluster, clusterProfiles)
+	if err != nil {
+		return err
+	}
+	alignClusterProfilesStateWithConfig(d, clusterProfiles)
+	return d.Set("cluster_profile", clusterProfiles)
+}
+
+// rollbackClusterProfileOnUpdateError restores cluster_profile after a failed updateProfiles.
+// When shouldSyncClusterProfilesFromAPI is true, re-fetches the cluster and syncs from API so
+// ResourceData reflects Palette (including partial applies). Otherwise restores the pre-apply snapshot.
+func rollbackClusterProfileOnUpdateError(c *client.V1Client, d *schema.ResourceData, oldProfile []interface{}) {
+	if shouldSyncClusterProfilesFromAPI(d) && c != nil && d.Id() != "" {
+		refreshed, err := c.GetCluster(d.Id())
+		if err != nil {
+			log.Printf("Warning: could not refresh cluster for profile rollback from API: %v; restoring pre-apply cluster_profile", err)
+			_ = d.Set("cluster_profile", oldProfile)
+			return
+		}
+		if err := setClusterProfilesFromAPI(c, d, refreshed); err != nil {
+			log.Printf("Warning: could not sync cluster_profile from API on rollback: %v; restoring pre-apply cluster_profile", err)
+			_ = d.Set("cluster_profile", oldProfile)
+		}
+		return
+	}
+	_ = d.Set("cluster_profile", oldProfile)
+}
+
 // syncClusterProfilesFromAPIWhenAddonDeploymentDisabled refreshes cluster_profile from the API during
 // read when disable_addon_deployment_resource is true (addon profiles are owned by the cluster resource).
 func syncClusterProfilesFromAPIWhenAddonDeploymentDisabled(c *client.V1Client, d *schema.ResourceData, cluster *models.V1SpectroCluster) diag.Diagnostics {
 	if !shouldSyncClusterProfilesFromAPI(d) {
 		return nil
 	}
-
-	clusterProfiles, err := flattenClusterProfilesFromCluster(cluster)
-	if err != nil {
-		return diag.FromErr(err)
-	}
-	clusterProfiles, err = enrichClusterProfilesWithVariables(c, d, d.Id(), clusterProfiles)
-	if err != nil {
-		return diag.FromErr(err)
-	}
-	clusterProfiles, err = enrichClusterProfilesWithPacks(c, d, cluster, clusterProfiles)
-	if err != nil {
-		return diag.FromErr(err)
-	}
-	alignClusterProfilesStateWithConfig(d, clusterProfiles)
-	if err := d.Set("cluster_profile", clusterProfiles); err != nil {
+	if err := setClusterProfilesFromAPI(c, d, cluster); err != nil {
 		return diag.FromErr(err)
 	}
 	return nil

--- a/spectrocloud/cluster_common_profiles.go
+++ b/spectrocloud/cluster_common_profiles.go
@@ -355,18 +355,13 @@ func setReplaceWithProfileForExisting(c *client.V1Client, cluster *models.V1Spec
 		}
 		// Check if a profile with the same name is already attached to the cluster
 		existingUID := findAttachedProfileByName(cluster, clusterProfile.Metadata.Name)
-		// Infra swap: if no same-name match but this profile is infra, replace the existing attached infra (different name)
-		if existingUID == "" && clusterProfile.Spec != nil {
-			var profileType string
-			if clusterProfile.Spec.Published != nil {
-				profileType = clusterProfile.Spec.Published.Type
-			}
-			if profileType == "infra" {
-				existingUID = findAttachedProfileByType(cluster, "infra")
-				if existingUID != "" {
-					log.Printf("Profile %s (name: %s) is infra - will replace existing infra %s via PATCH",
-						profile.UID, clusterProfile.Metadata.Name, existingUID)
-				}
+		// Infra swap: if no same-name match but this profile is infra/cluster type, replace the attached infra layer.
+		if existingUID == "" && clusterProfile.Spec != nil && clusterProfile.Spec.Published != nil &&
+			isInfraClusterProfileType(clusterProfile.Spec.Published.Type) {
+			existingUID = findAttachedInfraProfile(cluster)
+			if existingUID != "" {
+				log.Printf("Profile %s (name: %s) is infra - will replace existing infra %s via PATCH",
+					profile.UID, clusterProfile.Metadata.Name, existingUID)
 			}
 		}
 		if existingUID != "" && existingUID != profile.UID {
@@ -383,19 +378,51 @@ func setReplaceWithProfileForExisting(c *client.V1Client, cluster *models.V1Spec
 	return nil
 }
 
-// findAttachedProfileByType returns the UID of the first attached profile with the given type (e.g. "infra").
-// Used when replacing an infra profile with another of a different name.
-func findAttachedProfileByType(cluster *models.V1SpectroCluster, profileType string) string {
-	if cluster == nil || cluster.Spec == nil || profileType == "" {
+// isInfraClusterProfileType reports whether a profile template type is an infra layer (Palette treats
+// both "infra" and "cluster" as infra; EKS profiles commonly use "cluster").
+func isInfraClusterProfileType(profileType string) bool {
+	return profileType == "infra" || profileType == "cluster"
+}
+
+// getAttachedProfileType returns the template type for a profile UID on the cluster, if attached.
+func getAttachedProfileType(cluster *models.V1SpectroCluster, profileUID string) string {
+	if cluster == nil || cluster.Spec == nil || profileUID == "" {
 		return ""
 	}
 	for _, template := range cluster.Spec.ClusterProfileTemplates {
-		if template != nil && template.Type == profileType {
+		if template != nil && template.UID == profileUID {
+			return template.Type
+		}
+	}
+	return ""
+}
+
+// findAttachedInfraProfile returns the UID of the first attached infra/cluster profile on the cluster.
+func findAttachedInfraProfile(cluster *models.V1SpectroCluster) string {
+	if cluster == nil || cluster.Spec == nil {
+		return ""
+	}
+	for _, template := range cluster.Spec.ClusterProfileTemplates {
+		if template != nil && isInfraClusterProfileType(template.Type) {
 			return template.UID
 		}
 	}
 	return ""
 }
+
+// // findAttachedProfileByType returns the UID of the first attached profile with the given type (e.g. "infra").
+// // Used when replacing an infra profile with another of a different name.
+// func findAttachedProfileByType(cluster *models.V1SpectroCluster, profileType string) string {
+// 	if cluster == nil || cluster.Spec == nil || profileType == "" {
+// 		return ""
+// 	}
+// 	for _, template := range cluster.Spec.ClusterProfileTemplates {
+// 		if template != nil && template.Type == profileType {
+// 			return template.UID
+// 		}
+// 	}
+// 	return ""
+// }
 
 // findAttachedProfileByName finds a profile attached to the cluster by its name.
 // Returns the UID of the attached profile if found, empty string otherwise.
@@ -466,16 +493,23 @@ func getProfilesToDelete(c *client.V1Client, d *schema.ResourceData, cluster *mo
 			continue
 		}
 
-		clusterProfile, err := c.GetClusterProfile(oldUID)
-		if err != nil {
-			log.Printf("Warning: could not get profile %s for delete check: %v", oldUID, err)
-			profilesToDelete = append(profilesToDelete, oldUID)
+		if isInfraClusterProfileType(getAttachedProfileType(cluster, oldUID)) {
+			log.Printf("Profile %s is infra/cluster on cluster - skip delete, will be replaced via PATCH", oldUID)
 			continue
 		}
-		if clusterProfile != nil && clusterProfile.Spec != nil && clusterProfile.Spec.Published != nil &&
-			clusterProfile.Spec.Published.Type == "infra" {
-			log.Printf("Profile %s is infra - skip delete, will be replaced via PATCH", oldUID)
-			continue
+
+		if c != nil {
+			clusterProfile, err := c.GetClusterProfile(oldUID)
+			if err != nil {
+				log.Printf("Warning: could not get profile %s for delete check: %v", oldUID, err)
+				profilesToDelete = append(profilesToDelete, oldUID)
+				continue
+			}
+			if clusterProfile != nil && clusterProfile.Spec != nil && clusterProfile.Spec.Published != nil &&
+				isInfraClusterProfileType(clusterProfile.Spec.Published.Type) {
+				log.Printf("Profile %s is infra/cluster profile - skip delete, will be replaced via PATCH", oldUID)
+				continue
+			}
 		}
 
 		log.Printf("Profile %s will be deleted (UID removed from cluster_profile but still attached on cluster)", oldUID)

--- a/spectrocloud/cluster_common_profiles.go
+++ b/spectrocloud/cluster_common_profiles.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
 	"github.com/spectrocloud/palette-sdk-go/api/models"
@@ -618,22 +619,180 @@ func updateProfiles(c *client.V1Client, d *schema.ResourceData) error {
 }
 
 func flattenClusterProfileForImport(c *client.V1Client, d *schema.ResourceData) ([]interface{}, error) {
-	//clusterContext := "project"
-	//if v, ok := d.GetOk("context"); ok {
-	//	clusterContext = v.(string)
-	//}
-	clusterProfiles := make([]interface{}, 0)
 	cluster, err := c.GetCluster(d.Id())
+	if err != nil {
+		return nil, err
+	}
+	clusterProfiles, err := flattenClusterProfilesFromCluster(cluster)
+	if err != nil {
+		return nil, err
+	}
+	clusterProfiles, err = enrichClusterProfilesWithVariables(c, d, d.Id(), clusterProfiles)
+	if err != nil {
+		return nil, err
+	}
+	return enrichClusterProfilesWithPacks(c, d, cluster, clusterProfiles)
+}
+
+// flattenClusterProfilesFromCluster maps every ClusterProfileTemplates entry from the API into
+// cluster_profile state. Used for import and for read refresh when addon deployment is disabled.
+func flattenClusterProfilesFromCluster(cluster *models.V1SpectroCluster) ([]interface{}, error) {
+	clusterProfiles := make([]interface{}, 0)
+	if cluster == nil || cluster.Spec == nil {
+		return clusterProfiles, nil
+	}
+
+	for _, profileTemplate := range cluster.Spec.ClusterProfileTemplates {
+		if profileTemplate == nil || profileTemplate.UID == "" {
+			continue
+		}
+		clusterProfiles = append(clusterProfiles, map[string]interface{}{
+			"id":   profileTemplate.UID,
+			"pack": []interface{}{},
+		})
+	}
+	return clusterProfiles, nil
+}
+
+// enrichClusterProfilesWithPacks attaches pack values from ClusterProfileTemplates when the profile
+// has pack blocks in Terraform config (same pattern as spectrocloud_addon_deployment read).
+func enrichClusterProfilesWithPacks(c *client.V1Client, d *schema.ResourceData, cluster *models.V1SpectroCluster, clusterProfiles []interface{}) ([]interface{}, error) {
+	if c == nil || cluster == nil || cluster.Spec == nil || len(clusterProfiles) == 0 {
+		return clusterProfiles, nil
+	}
+
+	templateByUID := make(map[string]*models.V1ClusterProfileTemplate, len(cluster.Spec.ClusterProfileTemplates))
+	for _, template := range cluster.Spec.ClusterProfileTemplates {
+		if template != nil && template.UID != "" {
+			templateByUID[template.UID] = template
+		}
+	}
+
+	registryNameMap := buildPackRegistryNameMapFromClusterProfiles(d)
+	registryUIDMap := buildPackRegistryUIDMapFromClusterProfiles(d)
+
+	for i := range clusterProfiles {
+		p := clusterProfiles[i].(map[string]interface{})
+		uid, ok := p["id"].(string)
+		if !ok || uid == "" || !clusterProfileHasPacksInConfig(d, uid) {
+			continue
+		}
+
+		template, ok := templateByUID[uid]
+		if !ok || len(template.Packs) == 0 {
+			continue
+		}
+
+		packManifests, packDiags, done := getPacksContent(template.Packs, c, d)
+		if done {
+			if len(packDiags) > 0 {
+				return clusterProfiles, fmt.Errorf("%s: %s", packDiags[0].Summary, packDiags[0].Detail)
+			}
+			return clusterProfiles, errors.New("failed to read pack manifest content")
+		}
+
+		packs, err := flattenPacksWithRegistryMaps(c, nil, template.Packs, packManifests, registryNameMap, registryUIDMap)
+		if err != nil {
+			return clusterProfiles, err
+		}
+		configPacks := getClusterProfilePacksFromConfig(d, uid)
+		for j := range packs {
+			pack, ok := packs[j].(map[string]interface{})
+			if !ok {
+				continue
+			}
+			name, _ := pack["name"].(string)
+			alignPackStateWithConfig(pack, findConfigPackByName(configPacks, name))
+			packs[j] = pack
+		}
+		p["pack"] = packs
+	}
+
+	return clusterProfiles, nil
+}
+
+// enrichClusterProfilesWithVariables attaches cluster profile variables from the Palette API so
+// refreshed state matches what Terraform config expects (avoids spurious cluster_profile changes).
+func enrichClusterProfilesWithVariables(c *client.V1Client, d *schema.ResourceData, clusterUID string, clusterProfiles []interface{}) ([]interface{}, error) {
+	if c == nil || len(clusterProfiles) == 0 {
+		return clusterProfiles, nil
+	}
+
+	clusterVars, err := c.GetClusterVariables(clusterUID)
 	if err != nil {
 		return clusterProfiles, err
 	}
 
-	for _, profileTemplate := range cluster.Spec.ClusterProfileTemplates {
-		profile := make(map[string]interface{})
-		profile["id"] = profileTemplate.UID
-		clusterProfiles = append(clusterProfiles, profile)
+	profileVariablesMap := make(map[string]map[string]interface{})
+	for _, cv := range clusterVars {
+		if cv.ProfileUID == nil || cv.Variables == nil {
+			continue
+		}
+		vars := make(map[string]interface{})
+		for _, v := range cv.Variables {
+			if v.Name != nil && v.Value != "" {
+				vars[*v.Name] = v.Value
+			}
+		}
+		if len(vars) > 0 {
+			profileVariablesMap[*cv.ProfileUID] = vars
+		}
 	}
+
+	for i := range clusterProfiles {
+		p := clusterProfiles[i].(map[string]interface{})
+		uid, ok := p["id"].(string)
+		if !ok || uid == "" {
+			continue
+		}
+		if vars, has := profileVariablesMap[uid]; has && len(vars) > 0 {
+			p["variables"] = vars
+		} else if clusterProfileHasVariablesInConfig(d, uid) {
+			p["variables"] = map[string]interface{}{}
+		} else {
+			delete(p, "variables")
+		}
+	}
+
 	return clusterProfiles, nil
+}
+
+func shouldSyncClusterProfilesFromAPI(d *schema.ResourceData) bool {
+	if !addonDeploymentResourceDisabled() {
+		return false
+	}
+	if raw := d.Get("cluster_template"); raw != nil {
+		if list, ok := raw.([]interface{}); ok && len(list) > 0 {
+			return false
+		}
+	}
+	return true
+}
+
+// syncClusterProfilesFromAPIWhenAddonDeploymentDisabled refreshes cluster_profile from the API during
+// read when disable_addon_deployment_resource is true (addon profiles are owned by the cluster resource).
+func syncClusterProfilesFromAPIWhenAddonDeploymentDisabled(c *client.V1Client, d *schema.ResourceData, cluster *models.V1SpectroCluster) diag.Diagnostics {
+	if !shouldSyncClusterProfilesFromAPI(d) {
+		return nil
+	}
+
+	clusterProfiles, err := flattenClusterProfilesFromCluster(cluster)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	clusterProfiles, err = enrichClusterProfilesWithVariables(c, d, d.Id(), clusterProfiles)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	clusterProfiles, err = enrichClusterProfilesWithPacks(c, d, cluster, clusterProfiles)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	alignClusterProfilesStateWithConfig(d, clusterProfiles)
+	if err := d.Set("cluster_profile", clusterProfiles); err != nil {
+		return diag.FromErr(err)
+	}
+	return nil
 }
 
 // toClusterTemplateReference extracts cluster template reference from ResourceData

--- a/spectrocloud/cluster_common_profiles_delete_test.go
+++ b/spectrocloud/cluster_common_profiles_delete_test.go
@@ -1,0 +1,49 @@
+package spectrocloud
+
+import (
+	"testing"
+
+	"github.com/spectrocloud/palette-sdk-go/api/models"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsProfileAttachedToCluster(t *testing.T) {
+	cluster := &models.V1SpectroCluster{
+		Spec: &models.V1SpectroClusterSpec{
+			ClusterProfileTemplates: []*models.V1ClusterProfileTemplate{
+				{UID: "profile-old", Name: "monitoring"},
+				{UID: "profile-new", Name: "monitoring"},
+				{UID: "profile-base", Name: "base"},
+			},
+		},
+	}
+
+	assert.True(t, isProfileAttachedToCluster(cluster, "profile-old"))
+	assert.True(t, isProfileAttachedToCluster(cluster, "profile-new"))
+	assert.False(t, isProfileAttachedToCluster(cluster, "profile-stale-state-only"))
+}
+
+func TestGetProfilesToDeleteUIDNotSkippedForSameName(t *testing.T) {
+	// Documents the AKS/UI corner case: old UID still on cluster, new UID in config, same profile name.
+	oldUID := "6a0c2a821d2aa718e3836f1a"
+	newUID := "6a0c2a579caf38df9cc3e290"
+
+	newProfileUIDs := map[string]bool{
+		"6a06b7162bc7f49b5b6140f3": true,
+		newUID:                     true,
+	}
+
+	cluster := &models.V1SpectroCluster{
+		Spec: &models.V1SpectroClusterSpec{
+			ClusterProfileTemplates: []*models.V1ClusterProfileTemplate{
+				{UID: oldUID, Name: "addon-profile"},
+				{UID: newUID, Name: "addon-profile"},
+				{UID: "6a06b7162bc7f49b5b6140f3", Name: "base"},
+			},
+		},
+	}
+
+	assert.False(t, newProfileUIDs[oldUID])
+	assert.True(t, isProfileAttachedToCluster(cluster, oldUID))
+	// Name-based logic treated this as a version upgrade and skipped API delete; UID-based delete includes oldUID.
+}

--- a/spectrocloud/cluster_common_profiles_delete_test.go
+++ b/spectrocloud/cluster_common_profiles_delete_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/spectrocloud/palette-sdk-go/api/models"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestIsProfileAttachedToCluster(t *testing.T) {
@@ -23,27 +24,74 @@ func TestIsProfileAttachedToCluster(t *testing.T) {
 	assert.False(t, isProfileAttachedToCluster(cluster, "profile-stale-state-only"))
 }
 
-func TestGetProfilesToDeleteUIDNotSkippedForSameName(t *testing.T) {
-	// Documents the AKS/UI corner case: old UID still on cluster, new UID in config, same profile name.
-	oldUID := "6a0c2a821d2aa718e3836f1a"
-	newUID := "6a0c2a579caf38df9cc3e290"
+func TestIsInfraClusterProfileType(t *testing.T) {
+	assert.True(t, isInfraClusterProfileType("infra"))
+	assert.True(t, isInfraClusterProfileType("cluster"))
+	assert.False(t, isInfraClusterProfileType("addon"))
+	assert.False(t, isInfraClusterProfileType(""))
+}
 
-	newProfileUIDs := map[string]bool{
-		"6a06b7162bc7f49b5b6140f3": true,
-		newUID:                     true,
+func TestFindAttachedInfraProfile(t *testing.T) {
+	cluster := &models.V1SpectroCluster{
+		Spec: &models.V1SpectroClusterSpec{
+			ClusterProfileTemplates: []*models.V1ClusterProfileTemplate{
+				{UID: "addon-1", Type: "addon", Name: "monitoring"},
+				{UID: "old-infra", Type: "cluster", Name: "eks-infra-old"},
+			},
+		},
 	}
+	assert.Equal(t, "old-infra", findAttachedInfraProfile(cluster))
+}
+
+func TestGetProfilesToDeleteSkipsClusterTypeInfra(t *testing.T) {
+	oldInfraUID := "6a0de2794ffb1a5d43004cb3"
+	newInfraUID := "6a0de28515e92045e165656c"
+	addonUID := "6a0de2000000000000000001"
 
 	cluster := &models.V1SpectroCluster{
 		Spec: &models.V1SpectroClusterSpec{
 			ClusterProfileTemplates: []*models.V1ClusterProfileTemplate{
-				{UID: oldUID, Name: "addon-profile"},
-				{UID: newUID, Name: "addon-profile"},
-				{UID: "6a06b7162bc7f49b5b6140f3", Name: "base"},
+				{UID: oldInfraUID, Type: "cluster", Name: "eks-infra-old"},
+				{UID: addonUID, Type: "addon", Name: "addon-profile"},
 			},
 		},
 	}
 
-	assert.False(t, newProfileUIDs[oldUID])
+	r := resourceClusterEks()
+	d := r.TestResourceData()
+	_ = d.Set("cluster_profile", []interface{}{
+		map[string]interface{}{"id": newInfraUID},
+		map[string]interface{}{"id": addonUID},
+	})
+
+	// Simulate state change: old infra + addon -> new infra + addon
+	require.NoError(t, d.Set("cluster_profile", []interface{}{
+		map[string]interface{}{"id": oldInfraUID, "variables": map[string]interface{}{}},
+		map[string]interface{}{"id": addonUID},
+	}))
+	require.NoError(t, d.Set("cluster_profile", []interface{}{
+		map[string]interface{}{"id": newInfraUID},
+		map[string]interface{}{"id": addonUID},
+	}))
+
+	toDelete := getProfilesToDelete(nil, d, cluster)
+	assert.NotContains(t, toDelete, oldInfraUID, "infra/cluster profile must not be deleted; use PATCH replace")
+}
+
+func TestGetProfilesToDeleteUIDNotSkippedForSameNameAddon(t *testing.T) {
+	oldUID := "6a0c2a821d2aa718e3836f1a"
+	newUID := "6a0c2a579caf38df9cc3e290"
+
+	cluster := &models.V1SpectroCluster{
+		Spec: &models.V1SpectroClusterSpec{
+			ClusterProfileTemplates: []*models.V1ClusterProfileTemplate{
+				{UID: oldUID, Name: "addon-profile", Type: "addon"},
+				{UID: newUID, Name: "addon-profile", Type: "addon"},
+				{UID: "6a06b7162bc7f49b5b6140f3", Name: "base", Type: "cluster"},
+			},
+		},
+	}
+
+	assert.False(t, isInfraClusterProfileType(getAttachedProfileType(cluster, oldUID)))
 	assert.True(t, isProfileAttachedToCluster(cluster, oldUID))
-	// Name-based logic treated this as a version upgrade and skipped API delete; UID-based delete includes oldUID.
 }

--- a/spectrocloud/cluster_common_profiles_feature_flag_test.go
+++ b/spectrocloud/cluster_common_profiles_feature_flag_test.go
@@ -156,3 +156,83 @@ func TestSyncClusterProfilesFromAPIWhenAddonDeploymentDisabled(t *testing.T) {
 	require.Len(t, profiles, 1)
 	assert.Equal(t, "profile-from-api", profiles[0].(map[string]interface{})["id"])
 }
+
+func TestSetClusterProfilesFromAPI(t *testing.T) {
+	r := resourceClusterEks()
+	d := r.TestResourceData()
+	d.SetId("cluster-1")
+
+	cluster := &models.V1SpectroCluster{
+		Spec: &models.V1SpectroClusterSpec{
+			ClusterProfileTemplates: []*models.V1ClusterProfileTemplate{
+				{UID: "api-profile-a"},
+				{UID: "api-profile-b"},
+			},
+		},
+	}
+
+	err := setClusterProfilesFromAPI(nil, d, cluster)
+	require.NoError(t, err)
+
+	profiles := normalizeInterfaceSliceFromListOrSet(d.Get("cluster_profile"))
+	require.Len(t, profiles, 2)
+}
+
+func TestRollbackClusterProfileOnUpdateError(t *testing.T) {
+	t.Cleanup(func() {
+		disableAddonDeploymentResource = false
+	})
+
+	r := resourceClusterEks()
+	oldProfile := []interface{}{
+		map[string]interface{}{"id": "pre-apply-profile"},
+	}
+
+	t.Run("flag off restores pre-apply snapshot", func(t *testing.T) {
+		disableAddonDeploymentResource = false
+		d := r.TestResourceData()
+		d.SetId("cluster-1")
+		_ = d.Set("cluster_profile", []interface{}{
+			map[string]interface{}{"id": "failed-desired-profile"},
+		})
+
+		rollbackClusterProfileOnUpdateError(nil, d, oldProfile)
+
+		profiles := normalizeInterfaceSliceFromListOrSet(d.Get("cluster_profile"))
+		require.Len(t, profiles, 1)
+		assert.Equal(t, "pre-apply-profile", profiles[0].(map[string]interface{})["id"])
+	})
+
+	t.Run("flag on without client falls back to pre-apply snapshot", func(t *testing.T) {
+		disableAddonDeploymentResource = true
+		d := r.TestResourceData()
+		d.SetId("cluster-1")
+		_ = d.Set("cluster_profile", []interface{}{
+			map[string]interface{}{"id": "failed-desired-profile"},
+		})
+
+		rollbackClusterProfileOnUpdateError(nil, d, oldProfile)
+
+		profiles := normalizeInterfaceSliceFromListOrSet(d.Get("cluster_profile"))
+		require.Len(t, profiles, 1)
+		assert.Equal(t, "pre-apply-profile", profiles[0].(map[string]interface{})["id"])
+	})
+
+	t.Run("flag on with cluster_template restores pre-apply snapshot", func(t *testing.T) {
+		disableAddonDeploymentResource = true
+		d := r.TestResourceData()
+		d.SetId("cluster-1")
+		_ = d.Set("cluster_template", []interface{}{
+			map[string]interface{}{"id": "template-1"},
+		})
+		_ = d.Set("cluster_profile", []interface{}{
+			map[string]interface{}{"id": "failed-desired-profile"},
+		})
+
+		rollbackClusterProfileOnUpdateError(nil, d, oldProfile)
+
+		profiles := normalizeInterfaceSliceFromListOrSet(d.Get("cluster_profile"))
+		require.Len(t, profiles, 1)
+		assert.Equal(t, "pre-apply-profile", profiles[0].(map[string]interface{})["id"])
+	})
+}

--- a/spectrocloud/cluster_common_profiles_feature_flag_test.go
+++ b/spectrocloud/cluster_common_profiles_feature_flag_test.go
@@ -1,0 +1,158 @@
+package spectrocloud
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/spectrocloud/palette-sdk-go/api/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFlattenClusterProfilesFromCluster(t *testing.T) {
+	cluster := &models.V1SpectroCluster{
+		Spec: &models.V1SpectroClusterSpec{
+			ClusterProfileTemplates: []*models.V1ClusterProfileTemplate{
+				{UID: "profile-a"},
+				{UID: "profile-b"},
+				nil,
+				{UID: ""},
+			},
+		},
+	}
+
+	profiles, err := flattenClusterProfilesFromCluster(cluster)
+	require.NoError(t, err)
+	require.Len(t, profiles, 2)
+	assert.Equal(t, "profile-a", profiles[0].(map[string]interface{})["id"])
+	_, hasVariables := profiles[0].(map[string]interface{})["variables"]
+	assert.False(t, hasVariables)
+	assert.Equal(t, []interface{}{}, profiles[0].(map[string]interface{})["pack"])
+	assert.Equal(t, "profile-b", profiles[1].(map[string]interface{})["id"])
+	_, hasVariables = profiles[1].(map[string]interface{})["variables"]
+	assert.False(t, hasVariables)
+	assert.Equal(t, []interface{}{}, profiles[1].(map[string]interface{})["pack"])
+}
+
+func TestAlignPackStateWithConfig(t *testing.T) {
+	flattened := map[string]interface{}{
+		"name":   "heartbeat",
+		"tag":    "1.0.0",
+		"type":   "spectro",
+		"uid":    "6023f4ff4fdd7f7047756474",
+		"values": "test",
+	}
+
+	t.Run("strips uid and type when omitted from config", func(t *testing.T) {
+		pack := copyPackMap(flattened)
+		alignPackStateWithConfig(pack, map[string]interface{}{
+			"name": "heartbeat",
+			"tag":  "1.0.0",
+		})
+		_, hasUID := pack["uid"]
+		_, hasType := pack["type"]
+		assert.False(t, hasUID)
+		assert.False(t, hasType)
+		assert.Equal(t, "heartbeat", pack["name"])
+	})
+
+	t.Run("keeps uid and type when present in config", func(t *testing.T) {
+		pack := copyPackMap(flattened)
+		alignPackStateWithConfig(pack, map[string]interface{}{
+			"name": "heartbeat",
+			"tag":  "1.0.0",
+			"type": "spectro",
+			"uid":  "6023f4ff4fdd7f7047756474",
+		})
+		assert.Equal(t, "6023f4ff4fdd7f7047756474", pack["uid"])
+		assert.Equal(t, "spectro", pack["type"])
+	})
+}
+
+func copyPackMap(src map[string]interface{}) map[string]interface{} {
+	dst := make(map[string]interface{}, len(src))
+	for k, v := range src {
+		dst[k] = v
+	}
+	return dst
+}
+
+func TestShouldSyncClusterProfilesFromAPI(t *testing.T) {
+	t.Cleanup(func() {
+		disableAddonDeploymentResource = false
+	})
+
+	baseSchema := &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"cluster_profile": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {Type: schema.TypeString, Required: true},
+					},
+				},
+			},
+			"cluster_template": {
+				Type:     schema.TypeList,
+				Optional: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {Type: schema.TypeString, Required: true},
+					},
+				},
+			},
+		},
+	}
+
+	t.Run("false when feature flag is off", func(t *testing.T) {
+		disableAddonDeploymentResource = false
+		d := baseSchema.TestResourceData()
+		assert.False(t, shouldSyncClusterProfilesFromAPI(d))
+	})
+
+	t.Run("true when feature flag is on and cluster_template is not used", func(t *testing.T) {
+		disableAddonDeploymentResource = true
+		d := baseSchema.TestResourceData()
+		assert.True(t, shouldSyncClusterProfilesFromAPI(d))
+	})
+
+	t.Run("false when feature flag is on but cluster_template is set", func(t *testing.T) {
+		disableAddonDeploymentResource = true
+		d := baseSchema.TestResourceData()
+		_ = d.Set("cluster_template", []interface{}{
+			map[string]interface{}{"id": "template-1"},
+		})
+		assert.False(t, shouldSyncClusterProfilesFromAPI(d))
+	})
+}
+
+func TestSyncClusterProfilesFromAPIWhenAddonDeploymentDisabled(t *testing.T) {
+	t.Cleanup(func() {
+		disableAddonDeploymentResource = false
+	})
+	disableAddonDeploymentResource = true
+
+	r := resourceClusterEks()
+	d := r.TestResourceData()
+	d.SetId("cluster-1")
+	_ = d.Set("cluster_profile", []interface{}{
+		map[string]interface{}{"id": "old-profile"},
+	})
+
+	cluster := &models.V1SpectroCluster{
+		Spec: &models.V1SpectroClusterSpec{
+			ClusterProfileTemplates: []*models.V1ClusterProfileTemplate{
+				{UID: "profile-from-api"},
+			},
+		},
+	}
+
+	diags := syncClusterProfilesFromAPIWhenAddonDeploymentDisabled(nil, d, cluster)
+	require.Empty(t, diags)
+
+	profiles := normalizeInterfaceSliceFromListOrSet(d.Get("cluster_profile"))
+	require.Len(t, profiles, 1)
+	assert.Equal(t, "profile-from-api", profiles[0].(map[string]interface{})["id"])
+}

--- a/spectrocloud/common_cluster_profile.go
+++ b/spectrocloud/common_cluster_profile.go
@@ -73,6 +73,162 @@ func flattenPacksWithRegistryMaps(c *client.V1Client, diagPacks []*models.V1Pack
 	return ps, nil
 }
 
+// buildPackRegistryNameMapFromClusterProfiles creates a map of pack names that use registry_name
+// from nested cluster_profile blocks on cluster resources.
+func buildPackRegistryNameMapFromClusterProfiles(d *schema.ResourceData) map[string]bool {
+	registryNameMap := make(map[string]bool)
+	for _, profile := range normalizeInterfaceSliceFromListOrSet(d.Get("cluster_profile")) {
+		profileMap := profile.(map[string]interface{})
+		packs, ok := profileMap["pack"].([]interface{})
+		if !ok {
+			continue
+		}
+		for _, packInterface := range packs {
+			pack := packInterface.(map[string]interface{})
+			packName := pack["name"].(string)
+			if registryName, ok := pack["registry_name"]; ok && registryName != nil && registryName.(string) != "" {
+				registryNameMap[packName] = true
+			}
+		}
+	}
+	return registryNameMap
+}
+
+// buildPackRegistryUIDMapFromClusterProfiles creates a map of pack names that use registry_uid
+// from nested cluster_profile blocks on cluster resources.
+func buildPackRegistryUIDMapFromClusterProfiles(d *schema.ResourceData) map[string]bool {
+	registryUIDMap := make(map[string]bool)
+	for _, profile := range normalizeInterfaceSliceFromListOrSet(d.Get("cluster_profile")) {
+		profileMap := profile.(map[string]interface{})
+		packs, ok := profileMap["pack"].([]interface{})
+		if !ok {
+			continue
+		}
+		for _, packInterface := range packs {
+			pack := packInterface.(map[string]interface{})
+			packName := pack["name"].(string)
+			if registryUID, ok := pack["registry_uid"]; ok && registryUID != nil && registryUID.(string) != "" {
+				registryUIDMap[packName] = true
+			}
+		}
+	}
+	return registryUIDMap
+}
+
+// clusterProfileHasVariablesInConfig reports whether variables are declared for a profile in config.
+func clusterProfileHasVariablesInConfig(d *schema.ResourceData, profileUID string) bool {
+	for _, profile := range normalizeInterfaceSliceFromListOrSet(d.Get("cluster_profile")) {
+		profileMap := profile.(map[string]interface{})
+		id, ok := profileMap["id"].(string)
+		if !ok || id != profileUID {
+			continue
+		}
+		_, ok = profileMap["variables"]
+		return ok
+	}
+	return false
+}
+
+// getClusterProfilePacksFromConfig returns pack blocks configured for a profile UID.
+func getClusterProfilePacksFromConfig(d *schema.ResourceData, profileUID string) []interface{} {
+	for _, profile := range normalizeInterfaceSliceFromListOrSet(d.Get("cluster_profile")) {
+		profileMap := profile.(map[string]interface{})
+		id, ok := profileMap["id"].(string)
+		if !ok || id != profileUID {
+			continue
+		}
+		if packs, ok := profileMap["pack"].([]interface{}); ok {
+			return packs
+		}
+		return nil
+	}
+	return nil
+}
+
+func findConfigPackByName(configPacks []interface{}, name string) map[string]interface{} {
+	for _, packRaw := range configPacks {
+		pack, ok := packRaw.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		if packName, ok := pack["name"].(string); ok && packName == name {
+			return pack
+		}
+	}
+	return nil
+}
+
+// alignPackStateWithConfig limits flattened pack state to fields the user declared in config.
+// API read populates computed attributes (uid, type); omitting them from state when absent in
+// config keeps cluster_profile TypeSet hashes aligned and avoids perpetual drift.
+func alignPackStateWithConfig(pack map[string]interface{}, configPack map[string]interface{}) {
+	if configPack == nil {
+		delete(pack, "uid")
+		delete(pack, "type")
+		delete(pack, "registry_uid")
+		delete(pack, "registry_name")
+		delete(pack, "manifest")
+		return
+	}
+
+	for _, field := range []string{"uid", "type", "registry_uid", "registry_name"} {
+		if v, ok := configPack[field]; !ok || v == nil || v == "" {
+			delete(pack, field)
+		} else {
+			pack[field] = v
+		}
+	}
+
+	if _, ok := configPack["manifest"]; !ok {
+		delete(pack, "manifest")
+	}
+}
+
+// alignClusterProfilesStateWithConfig aligns refreshed profile state with config field presence.
+func alignClusterProfilesStateWithConfig(d *schema.ResourceData, clusterProfiles []interface{}) {
+	for i := range clusterProfiles {
+		p := clusterProfiles[i].(map[string]interface{})
+		uid, ok := p["id"].(string)
+		if !ok || uid == "" {
+			continue
+		}
+
+		if !clusterProfileHasVariablesInConfig(d, uid) {
+			delete(p, "variables")
+		}
+
+		packs, ok := p["pack"].([]interface{})
+		if !ok {
+			continue
+		}
+		configPacks := getClusterProfilePacksFromConfig(d, uid)
+		for j := range packs {
+			pack, ok := packs[j].(map[string]interface{})
+			if !ok {
+				continue
+			}
+			name, _ := pack["name"].(string)
+			alignPackStateWithConfig(pack, findConfigPackByName(configPacks, name))
+			packs[j] = pack
+		}
+		p["pack"] = packs
+	}
+}
+
+// clusterProfileHasPacksInConfig reports whether the given profile UID has pack blocks in config.
+func clusterProfileHasPacksInConfig(d *schema.ResourceData, profileUID string) bool {
+	for _, profile := range normalizeInterfaceSliceFromListOrSet(d.Get("cluster_profile")) {
+		profileMap := profile.(map[string]interface{})
+		id, ok := profileMap["id"].(string)
+		if !ok || id != profileUID {
+			continue
+		}
+		packs, ok := profileMap["pack"].([]interface{})
+		return ok && len(packs) > 0
+	}
+	return false
+}
+
 // buildPackRegistryNameMap creates a map indicating which packs use registry_name
 // by directly checking the resource data
 func buildPackRegistryNameMap(d *schema.ResourceData) map[string]bool {

--- a/spectrocloud/feature_flag.go
+++ b/spectrocloud/feature_flag.go
@@ -1,0 +1,43 @@
+package spectrocloud
+
+import (
+	"errors"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+const featureFlagDisableAddonDeploymentResource = "disable_addon_deployment_resource"
+
+// disableAddonDeploymentResource is set from provider feature_flag configuration.
+var disableAddonDeploymentResource bool
+
+const addonDeploymentResourceDisabledMessage = "spectrocloud_addon_deployment is disabled by provider feature flag " +
+	"`disable_addon_deployment_resource`. Remove this resource from configuration or set the flag to false."
+
+func configureFeatureFlags(d *schema.ResourceData) {
+	disableAddonDeploymentResource = false
+
+	raw, ok := d.GetOk("feature_flag")
+	if !ok {
+		return
+	}
+
+	flags, ok := raw.(map[string]interface{})
+	if !ok {
+		return
+	}
+
+	if v, ok := flags[featureFlagDisableAddonDeploymentResource]; ok {
+		if disabled, ok := v.(bool); ok {
+			disableAddonDeploymentResource = disabled
+		}
+	}
+}
+
+func addonDeploymentResourceDisabled() bool {
+	return disableAddonDeploymentResource
+}
+
+func addonDeploymentResourceDisabledError() error {
+	return errors.New(addonDeploymentResourceDisabledMessage)
+}

--- a/spectrocloud/feature_flag_test.go
+++ b/spectrocloud/feature_flag_test.go
@@ -1,0 +1,75 @@
+package spectrocloud
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConfigureFeatureFlags(t *testing.T) {
+	t.Cleanup(func() {
+		disableAddonDeploymentResource = false
+	})
+
+	t.Run("defaults to disabled flag false", func(t *testing.T) {
+		d := prepareProviderConfigWithFeatureFlags(nil)
+		configureFeatureFlags(d)
+		assert.False(t, disableAddonDeploymentResource)
+	})
+
+	t.Run("enables disable_addon_deployment_resource", func(t *testing.T) {
+		d := prepareProviderConfigWithFeatureFlags(map[string]interface{}{
+			featureFlagDisableAddonDeploymentResource: true,
+		})
+		configureFeatureFlags(d)
+		assert.True(t, disableAddonDeploymentResource)
+	})
+
+	t.Run("ignores unknown feature flags", func(t *testing.T) {
+		d := prepareProviderConfigWithFeatureFlags(map[string]interface{}{
+			"future_flag": true,
+		})
+		configureFeatureFlags(d)
+		assert.False(t, disableAddonDeploymentResource)
+	})
+
+	t.Run("provider configure resets flag when omitted", func(t *testing.T) {
+		disableAddonDeploymentResource = true
+		d := prepareBaseProviderConfig()
+		configureFeatureFlags(d)
+		assert.False(t, disableAddonDeploymentResource)
+	})
+}
+
+func TestAddonDeploymentBlockedByFeatureFlag(t *testing.T) {
+	t.Cleanup(func() {
+		disableAddonDeploymentResource = false
+	})
+	disableAddonDeploymentResource = true
+
+	d := prepareAddonDeploymentTestData("cluster-123_profile-1")
+	require.NotNil(t, d)
+
+	err := resourceAddonDeploymentCustomizeDiff(context.Background(), nil, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), featureFlagDisableAddonDeploymentResource)
+
+	diags := resourceAddonDeploymentRead(context.Background(), d, unitTestMockAPIClient)
+	assert.NotEmpty(t, diags)
+	assert.Contains(t, diags[0].Summary+diags[0].Detail, featureFlagDisableAddonDeploymentResource)
+
+	diags = resourceAddonDeploymentDelete(context.Background(), d, unitTestMockAPIClient)
+	assert.NotEmpty(t, diags)
+	assert.Contains(t, diags[0].Summary+diags[0].Detail, featureFlagDisableAddonDeploymentResource)
+}
+
+func prepareProviderConfigWithFeatureFlags(flags map[string]interface{}) *schema.ResourceData {
+	d := prepareBaseProviderConfig()
+	if flags != nil {
+		_ = d.Set("feature_flag", flags)
+	}
+	return d
+}

--- a/spectrocloud/provider.go
+++ b/spectrocloud/provider.go
@@ -62,6 +62,15 @@ func New(_ string) func() *schema.Provider {
 					Optional:    true,
 					Description: "Ignore insecure TLS errors for Spectro Cloud API endpoints. ⚠️ WARNING: Setting this to true disables SSL certificate verification and makes connections vulnerable to man-in-the-middle attacks. Only use this in development/testing environments or when connecting to self-signed certificates in trusted networks. Defaults to false.",
 				},
+				"feature_flag": {
+					Type:     schema.TypeMap,
+					Optional: true,
+					Elem: &schema.Schema{
+						Type: schema.TypeBool,
+					},
+					Description: "Optional provider feature flags (map of booleans). Unknown keys are ignored. " +
+						"Set `disable_addon_deployment_resource` to `true` to block the `spectrocloud_addon_deployment` resource during plan and apply.",
+				},
 			},
 			ResourcesMap: map[string]*schema.Resource{
 				"spectrocloud_team": resourceTeam(),
@@ -205,6 +214,8 @@ func New(_ string) func() *schema.Provider {
 
 func providerConfigure(ctx context.Context, d *schema.ResourceData) (interface{}, diag.Diagnostics) {
 	var diags diag.Diagnostics
+
+	configureFeatureFlags(d)
 
 	host := d.Get("host").(string)
 	projectName := d.Get("project_name").(string)

--- a/spectrocloud/provider_test.go
+++ b/spectrocloud/provider_test.go
@@ -59,6 +59,13 @@ func prepareBaseProviderConfig() *schema.ResourceData {
 				Optional:    true,
 				Description: "Ignore insecure TLS errors for Spectro Cloud API endpoints. Defaults to false.",
 			},
+			"feature_flag": {
+				Type:     schema.TypeMap,
+				Optional: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeBool,
+				},
+			},
 		},
 	}
 

--- a/spectrocloud/resource_cluster_attachment.go
+++ b/spectrocloud/resource_cluster_attachment.go
@@ -24,6 +24,7 @@ func resourceAddonDeployment() *schema.Resource {
 		ReadContext:   resourceAddonDeploymentRead,
 		UpdateContext: resourceAddonDeploymentUpdate,
 		DeleteContext: resourceAddonDeploymentDelete,
+		CustomizeDiff: resourceAddonDeploymentCustomizeDiff,
 		Description:   "Resource for attaching cluster profiles as addon deployments to an existing cluster.",
 
 		Timeouts: &schema.ResourceTimeout{
@@ -68,7 +69,18 @@ func resourceAddonDeployment() *schema.Resource {
 	}
 }
 
+func resourceAddonDeploymentCustomizeDiff(_ context.Context, _ *schema.ResourceDiff, _ interface{}) error {
+	if addonDeploymentResourceDisabled() {
+		return addonDeploymentResourceDisabledError()
+	}
+	return nil
+}
+
 func resourceAddonDeploymentStateUpgradeV2(ctx context.Context, rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
+	if addonDeploymentResourceDisabled() {
+		return nil, addonDeploymentResourceDisabledError()
+	}
+
 	log.Printf("[DEBUG] Upgrading addon deployment state from version 2 to 3")
 
 	// Convert cluster_profile from TypeList (v2) to TypeSet (v3).
@@ -104,6 +116,10 @@ func validateSingleClusterProfile(d *schema.ResourceData) error {
 }
 
 func resourceAddonDeploymentCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	if addonDeploymentResourceDisabled() {
+		return diag.FromErr(addonDeploymentResourceDisabledError())
+	}
+
 	// Validate exactly one cluster_profile is specified
 	if err := validateSingleClusterProfile(d); err != nil {
 		return diag.FromErr(err)
@@ -186,6 +202,10 @@ func isProfileAttached(cluster *models.V1SpectroCluster, uid string) bool {
 
 //goland:noinspection GoUnhandledErrorResult
 func resourceAddonDeploymentRead(_ context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	if addonDeploymentResourceDisabled() {
+		return diag.FromErr(addonDeploymentResourceDisabledError())
+	}
+
 	resourceContext := d.Get("context").(string)
 	c := getV1ClientWithResourceContext(m, resourceContext)
 
@@ -211,6 +231,10 @@ func resourceAddonDeploymentRead(_ context.Context, d *schema.ResourceData, m in
 }
 
 func resourceAddonDeploymentUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	if addonDeploymentResourceDisabled() {
+		return diag.FromErr(addonDeploymentResourceDisabledError())
+	}
+
 	// Validate exactly one cluster_profile is specified
 	if err := validateSingleClusterProfile(d); err != nil {
 		return diag.FromErr(err)

--- a/spectrocloud/resource_cluster_brownfield.go
+++ b/spectrocloud/resource_cluster_brownfield.go
@@ -827,6 +827,10 @@ func readCommonFieldsBrownfield(c *client.V1Client, d *schema.ResourceData, clus
 		}
 	}
 
+	if diags := syncClusterProfilesFromAPIWhenAddonDeploymentDisabled(c, d, cluster); diags.HasError() {
+		return diags, true
+	}
+
 	return diag.Diagnostics{}, false
 }
 

--- a/spectrocloud/resource_cluster_virtual.go
+++ b/spectrocloud/resource_cluster_virtual.go
@@ -340,8 +340,9 @@ func resourceClusterVirtualRead(_ context.Context, d *schema.ResourceData, m int
 		}
 	}
 
-	// Populate cluster_profile (profile IDs + variables) for read/import — same pattern as resources
-	clusterProfiles, err := flattenClusterProfileForImport(c, d)
+	// Populate cluster_profile (profile IDs + variables) for read/import.
+	// When disable_addon_deployment_resource is true, readCommonFields already synced profile IDs.
+	clusterProfiles, err := flattenClusterProfilesFromCluster(cluster)
 	if err != nil {
 		log.Printf("[WARN] failed to flatten cluster profiles: %v", err)
 		clusterProfiles = make([]interface{}, 0)
@@ -357,33 +358,15 @@ func resourceClusterVirtualRead(_ context.Context, d *schema.ResourceData, m int
 		}
 	}
 	if len(clusterProfiles) > 0 {
-		clusterVars, err := c.GetClusterVariables(d.Id())
+		clusterProfiles, err = enrichClusterProfilesWithVariables(c, d, d.Id(), clusterProfiles)
 		if err != nil {
-			log.Printf("[WARN] failed to get cluster variables: %v", err)
-		} else {
-			profileVariablesMap := make(map[string]map[string]interface{})
-			for _, cv := range clusterVars {
-				if cv.ProfileUID != nil && cv.Variables != nil {
-					vars := make(map[string]interface{})
-					for _, v := range cv.Variables {
-						if v.Name != nil && v.Value != "" {
-							vars[*v.Name] = v.Value
-						}
-					}
-					if len(vars) > 0 {
-						profileVariablesMap[*cv.ProfileUID] = vars
-					}
-				}
-			}
-			for i := range clusterProfiles {
-				p := clusterProfiles[i].(map[string]interface{})
-				if uid, ok := p["id"].(string); ok && uid != "" {
-					if vars, has := profileVariablesMap[uid]; has {
-						p["variables"] = vars
-					}
-				}
-			}
+			log.Printf("[WARN] failed to enrich cluster profile variables: %v", err)
 		}
+		clusterProfiles, err = enrichClusterProfilesWithPacks(c, d, cluster, clusterProfiles)
+		if err != nil {
+			log.Printf("[WARN] failed to enrich cluster profile packs: %v", err)
+		}
+		alignClusterProfilesStateWithConfig(d, clusterProfiles)
 	}
 	if err := d.Set("cluster_profile", clusterProfiles); err != nil {
 		log.Printf("[WARN] failed to set cluster_profile: %v", err)

--- a/templates/index.md.tmpl
+++ b/templates/index.md.tmpl
@@ -68,6 +68,35 @@ export SPECTROCLOUD_APIKEY=5b7aad.........
 provider "spectrocloud" {}
 ```
 
+## Feature Flags
+
+The provider accepts optional feature flags through the `feature_flag` map argument in the provider block. Unknown keys are ignored.
+
+### disable_addon_deployment_resource
+
+When set to `true`, the provider disallows the [`spectrocloud_addon_deployment`](resources/addon_deployment.md) resource. Any configuration that references this resource fails during `terraform plan` (including refresh) and apply with an error indicating the feature flag is disabled. Defaults to `false`.
+
+`cluster_profile` and `cluster_template` are **mutually exclusive** on `spectrocloud_cluster_*` resources. The provider returns an error if both are set in the same resource.
+
+When this flag is enabled:
+
+- **`cluster_profile` only** — On read, the provider refreshes every profile attached to the cluster from the Palette API into the top-level `cluster_profile` block (including addon profiles previously managed by `spectrocloud_addon_deployment`). Pack and variable fields in state follow what you declare in configuration.
+- **`cluster_template` only** — The provider does **not** modify top-level `cluster_profile`. Profiles are managed inside `cluster_template` (nested `cluster_profile` blocks). Read continues to refresh `cluster_template` variables from the API via the existing template flow.
+- **Neither** — No profile sync from this flag.
+
+To destroy existing addon deployments still in Terraform state, set the flag back to `false`, run `terraform destroy` on those resources, then set the flag to `true` again if you want to keep `spectrocloud_addon_deployment` blocked.
+
+```terraform
+provider "spectrocloud" {
+  host    = var.sc_host
+  api_key = var.sc_api_key
+
+  feature_flag = {
+    disable_addon_deployment_resource = true
+  }
+}
+```
+
 ## Import
 Starting with Terraform v1.5.0 and later, you can use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import resources into your state file.
 

--- a/templates/resources/addon_deployment.md.tmpl
+++ b/templates/resources/addon_deployment.md.tmpl
@@ -9,6 +9,8 @@ description: |-
 
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 
+~> **Provider feature flag:** Set `feature_flag.disable_addon_deployment_resource = true` in the [provider configuration](../index.md#feature-flags) to disallow this resource during plan and apply.
+
 ## Example Usage
 
 ```hcl


### PR DESCRIPTION
**Summary**
Adds a provider feature flag to disable `spectrocloud_addon_deployment` and manage addon profiles on `spectrocloud_cluster_* `resources via cluster_profile instead. On read (when the flag is enabled), cluster resources sync attached profiles from the Palette API into state in a way that matches Terraform configuration and avoids spurious plan drift.

**Provider feature flag**

- New optional feature_flag map on the spectrocloud provider.
- `disable_addon_deployment_resource` (default false): when true, blocks all use of `spectrocloud_addon_deployment` at plan time (CustomizeDiff) and apply (Create/Read/Update/Delete, state upgrade).
- Unknown `feature_flag` keys are ignored. HCL-only (no env var).

**spectrocloud_addon_deployment**

- Guarded when the flag is true; clear error directing users to remove the resource or set the flag to false.
- Destroy is also blocked while the flag is on (users must turn the flag off to clean up existing state).

**spectrocloud_cluster_* profile sync (flag enabled)**

- cluster_profile only: On read, refreshes all attached profiles from ClusterProfileTemplates into top-level cluster_profile, including variables and packs from the API.
- cluster_template only: Does not touch top-level cluster_profile; existing flattenClusterTemplateVariables behavior is unchanged.
- cluster_profile and cluster_template: Still mutually exclusive (validateProfileSource); documented in provider docs.