### PR TITLE
PLT-2286:Fixed profile variable presistion on immutable cluster profiles

### DIFF
--- a/spectrocloud/resource_cluster_profile.go
+++ b/spectrocloud/resource_cluster_profile.go
@@ -388,6 +388,9 @@ func resourceClusterProfileCreate(ctx context.Context, d *schema.ResourceData, m
 			if err := c.PublishClusterProfile(newUID); err != nil {
 				return diag.FromErr(err)
 			}
+			if err := updateClusterProfileVariablesFromConfig(d, c, newUID); err != nil {
+				return diag.FromErr(err)
+			}
 
 			resourceClusterProfileRead(ctx, d, m)
 			return diags
@@ -919,6 +922,21 @@ func getManifestUID(name string, packs []*models.V1PackRef) string {
 	}
 
 	return ""
+}
+
+// updateClusterProfileVariablesFromConfig syncs profile_variables from Terraform
+// config to the dedicated Palette /variables endpoint. Clone copies variables
+// from the source version only; this applies the user's HCL variable definitions
+// after packs are published on the immutable version-bump Create path.
+func updateClusterProfileVariablesFromConfig(d *schema.ResourceData, c *client.V1Client, uid string) error {
+	if _, ok := d.GetOk("profile_variables"); !ok {
+		return nil
+	}
+	pvs, err := toClusterProfileVariables(d)
+	if err != nil {
+		return err
+	}
+	return c.UpdateProfileVariables(&models.V1Variables{Variables: pvs}, uid)
 }
 
 func toClusterProfileVariables(d *schema.ResourceData) ([]*models.V1Variable, error) {

--- a/spectrocloud/resource_cluster_profile_test.go
+++ b/spectrocloud/resource_cluster_profile_test.go
@@ -1126,6 +1126,25 @@ func TestResourceClusterProfileDelete_NormalDestroy(t *testing.T) {
 	assert.Empty(t, diags)
 }
 
+// TestResourceClusterProfileCreate_ImmutableCloneUpdatesVariables verifies that
+// the immutable version-bump Create path (clone + overwrite) syncs
+// profile_variables from HCL via the dedicated /variables endpoint after publish.
+func TestResourceClusterProfileCreate_ImmutableCloneUpdatesVariables(t *testing.T) {
+	orig := ProviderFeaturePreview
+	defer func() { ProviderFeaturePreview = orig }()
+	ProviderFeaturePreview = map[string]bool{"immutable-clusterprofiles": true}
+
+	d := prepareBaseClusterProfileTestData()
+	_ = d.Set("name", "test-cluster-profile-1")
+	_ = d.Set("version", "2.0.0")
+	_ = d.Set("type", "add-on")
+
+	var ctx context.Context
+	diags := resourceClusterProfileCreate(ctx, d, unitTestMockAPIClient)
+	assert.Empty(t, diags)
+	assert.Equal(t, "cloned-profile-uid", d.Id())
+}
+
 // TestFindAnyExistingProfileVersionUID_Found verifies that the helper finds
 // an existing profile by name via the SDK's GetClusterProfiles listing endpoint.
 // This helper is used by the immutable-clusterprofiles Create path to discover

--- a/tests/mockApiServer/routes/mockClusterProfile.go
+++ b/tests/mockApiServer/routes/mockClusterProfile.go
@@ -129,6 +129,14 @@ func ClusterProfileRoutes() []Route {
 			},
 		},
 		{
+			Method: "PUT",
+			Path:   "/v1/clusterprofiles/{uid}/variables",
+			Response: ResponseData{
+				StatusCode: 204,
+				Payload:    nil,
+			},
+		},
+		{
 			Method: "DELETE",
 			Path:   "/v1/clusterprofiles/{uid}",
 			Response: ResponseData{


### PR DESCRIPTION
`<h3 class="mt-6 mb-2 font-semibold text-xl" data-streamdown="heading-3" style="--tw-space-y-reverse: 0; margin-block: 0px 16px; margin-bottom: 8px; font-size: 1.15em; line-height: 1.25; --tw-font-weight: 600; font-weight: 600; color: rgb(204, 204, 204); margin-top: 18px; font-family: -apple-system, &quot;system-ui&quot;, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(31, 31, 31); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">A. Primary fix — variable changes on version bump (clone path)</h3><p style="--tw-space-y-reverse: 0; margin-block: 0px 16px; margin: 6px 0px; word-break: break-word; color: rgb(204, 204, 204); font-family: -apple-system, &quot;system-ui&quot;, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(31, 31, 31); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">These are the<span> </span><span class="font-semibold" data-streamdown="strong" style="--tw-font-weight: 600; font-weight: 600;">core</span><span> </span>cases for this change.</p><div class="ui-scroll-area" data-visibility="hover" data-direction="horizontal" style="--tw-space-y-reverse: 0; margin-block: 0px 16px; --scrollbar-size: 6px; --scrollbar-inset: 0px; --scrollbar-thumb-top-offset: 6px; position: relative; overflow: hidden; display: grid; grid-template: 1fr / 1fr; margin: 1em 0px; border-color: color(srgb 0.8 0.8 0.8 / 0.08); border-style: solid; border-width: 0.833333px; border-image: none 100% / 1 / 0 stretch; border-radius: 6px; color: rgb(204, 204, 204); font-family: -apple-system, &quot;system-ui&quot;, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(31, 31, 31); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><div class="ui-scroll-area__viewport" style="grid-area: 1 / 1; min-height: 0px; max-height: 100%; border-radius: inherit; overflow: auto hidden; scroll-padding: 0px 4px; overscroll-behavior: contain; scrollbar-width: none;"><div class="ui-scroll-area__content" style="box-sizing: border-box; width: auto; min-width: 100%; max-width: 100%; min-height: 100%; display: flex; flex-direction: row; height: fit-content;">
# | Scenario | HCL change | Version bump? | Expected
-- | -- | -- | -- | --
A1 | Add new variables (customer bug) | Add test_string_var, test_number_var | Yes | New vars appear in API/UI; existing vars unchanged
A2 | Modify existing variable | Change default_value, description, or display_name on an existing var | Yes | Updated values on new version only
A3 | Remove a variable | Drop one var from profile_variables block; keep others | Yes | Removed var absent on new version; others remain
A4 | Replace variable set | Remove old vars, add entirely new names | Yes | New version has only HCL-defined vars
A5 | Variables only (no pack change) | Only profile_variables + version bump | Yes | Vars synced; packs same as HCL
A6 | No profile_variables block | Omit block entirely; bump version for pack-only change | Yes | Clone-copied vars from source remain (no PUT /variables)
A7 | Empty profile_variables block | Block present with variable = [] | Yes | Confirm backend behavior: all vars cleared vs unchanged (document result)

</div></div></div>`