### PR TITLE
fix (alternative): reorder immutable-clusterprofiles Create so variable removal is always safe

### DIFF
--- a/spectrocloud/resource_cluster_profile.go
+++ b/spectrocloud/resource_cluster_profile.go
@@ -553,10 +553,13 @@ func resourceClusterProfileCreate(ctx context.Context, d *schema.ResourceData, m
 			}
 			d.SetId(newUID)
 
-			// Sync profile variables from HCL before updating packs. Palette validates
-			// pack variable references against variables stored on the profile during
-			// UpdateClusterProfile; clone only copies the source version's variables.
-			if err := syncClusterProfileVariablesFromConfig(d, c, newUID); err != nil {
+			// Register any NEW variables from HCL before updating packs. Palette
+			// validates pack variable references against variables stored on the
+			// profile during UpdateClusterProfile; clone only copies the source
+			// version's variables, so a pack referencing a variable the clone
+			// didn't inherit needs it registered first. This is always safe: it
+			// only ever adds, never removes.
+			if err := addNewProfileVariablesFromConfig(d, c, newUID); err != nil {
 				return diag.FromErr(err)
 			}
 
@@ -582,7 +585,26 @@ func resourceClusterProfileCreate(ctx context.Context, d *schema.ResourceData, m
 			if err := c.PatchClusterProfile(cluster, metadata); err != nil {
 				return diag.FromErr(err)
 			}
+
+			// Publish BEFORE pruning variables -- deliberately, and this order
+			// matters more subtly than it looks. UpdateClusterProfile above only
+			// writes the DRAFT pack content; Palette validates variable removal
+			// against the PUBLISHED content, which still shows the stale,
+			// cloned-from-source values until Publish runs. Pruning before
+			// Publish still fails PackVariablesUndefined even though the draft
+			// no longer references the variable being removed -- confirmed by
+			// instrumenting each call in this sequence and observing that
+			// UpdateClusterProfile/PatchClusterProfile succeed but the prune
+			// call still fails when it runs before Publish (see the linked
+			// issue for the full debug trace).
 			if err := c.PublishClusterProfile(newUID); err != nil {
+				return diag.FromErr(err)
+			}
+
+			// Now that the published content matches the desired HCL (no longer
+			// references anything about to be removed), it's safe to prune the
+			// variable set down to exactly what HCL declares.
+			if err := pruneProfileVariablesToConfig(d, c, newUID); err != nil {
 				return diag.FromErr(err)
 			}
 
@@ -1118,36 +1140,21 @@ func getManifestUID(name string, packs []*models.V1PackRef) string {
 	return ""
 }
 
-// syncClusterProfileVariablesFromConfig applies profile_variables from Terraform
-// config to the Palette /variables endpoint. New variables (not present on the
-// cloned profile) are registered via PATCH; the full desired set is then applied
-// via PUT so existing definitions stay in sync with HCL.
+// addNewProfileVariablesFromConfig registers, via PATCH, any profile_variables
+// in the Terraform config that the cloned profile doesn't already have. This
+// is always safe to run immediately after clone: it only ever adds variables,
+// never removes ones the cloned pack's (not-yet-overwritten) content might
+// still reference.
 //
-// This must run before UpdateClusterProfile on the immutable clone Create path:
-// UpdateClusterProfile validates pack references against variables already stored
-// on the profile. Applying variables after publish causes PackVariablesUndefined
-// when HCL adds packs or variables that the clone did not inherit.
-func syncClusterProfileVariablesFromConfig(d *schema.ResourceData, c *client.V1Client, uid string) error {
-	if _, ok := d.GetOk("profile_variables"); !ok {
-		return nil
-	}
-	desired, err := toClusterProfileVariables(d)
-	if err != nil {
+// Must run before the new pack content is pushed on the immutable clone
+// Create path: UpdateClusterProfile validates pack variable references
+// against variables already stored on the profile, so a pack referencing a
+// brand-new HCL variable the clone didn't inherit would fail validation if
+// this hasn't registered it yet.
+func addNewProfileVariablesFromConfig(d *schema.ResourceData, c *client.V1Client, uid string) error {
+	desired, existingNames, err := desiredAndExistingProfileVariableNames(d, c, uid)
+	if err != nil || desired == nil {
 		return err
-	}
-	if len(desired) == 0 {
-		return nil
-	}
-
-	existing, err := c.GetProfileVariables(uid)
-	if err != nil {
-		return err
-	}
-	existingNames := make(map[string]struct{}, len(existing))
-	for _, v := range existing {
-		if v != nil && v.Name != nil {
-			existingNames[*v.Name] = struct{}{}
-		}
 	}
 
 	var newVars []*models.V1Variable
@@ -1159,13 +1166,61 @@ func syncClusterProfileVariablesFromConfig(d *schema.ResourceData, c *client.V1C
 			newVars = append(newVars, v)
 		}
 	}
-	if len(newVars) > 0 {
-		if err := c.PatchProfileVariables(&models.V1Variables{Variables: newVars}, uid); err != nil {
-			return err
-		}
+	if len(newVars) == 0 {
+		return nil
+	}
+	return c.PatchProfileVariables(&models.V1Variables{Variables: newVars}, uid)
+}
+
+// pruneProfileVariablesToConfig replaces the profile's full variable set with
+// exactly what the Terraform config declares, via PUT -- dropping any
+// variable a clone source had that current HCL no longer declares.
+//
+// Must run AFTER the new pack content has been pushed (see
+// resourceClusterProfileCreate's immutable-clone Create path): removing a
+// variable while pack content still references it -- e.g. a freshly cloned
+// object's not-yet-overwritten stale values -- fails server-side
+// pack/variable validation with PackVariablesUndefined. By the time this
+// runs, pack content already matches the desired HCL and cannot reference
+// anything this call removes, regardless of which existing version was
+// picked as the clone source or what changed in the same apply.
+func pruneProfileVariablesToConfig(d *schema.ResourceData, c *client.V1Client, uid string) error {
+	desired, _, err := desiredAndExistingProfileVariableNames(d, c, uid)
+	if err != nil || desired == nil {
+		return err
+	}
+	return c.UpdateProfileVariables(&models.V1Variables{Variables: desired}, uid)
+}
+
+// desiredAndExistingProfileVariableNames returns the profile_variables the
+// Terraform config declares, and the set of variable names already present
+// on uid. Returns (nil, nil, nil) when there's nothing to reconcile (no
+// profile_variables block, or an empty one), which both
+// addNewProfileVariablesFromConfig and pruneProfileVariablesToConfig treat as
+// "nothing to do".
+func desiredAndExistingProfileVariableNames(d *schema.ResourceData, c *client.V1Client, uid string) ([]*models.V1Variable, map[string]struct{}, error) {
+	if _, ok := d.GetOk("profile_variables"); !ok {
+		return nil, nil, nil
+	}
+	desired, err := toClusterProfileVariables(d)
+	if err != nil {
+		return nil, nil, err
+	}
+	if len(desired) == 0 {
+		return nil, nil, nil
 	}
 
-	return c.UpdateProfileVariables(&models.V1Variables{Variables: desired}, uid)
+	existing, err := c.GetProfileVariables(uid)
+	if err != nil {
+		return nil, nil, err
+	}
+	existingNames := make(map[string]struct{}, len(existing))
+	for _, v := range existing {
+		if v != nil && v.Name != nil {
+			existingNames[*v.Name] = struct{}{}
+		}
+	}
+	return desired, existingNames, nil
 }
 
 func toClusterProfileVariables(d *schema.ResourceData) ([]*models.V1Variable, error) {

--- a/spectrocloud/resource_cluster_profile_test.go
+++ b/spectrocloud/resource_cluster_profile_test.go
@@ -1283,14 +1283,24 @@ func TestResourceClusterProfileCreate_ImmutableCloneUpdatesVariables(t *testing.
 	assert.Equal(t, "cloned-profile-uid", d.Id())
 }
 
-func TestSyncClusterProfileVariablesFromConfigNewVariable(t *testing.T) {
+func TestAddNewProfileVariablesFromConfigNewVariable(t *testing.T) {
 	t.Parallel()
 
 	d := prepareBaseClusterProfileTestData()
 	c := getV1ClientWithResourceContext(unitTestMockAPIClient, "project")
 
-	// Mock GET /variables returns empty; variables from HCL are registered via PATCH then PUT.
-	assert.NoError(t, syncClusterProfileVariablesFromConfig(d, c, "cloned-profile-uid"))
+	// Mock GET /variables returns empty; new variables from HCL are registered via PATCH.
+	assert.NoError(t, addNewProfileVariablesFromConfig(d, c, "cloned-profile-uid"))
+}
+
+func TestPruneProfileVariablesToConfig(t *testing.T) {
+	t.Parallel()
+
+	d := prepareBaseClusterProfileTestData()
+	c := getV1ClientWithResourceContext(unitTestMockAPIClient, "project")
+
+	// Mock GET /variables returns empty; the desired set from HCL is applied via PUT.
+	assert.NoError(t, pruneProfileVariablesToConfig(d, c, "cloned-profile-uid"))
 }
 
 // TestFindAnyExistingProfileVersionUID_Found verifies that the helper finds


### PR DESCRIPTION
## Alternative to #972 — closes the whole bug class, touches more code

This is a **labeled alternative** to #972, not a replacement or a stack on top of it — it fixes the same underlying defect (issue #973) via a different, more thorough mechanism. Either PR resolves the reported case on its own. See "Which one?" below.

## The gap #972 leaves open

#972 fixes `findAnyExistingProfileVersionUID` to prefer the newest surviving version as the clone source, which resolves the originally reported case (an old version's stale content referencing a since-removed variable). But it leaves one case open: **bump the version and remove a `profile_variable` in the same apply**, and the clone source is now the current-latest version — which *still has* that variable in its own stored content. Same failure, narrower trigger.

I verified this gap is real, not theoretical: reproduced it against a disposable test profile with #972's fix applied (and confirmed it fails identically even with the *original*, unpatched "any/first-match" source selection — i.e., this isn't about which version gets picked at all).

## The actual fix: make the operation ordering itself safe

`resourceClusterProfileCreate`'s immutable-clone path clones, then overwrites the clone with HCL content via a chain of calls. The variable sync (`syncClusterProfileVariablesFromConfig`) did both ADD and REMOVE in one call, entirely *before* pack content was pushed. The ADD half is fine — additive, never breaks anything. The REMOVE half is what's unsafe: it can strip a variable while the cloned pack's own (not-yet-overwritten) content still references it.

Fix:
1. Split into `addNewProfileVariablesFromConfig` (PATCH, additive only, stays before pack update) and `pruneProfileVariablesToConfig` (PUT, full replace, moved to run last).
2. Reordered the Create sequence: clone → add new variables → push new pack content (`UpdateClusterProfile` + `PatchClusterProfile`) → **`Publish`** → *then* prune variables.

**The non-obvious part** (found by instrumenting each call and reading the debug trace): `UpdateClusterProfile` only writes the profile's *draft* pack content. Palette validates variable removal against the *published* content, which still shows the stale, cloned-from-source values until `PublishClusterProfile` runs. I initially moved only the prune step after `UpdateClusterProfile`/`PatchClusterProfile` (keeping `Publish` in its original last position) — that still failed identically, because the published content hadn't caught up yet. Moving `Publish` itself ahead of the prune (not just ahead of the pack-content push) was what actually closed the gap.

## Testing

- Full existing `./spectrocloud/...` suite passes unchanged.
- Updated the two existing unit tests that referenced the old single function.
- **Verified against real Palette infrastructure** (same methodology as #972): built this patch, pointed a disposable test `spectrocloud_cluster_profile` at it via `dev_overrides`, and exercised exactly the case #972 doesn't cover — bump version + drop a `profile_variable` the current version's own pack content still references, in one apply. Confirmed:
  - This case reproduces the failure with #972's fix alone (and independently, with the *original* source-selection logic, confirming it's not about which version is picked).
  - Instrumented the sequence to find the precise failure point (draft vs. published content, described above).
  - The fix resolves it cleanly — verified via a direct API read of both the published pack content (no stale variable reference) and the profile's variable set (correctly pruned) afterward.
  - Re-verified across a subsequent third version bump with no regression.

## Which one?

Both are real fixes for #973. #972 is smaller and resolves the reported case. This one is more invasive (reorders more of `Create`) but closes the entire class, including same-apply variable removal, regardless of source selection. Happy to combine them (this fix's ordering + #972's newest-source preference, for defense in depth) if that's preferred — let me know and I'll open a combined PR instead.