### PR TITLE
fix: immutable-clusterprofiles clone source prefers newest version, not first-in-list

### DIFF
--- a/spectrocloud/resource_cluster_profile.go
+++ b/spectrocloud/resource_cluster_profile.go
@@ -11,9 +11,11 @@ import (
 
 	"log"
 	"reflect"
+	"sort"
 	"strings"
 	"time"
 
+	"github.com/Masterminds/semver/v3"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/spectrocloud/palette-sdk-go/api/models"
@@ -461,16 +463,37 @@ func bumpPatchHint(current string) string {
 	return strings.Join(parts, ".")
 }
 
-// findAnyExistingProfileVersionUID returns the UID of any existing version of
-// the given profile name in the current scope, or an empty string if none exists.
+// findAnyExistingProfileVersionUID returns the UID of the existing version of
+// the given profile name with the highest semver version in the current scope,
+// or an empty string if none exists.
 //
 // Used by the `immutable-clusterprofiles` Create path to find a clone source:
 // when the user bumps the `version` field, Terraform plans a replacement
 // (destroy + create), and the new resource's Create function runs against an
 // existing Palette lineage. To produce the new immutable version, Create needs
-// any existing uid in that lineage to call `CloneClusterProfile` against -- the
-// exact source version doesn't matter, since clone always produces a new uid
-// that we then overwrite with the user's pack content.
+// an existing uid in that lineage to call `CloneClusterProfile` against, then
+// overwrites the clone's pack content with the user's HCL via the standard
+// update chain below.
+//
+// This deliberately prefers the NEWEST surviving version rather than an
+// arbitrary one (previously: whichever entry `GetClusterProfiles()` happened
+// to list first for this name, which in practice was consistently the OLDEST
+// surviving version). The choice matters even though the clone is overwritten
+// immediately afterward: if the chosen source's own pack content references a
+// profile variable (`{{.spectro.var.X}}`) that the current HCL no longer
+// declares, the variable-sync + pack-update calls below can fail with
+// PackVariablesUndefined -- there is no safe ordering of "drop the now-unused
+// variable" vs. "push pack content that no longer references it" that isn't
+// circular when the *old, not-yet-overwritten* content is what's being
+// validated. When that happens, Create aborts partway through and the new
+// immutable version is left permanently stuck showing the stale, cloned-but-
+// never-overwritten content of whichever version was picked as the source.
+// Preferring the newest surviving version doesn't eliminate this class of bug
+// (a version bump that itself removes a variable the *current* version's own
+// content still uses would still hit it), but it removes the common case,
+// where an old profile has accumulated a variable-schema change somewhere in
+// its history and the previous "any" selection was choosing from arbitrarily
+// far back in that history on every single clone.
 //
 // This helper exists because Palette's data model treats every profile version
 // as a separate object with its own UID -- there is no "lineage parent" object,
@@ -481,12 +504,56 @@ func findAnyExistingProfileVersionUID(c *client.V1Client, name string) (string, 
 	if err != nil {
 		return "", err
 	}
+	return selectNewestProfileVersionUID(profiles, name), nil
+}
+
+// selectNewestProfileVersionUID returns the UID of the entry in profiles whose
+// name matches and whose version sorts highest (semver), or "" if there's no
+// match. Split out from findAnyExistingProfileVersionUID so the selection
+// logic is testable without mocking the Palette client.
+func selectNewestProfileVersionUID(profiles []*models.V1ClusterProfileMetadata, name string) string {
+	var matches []*models.V1ClusterProfileMetadata
 	for _, p := range profiles {
 		if p.Metadata != nil && p.Metadata.Name == name {
-			return p.Metadata.UID, nil
+			matches = append(matches, p)
 		}
 	}
-	return "", nil
+	if len(matches) == 0 {
+		return ""
+	}
+
+	// Sort by version (semver) ascending and take the highest -- same
+	// tie-break/fallback convention as the "Latest" resolution in
+	// resource_cluster_profile_import.go, so a non-semver-parseable version
+	// string (defensively; every version we've observed is well-formed) sorts
+	// as lowest rather than panicking or being skipped.
+	sort.Slice(matches, func(i, j int) bool {
+		vi := profileMetadataVersion(matches[i])
+		vj := profileMetadataVersion(matches[j])
+		si, ei := semver.NewVersion(vi)
+		sj, ej := semver.NewVersion(vj)
+		if ei != nil && ej != nil {
+			return vi < vj
+		}
+		if ei != nil {
+			return true
+		}
+		if ej != nil {
+			return false
+		}
+		return si.LessThan(sj)
+	})
+	return matches[len(matches)-1].Metadata.UID
+}
+
+// profileMetadataVersion returns p's version string, or "0.0.0" if p or its
+// spec is nil (matches getProfileVersion's nil-handling convention in
+// resource_cluster_profile_import.go).
+func profileMetadataVersion(p *models.V1ClusterProfileMetadata) string {
+	if p != nil && p.Spec != nil {
+		return p.Spec.Version
+	}
+	return "0.0.0"
 }
 
 func resourceClusterProfileCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {

--- a/spectrocloud/resource_cluster_profile_test.go
+++ b/spectrocloud/resource_cluster_profile_test.go
@@ -1399,3 +1399,90 @@ func TestCanonicalBool(t *testing.T) {
 	assert.True(t, canonicalBool(true))
 	assert.False(t, canonicalBool(false))
 }
+
+// TestSelectNewestProfileVersionUID covers findAnyExistingProfileVersionUID's
+// clone-source selection: it must pick the highest-semver-version match for
+// the given name, not whichever entry the listing endpoint happened to return
+// first. Regression coverage for a bug where the previous "return the first
+// match" implementation deterministically picked the OLDEST surviving
+// version of an `immutable-clusterprofiles` lineage as the clone source --
+// if that old version's pack content referenced a profile variable the
+// current HCL no longer declares, the subsequent overwrite steps in
+// resourceClusterProfileCreate could fail with PackVariablesUndefined,
+// leaving the new immutable version permanently stuck showing the old
+// version's stale, never-overwritten content.
+func TestSelectNewestProfileVersionUID(t *testing.T) {
+	meta := func(uid, name, version string) *models.V1ClusterProfileMetadata {
+		return &models.V1ClusterProfileMetadata{
+			Metadata: &models.V1ObjectEntity{UID: uid, Name: name},
+			Spec:     &models.V1ClusterProfileMetadataSpec{Version: version},
+		}
+	}
+
+	tests := []struct {
+		name     string
+		profiles []*models.V1ClusterProfileMetadata
+		lookup   string
+		want     string
+	}{
+		{
+			name: "oldest-listed-first: must still pick the newest version, not the first match",
+			// Mirrors the real-world shape that triggered this bug: a
+			// long-lived lineage where the listing endpoint returns older
+			// versions before newer ones.
+			profiles: []*models.V1ClusterProfileMetadata{
+				meta("uid-0.2.121", "aigw-instance", "0.2.121"),
+				meta("uid-0.2.130", "aigw-instance", "0.2.130"),
+				meta("uid-0.2.133", "aigw-instance", "0.2.133"),
+			},
+			lookup: "aigw-instance",
+			want:   "uid-0.2.133",
+		},
+		{
+			name: "newest-listed-first: still picks the newest (not a first-match-happens-to-work case)",
+			profiles: []*models.V1ClusterProfileMetadata{
+				meta("uid-0.2.133", "aigw-instance", "0.2.133"),
+				meta("uid-0.2.121", "aigw-instance", "0.2.121"),
+			},
+			lookup: "aigw-instance",
+			want:   "uid-0.2.133",
+		},
+		{
+			name: "filters by name -- ignores other lineages, including ones with a higher version",
+			profiles: []*models.V1ClusterProfileMetadata{
+				meta("uid-other-9.9.9", "some-other-profile", "9.9.9"),
+				meta("uid-target-0.1.0", "aigw-instance", "0.1.0"),
+			},
+			lookup: "aigw-instance",
+			want:   "uid-target-0.1.0",
+		},
+		{
+			name:     "no match returns empty string",
+			profiles: []*models.V1ClusterProfileMetadata{meta("uid-x", "some-other-profile", "1.0.0")},
+			lookup:   "aigw-instance",
+			want:     "",
+		},
+		{
+			name:     "empty profile list returns empty string",
+			profiles: nil,
+			lookup:   "aigw-instance",
+			want:     "",
+		},
+		{
+			name: "double-digit version components sort numerically, not lexicographically",
+			profiles: []*models.V1ClusterProfileMetadata{
+				meta("uid-0.2.9", "aigw-instance", "0.2.9"),
+				meta("uid-0.2.10", "aigw-instance", "0.2.10"),
+			},
+			lookup: "aigw-instance",
+			want:   "uid-0.2.10",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := selectNewestProfileVersionUID(tt.profiles, tt.lookup)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}


### PR DESCRIPTION
Fixes #973

## Summary

`resourceClusterProfileCreate`'s `immutable-clusterprofiles` branch clones a new version from an existing version of the profile lineage, then overwrites the clone with the user's HCL content. `findAnyExistingProfileVersionUID` picked this source via a plain linear scan over `GetClusterProfiles()`, returning the first name match — no sort by version or recency at all.

In practice this deterministically returns the **oldest** surviving version of a long-lived lineage. That's usually harmless, per the function's own comment ("the exact source version doesn't matter, since clone always produces a new uid that we then overwrite with the user's pack content") — but it isn't safe when the arbitrarily-picked old source's own pack content references a profile variable (`{{.spectro.var.X}}`) that the current HCL no longer declares. There's no ordering of "drop the now-unused variable" vs. "push pack content that no longer references it" that isn't circular when it's the *old, not-yet-overwritten* content being validated — `Create` aborts partway through with `PackVariablesUndefined`, and the new immutable version is left **permanently stuck** showing the untouched, stale content of whichever old version was picked as the source.

This isn't an edge case — it reproduces on any profile old enough to have had a variable removed somewhere in its version history, the moment the arbitrarily-picked source predates that removal. We hit it on a profile with ~10 accumulated versions and reproduced it identically 4 times across two provider releases (v0.29.7 and the then-latest v0.29.9).

## Fix

Sort candidates by semver and take the highest, using the same sort-by-semver-take-highest pattern (and the already-vendored `github.com/Masterminds/semver/v3` dependency) already established in `resource_cluster_profile_import.go`'s "Latest" version resolution — this follows an existing convention rather than introducing a new one. The selection logic is split into a small pure function (`selectNewestProfileVersionUID`) so it's unit-testable without mocking the Palette client.

This doesn't eliminate the underlying class of bug (a version bump that itself removes a variable the *current* version's own content still references would still hit it), but it resolves the reported case and makes it far less likely in general.

## Testing

- New unit tests (`TestSelectNewestProfileVersionUID`) cover: the exact real-world ordering that triggered this (oldest-listed-first), input-order independence, name filtering across lineages, no-match/empty-input, and numeric-vs-lexicographic version sorting (`0.2.9` < `0.2.10`).
- Full existing `./spectrocloud/...` test suite passes unchanged.
- **Verified against real Palette infrastructure**, not just unit tests: built this patch, pointed a real Terraform config using `immutable-clusterprofiles` at it via `dev_overrides` (bypassing the registry), and re-ran the exact version bump that had failed consistently with the unpatched provider. Result: clean `Create`, correct pack content, no stale variable reference — confirmed via a direct API read of `spec.published.packs`.

## Related

Full repro details, root-cause writeup, and the proof this is provider-side (not Palette API-side — a raw API clone call with an explicit source uid returns correct content) are in #973.