### PR TITLE
fix: make update_worker_pools_in_parallel Optional+Computed to stop perpetual diff

### DIFF
--- a/spectrocloud/cluster_common.go
+++ b/spectrocloud/cluster_common.go
@@ -58,12 +58,22 @@ func toClusterConfig(d *schema.ResourceData) *models.V1ClusterConfigEntity {
 		Timezone:                toClusterTimezone(d),
 	}
 
-	// Set UpdateWorkerPoolsInParallel if specified
-	if v, ok := d.GetOk("update_worker_pools_in_parallel"); ok {
-		config.UpdateWorkerPoolsInParallel = v.(bool)
-	}
+	// The field is Optional+Computed (no schema Default) to avoid a perpetual diff
+	// against the API value. Honor an explicit user value (including false), and
+	// fall back to the create-time default of true when the user did not set it.
+	config.UpdateWorkerPoolsInParallel = updateWorkerPoolsInParallel(d)
 
 	return config
+}
+
+// updateWorkerPoolsInParallel returns the explicit user value (including false)
+// or the create-time default of true when the field is unset. GetOkExists is
+// used instead of GetOk because GetOk treats a bool false as "unset".
+func updateWorkerPoolsInParallel(d *schema.ResourceData) bool {
+	if v, ok := d.GetOkExists("update_worker_pools_in_parallel"); ok {
+		return v.(bool)
+	}
+	return true
 }
 
 func toClusterMetaAttribute(d *schema.ResourceData) string {

--- a/spectrocloud/cluster_common_test.go
+++ b/spectrocloud/cluster_common_test.go
@@ -1921,3 +1921,72 @@ func TestClusterTemplateProfileSetFromList(t *testing.T) {
 	profileSet := clusterTemplateProfileSetFromList(profiles)
 	require.Equal(t, 1, profileSet.Len())
 }
+
+// TestUpdateWorkerPoolsInParallelNoPerpetualDiff guards against the perpetual
+// reconcile diff for update_worker_pools_in_parallel. The field is
+// Optional+Computed (no schema Default), so the value the provider sends to the
+// API during expand must equal whatever value Read flattened into state from the
+// API. If the user did not configure the field, expand must fall back to the
+// create-time default (true) instead of forcing it onto an API value of false.
+func TestUpdateWorkerPoolsInParallelNoPerpetualDiff(t *testing.T) {
+	cases := []struct {
+		name string
+		// stateValue mimics the value Read flattens from the API into state.
+		// nil means the field is unset (user did not configure it).
+		stateValue *bool
+		expected   bool
+	}{
+		{name: "unset falls back to create default true", stateValue: nil, expected: true},
+		{name: "api/user value false is preserved", stateValue: BoolPtr(false), expected: false},
+		{name: "api/user value true is preserved", stateValue: BoolPtr(true), expected: true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			d := resourceClusterAws().TestResourceData()
+			if tc.stateValue != nil {
+				_ = d.Set("update_worker_pools_in_parallel", *tc.stateValue)
+			}
+
+			got := updateWorkerPoolsInParallel(d)
+			assert.Equal(t, tc.expected, got)
+
+			// The expand result must match the value in state, otherwise Terraform
+			// would plan a change on every apply (the perpetual diff).
+			config := toClusterConfig(d)
+			assert.Equal(t, tc.expected, config.UpdateWorkerPoolsInParallel)
+		})
+	}
+}
+
+// TestUpdateWorkerPoolsInParallelEdgeNativeDefault verifies Edge Native keeps its
+// historical create-time default of false when the field is unset, while still
+// honoring an explicit user value (and therefore not creating a perpetual diff).
+func TestUpdateWorkerPoolsInParallelEdgeNativeDefault(t *testing.T) {
+	cases := []struct {
+		name       string
+		stateValue *bool
+		expected   bool
+	}{
+		{name: "unset falls back to edge native default false", stateValue: nil, expected: false},
+		{name: "explicit true is preserved", stateValue: BoolPtr(true), expected: true},
+		{name: "explicit false is preserved", stateValue: BoolPtr(false), expected: false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			d := resourceClusterEdgeNative().TestResourceData()
+			if tc.stateValue != nil {
+				_ = d.Set("update_worker_pools_in_parallel", *tc.stateValue)
+			}
+
+			config := toClusterConfig(d)
+			// Mirror the edge native create override.
+			if _, ok := d.GetOkExists("update_worker_pools_in_parallel"); !ok {
+				config.UpdateWorkerPoolsInParallel = false
+			}
+
+			assert.Equal(t, tc.expected, config.UpdateWorkerPoolsInParallel)
+		})
+	}
+}

--- a/spectrocloud/resource_cluster_aks.go
+++ b/spectrocloud/resource_cluster_aks.go
@@ -147,7 +147,7 @@ func resourceClusterAks() *schema.Resource {
 			"update_worker_pools_in_parallel": {
 				Type:        schema.TypeBool,
 				Optional:    true,
-				Default:     true,
+				Computed:    true,
 				Description: "Controls whether worker pool updates occur in parallel or sequentially. When set to `true` (default), all worker pools are updated simultaneously. When `false`, worker pools are updated one at a time, reducing cluster disruption but taking longer to complete updates.",
 			},
 			"kubeconfig": {

--- a/spectrocloud/resource_cluster_apache_cloudstack.go
+++ b/spectrocloud/resource_cluster_apache_cloudstack.go
@@ -153,7 +153,7 @@ func resourceClusterApacheCloudStack() *schema.Resource {
 			"update_worker_pools_in_parallel": {
 				Type:        schema.TypeBool,
 				Optional:    true,
-				Default:     true,
+				Computed:    true,
 				Description: "Controls whether worker pool updates occur in parallel or sequentially. When set to `true` (default), all worker pools are updated simultaneously. When `false`, worker pools are updated one at a time, reducing cluster disruption but taking longer to complete updates.",
 			},
 			"kubeconfig": {

--- a/spectrocloud/resource_cluster_aws.go
+++ b/spectrocloud/resource_cluster_aws.go
@@ -153,7 +153,7 @@ func resourceClusterAws() *schema.Resource {
 			"update_worker_pools_in_parallel": {
 				Type:        schema.TypeBool,
 				Optional:    true,
-				Default:     true,
+				Computed:    true,
 				Description: "Controls whether worker pool updates occur in parallel or sequentially. When set to `true` (default), all worker pools are updated simultaneously. When `false`, worker pools are updated one at a time, reducing cluster disruption but taking longer to complete updates.",
 			},
 			"kubeconfig": {

--- a/spectrocloud/resource_cluster_azure.go
+++ b/spectrocloud/resource_cluster_azure.go
@@ -144,7 +144,7 @@ func resourceClusterAzure() *schema.Resource {
 			"update_worker_pools_in_parallel": {
 				Type:        schema.TypeBool,
 				Optional:    true,
-				Default:     true,
+				Computed:    true,
 				Description: "Controls whether worker pool updates occur in parallel or sequentially. When set to `true` (default), all worker pools are updated simultaneously. When `false`, worker pools are updated one at a time, reducing cluster disruption but taking longer to complete updates.",
 			},
 			"kubeconfig": {

--- a/spectrocloud/resource_cluster_custom_cloud.go
+++ b/spectrocloud/resource_cluster_custom_cloud.go
@@ -121,7 +121,7 @@ func resourceClusterCustomCloud() *schema.Resource {
 			"update_worker_pools_in_parallel": {
 				Type:        schema.TypeBool,
 				Optional:    true,
-				Default:     true,
+				Computed:    true,
 				Description: "Controls whether worker pool updates occur in parallel or sequentially. When set to `true` (default), all worker pools are updated simultaneously. When `false`, worker pools are updated one at a time, reducing cluster disruption but taking longer to complete updates.",
 			},
 			"cloud_config": {

--- a/spectrocloud/resource_cluster_edge_native.go
+++ b/spectrocloud/resource_cluster_edge_native.go
@@ -142,8 +142,8 @@ func resourceClusterEdgeNative() *schema.Resource {
 			"update_worker_pools_in_parallel": {
 				Type:        schema.TypeBool,
 				Optional:    true,
-				Default:     false,
-				Description: "Controls whether worker pool updates occur in parallel or sequentially. When set to `true` (default), all worker pools are updated simultaneously. When `false`, worker pools are updated one at a time, reducing cluster disruption but taking longer to complete updates.",
+				Computed:    true,
+				Description: "Controls whether worker pool updates occur in parallel or sequentially. When set to `true`, all worker pools are updated simultaneously. When `false` (default), worker pools are updated one at a time, reducing cluster disruption but taking longer to complete updates.",
 			},
 			"kubeconfig": {
 				Type:        schema.TypeString,
@@ -808,6 +808,10 @@ func toEdgeNativeCluster(c *client.V1Client, d *schema.ResourceData) (*models.V1
 	}
 	cluster.Spec.Machinepoolconfig = machinePoolConfigs
 	cluster.Spec.ClusterConfig = toClusterConfig(d)
+	// Edge Native defaults worker pool updates to sequential (false) when unset.
+	if _, ok := d.GetOkExists("update_worker_pools_in_parallel"); !ok {
+		cluster.Spec.ClusterConfig.UpdateWorkerPoolsInParallel = false
+	}
 
 	return cluster, nil
 }

--- a/spectrocloud/resource_cluster_edge_vsphere.go
+++ b/spectrocloud/resource_cluster_edge_vsphere.go
@@ -133,7 +133,7 @@ func resourceClusterEdgeVsphere() *schema.Resource {
 			"update_worker_pools_in_parallel": {
 				Type:        schema.TypeBool,
 				Optional:    true,
-				Default:     true,
+				Computed:    true,
 				Description: "Controls whether worker pool updates occur in parallel or sequentially. When set to `true` (default), all worker pools are updated simultaneously. When `false`, worker pools are updated one at a time, reducing cluster disruption but taking longer to complete updates.",
 			},
 			"kubeconfig": {

--- a/spectrocloud/resource_cluster_eks.go
+++ b/spectrocloud/resource_cluster_eks.go
@@ -159,7 +159,7 @@ func resourceClusterEks() *schema.Resource {
 			"update_worker_pools_in_parallel": {
 				Type:        schema.TypeBool,
 				Optional:    true,
-				Default:     true,
+				Computed:    true,
 				Description: "Controls whether worker pool updates occur in parallel or sequentially. When set to `true` (default), all worker pools are updated simultaneously. When `false`, worker pools are updated one at a time, reducing cluster disruption but taking longer to complete updates.",
 			},
 			"kubeconfig": {

--- a/spectrocloud/resource_cluster_gcp.go
+++ b/spectrocloud/resource_cluster_gcp.go
@@ -142,7 +142,7 @@ func resourceClusterGcp() *schema.Resource {
 			"update_worker_pools_in_parallel": {
 				Type:        schema.TypeBool,
 				Optional:    true,
-				Default:     true,
+				Computed:    true,
 				Description: "Controls whether worker pool updates occur in parallel or sequentially. When set to `true` (default), all worker pools are updated simultaneously. When `false`, worker pools are updated one at a time, reducing cluster disruption but taking longer to complete updates.",
 			},
 			"kubeconfig": {

--- a/spectrocloud/resource_cluster_gke.go
+++ b/spectrocloud/resource_cluster_gke.go
@@ -138,7 +138,7 @@ func resourceClusterGke() *schema.Resource {
 			"update_worker_pools_in_parallel": {
 				Type:        schema.TypeBool,
 				Optional:    true,
-				Default:     true,
+				Computed:    true,
 				Description: "Controls whether worker pool updates occur in parallel or sequentially. When set to `true` (default), all worker pools are updated simultaneously. When `false`, worker pools are updated one at a time, reducing cluster disruption but taking longer to complete updates.",
 			},
 			// we will depricate it opearional is update_worker_pools_in_parallel

--- a/spectrocloud/resource_cluster_maas.go
+++ b/spectrocloud/resource_cluster_maas.go
@@ -171,7 +171,7 @@ func resourceClusterMaas() *schema.Resource {
 			"update_worker_pools_in_parallel": {
 				Type:        schema.TypeBool,
 				Optional:    true,
-				Default:     true,
+				Computed:    true,
 				Description: "Controls whether worker pool updates occur in parallel or sequentially. When set to `true` (default), all worker pools are updated simultaneously. When `false`, worker pools are updated one at a time, reducing cluster disruption but taking longer to complete updates.",
 			},
 			"kubeconfig": {

--- a/spectrocloud/resource_cluster_virtual.go
+++ b/spectrocloud/resource_cluster_virtual.go
@@ -148,7 +148,7 @@ func resourceClusterVirtual() *schema.Resource {
 			"update_worker_pools_in_parallel": {
 				Type:        schema.TypeBool,
 				Optional:    true,
-				Default:     true,
+				Computed:    true,
 				Description: "Controls whether worker pool updates occur in parallel or sequentially. When set to `true` (default), all worker pools are updated simultaneously. When `false`, worker pools are updated one at a time, reducing cluster disruption but taking longer to complete updates.",
 			},
 			"cluster_timezone": {
@@ -569,7 +569,7 @@ func toVirtualCluster(c *client.V1Client, d *schema.ResourceData) (*models.V1Spe
 						UID: hostClusterUid,
 					},
 				},
-				UpdateWorkerPoolsInParallel: d.Get("update_worker_pools_in_parallel").(bool),
+				UpdateWorkerPoolsInParallel: updateWorkerPoolsInParallel(d),
 				Timezone:                    d.Get("cluster_timezone").(string),
 			},
 			Machinepoolconfig: nil,

--- a/spectrocloud/resource_cluster_vsphere.go
+++ b/spectrocloud/resource_cluster_vsphere.go
@@ -146,7 +146,7 @@ func resourceClusterVsphere() *schema.Resource {
 			"update_worker_pools_in_parallel": {
 				Type:        schema.TypeBool,
 				Optional:    true,
-				Default:     true,
+				Computed:    true,
 				Description: "Controls whether worker pool updates occur in parallel or sequentially. When set to `true` (default), all worker pools are updated simultaneously. When `false`, worker pools are updated one at a time, reducing cluster disruption but taking longer to complete updates.",
 			},
 			"kubeconfig": {


### PR DESCRIPTION
What was wrong:
update_worker_pools_in_parallel had Default: true. If you didn't set it, Terraform assumed true, but the API could return false - so every plan showed false -> true and never settled
Even right after a successful apply, the next plan showed the same change again:
```
~ resource "spectrocloud_cluster_custom_cloud" "ite-tools-preprod" {
      ~ update_worker_pools_in_parallel = false -> true
    }
Plan: 0 to add, 1 to change, 0 to destroy.

Apply complete! Resources: 0 added, 1 changed, 0 destroyed.

# run apply again immediately...
~ resource "spectrocloud_cluster_custom_cloud" "ite-tools-preprod" {
      ~ update_worker_pools_in_parallel = false -> true   # same change, forever
    }
Plan: 0 to add, 1 to change, 0 to destroy.
```

The fix:
Changed the field from Default: true to Computed:
- Empty field → Terraform accepts the API value (no more endless diff);
- Set to true/false → your value is respected;
- New clusters still default to true (moved into create logic); Edge Native stays false;

Also switched GetOk → GetOkExists so an explicit false isn't dropped

Added tests to lock in the no-diff behavior