### PR TITLE
PLT-2327: Implemented the guardrail in cluster group resource for deprecated k3s support.

### DIFF
--- a/docs/resources/cluster_group.md
+++ b/docs/resources/cluster_group.md
@@ -88,7 +88,7 @@ Optional:
 
 - `cpu_millicore` (Number) The CPU limit in millicores.
 - `host_endpoint_type` (String) The host endpoint type. Allowed values are 'Ingress' or 'LoadBalancer'. Defaults to 'Ingress'.
-- `k8s_distribution` (String) The Kubernetes distribution, allowed values are `vcluster-generic`,`k3s` and `cncf_k8s`.
+- `k8s_distribution` (String) The Kubernetes distribution, allowed values are `vcluster-generic`,`k3s` and `cncf_k8s`. `k3s` is no longer supported for new Cluster Groups - use `vcluster-generic` or `cncf_k8s` instead. Existing Cluster Groups on `k3s` remain manageable but must be migrated to a new Cluster Group manually.
 - `memory_in_mb` (Number) The memory limit in megabytes (MB).
 - `oversubscription_percent` (Number) The allowed oversubscription percentage.
 - `storage_in_gb` (Number) The storage limit in gigabytes (GB).

--- a/spectrocloud/resource_cluster_group.go
+++ b/spectrocloud/resource_cluster_group.go
@@ -109,11 +109,13 @@ func resourceClusterGroup() *schema.Resource {
 							Description: "YAML values override string applied to the cluster group configuration.",
 						},
 						"k8s_distribution": {
-							Type:        schema.TypeString,
-							Optional:    true,
-							Default:     "vcluster-generic",
-							ForceNew:    true,
-							Description: "The Kubernetes distribution, allowed values are `vcluster-generic`,`k3s` and `cncf_k8s`.",
+							Type:     schema.TypeString,
+							Optional: true,
+							Default:  "vcluster-generic",
+							ForceNew: true,
+							Description: "The Kubernetes distribution, allowed values are `vcluster-generic`,`k3s` and `cncf_k8s`. " +
+								"`k3s` is no longer supported for new Cluster Groups - use `vcluster-generic` or `cncf_k8s` instead. " +
+								"Existing Cluster Groups on `k3s` remain manageable but must be migrated to a new Cluster Group manually.",
 						},
 					},
 				},
@@ -171,6 +173,16 @@ func resourceClusterGroupCreate(ctx context.Context, d *schema.ResourceData, m i
 
 	// Warning or errors can be collected in a slice type
 	var diags diag.Diagnostics
+
+	if resourcesObj, ok := d.GetOk("config"); ok {
+		resources := resourcesObj.([]interface{})[0].(map[string]interface{})
+		if distro, ok := resources["k8s_distribution"].(string); ok && distro == string(models.V1ClusterKubernetesDistroTypeK3s) {
+			return diag.Errorf("k3s is no longer supported for new Cluster Groups. Use `vcluster-generic` or `cncf_k8s` " +
+				"instead. Existing k3s Cluster Groups remain manageable but must be migrated to a new Cluster Group manually - " +
+				"see https://docs.spectrocloud.com/clusters/cluster-groups/vcluster-upgrades/")
+		}
+	}
+
 	cluster := toClusterGroup(c, d)
 
 	uid, err := c.CreateClusterGroup(cluster)

--- a/spectrocloud/resource_cluster_group_test.go
+++ b/spectrocloud/resource_cluster_group_test.go
@@ -280,3 +280,26 @@ func TestResourceClusterGroupCRUD(t *testing.T) {
 	}, unitTestMockAPIClient,
 		resourceClusterGroupCreate, resourceClusterGroupRead, resourceClusterGroupUpdate, resourceClusterGroupDelete)
 }
+
+func TestResourceClusterGroupCreate_RejectsK3s(t *testing.T) {
+	prepare := func() *schema.ResourceData {
+		d, err := prepareClusterGroupTestData()
+		if err != nil {
+			t.Fatal(err)
+		}
+		err = d.Set("config", []map[string]interface{}{
+			{
+				"host_endpoint_type": "LoadBalancer",
+				"k8s_distribution":   "k3s",
+			},
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		return d
+	}
+
+	testResourceCRUDNegative(t, "Create", prepare, unitTestMockAPIClient,
+		resourceClusterGroupCreate, resourceClusterGroupRead, resourceClusterGroupUpdate, resourceClusterGroupDelete,
+		false, "k3s is no longer supported")
+}


### PR DESCRIPTION
Implemented the PPD-1605 guardrail in terraform-provider-spectrocloud:

resource_cluster_group.go:112-121 — resourceClusterGroupCreate now rejects k8s_distribution = "k3s" at plan/apply time with a clear error pointing to vcluster-generic/cncf_k8s and a migration doc link, satisfying AC "block creation of new K3s-based virtual clusters end-to-end (UI and API)."
The check is Create-only — deliberately not added to toClusterGroup/resourceClusterGroupUpdate, since that function is shared with Update and k8s_distribution is ForceNew (changing it already forces a replace). Blocking it there too would break AC #3: existing K3s Cluster Groups must remain updatable (e.g. resizing limits) without being forced to migrate.
Updated the schema description and regenerated docs/resources/cluster_group.md via tfplugindocs to document that k3s is deprecated for new groups but still valid for existing ones.
Added terraform-provider-spectrocloud/spectrocloud/resource_cluster_group_test.go:283, verified with the existing testResourceCRUDNegative harness.