### PR TITLE
Fix backup_policy and scan_policy not applied on custom cloud cluster…

### DIFF
--- a/spectrocloud/resource_cluster_custom_cloud.go
+++ b/spectrocloud/resource_cluster_custom_cloud.go
@@ -341,6 +341,21 @@ func resourceClusterCustomCloudCreate(ctx context.Context, d *schema.ResourceDat
 	if isError && diagnostics != nil {
 		return diagnostics
 	}
+
+	// Apply backup policy after cluster creation if specified
+	if _, found := d.GetOk("backup_policy"); found {
+		if err := updateBackupPolicy(c, d); err != nil {
+			return diag.FromErr(err)
+		}
+	}
+
+	// Apply scan policy after cluster creation if specified
+	if _, found := d.GetOk("scan_policy"); found {
+		if err := updateScanPolicy(c, d); err != nil {
+			return diag.FromErr(err)
+		}
+	}
+
 	resourceClusterCustomCloudRead(ctx, d, m)
 
 	return diags


### PR DESCRIPTION
Fixes **backup_policy** and **scan_policy** not being applied when creating CustomCloud clusters

Problem
When creating CustomCloud cluster with backup_policy configured, the cluster is created successfully and the policy appears in the status, but the backup is NOT enabled in Palette UI

Root cause: CustomCloud cluster creation does not apply policies during cluster creation, unlike other cluster types (AWS, Azure, GCP, etc.). Policies are only applied during updates when d.HasChange() detects changes, which never happens for initial creation

Solution
Apply backup_policy and scan_policy after cluster creation completes:
- Check if backup_policy is configured
- Call updateBackupPolicy() after waitForClusterCreation()
- Same for scan_policy

This makes CustomCloud clusters behave consistently with other cluster types