### PR TITLE
PLT-2356: add tls_config to spectrocloud_registry_helm credentials

### DIFF
--- a/docs/resources/registry_helm.md
+++ b/docs/resources/registry_helm.md
@@ -20,6 +20,15 @@ resource "spectrocloud_registry_helm" "r1" {
     credential_type = "noAuth"
     username        = "abc"
     password        = "def"
+    # Optional: TLS configuration. Omit the block to send no TLS configuration.
+    # Certificates are PEM content, not paths - use file() to read them from disk.
+    # tls_config {
+    #   enabled              = true
+    #   ca                   = file("${path.module}/ca.pem")
+    #   certificate          = file("${path.module}/client.pem")
+    #   key                  = file("${path.module}/client-key.pem")
+    #   insecure_skip_verify = false
+    # }
   }
   # Optional: Wait for the registry to complete synchronization
   # wait_for_sync = true
@@ -70,8 +79,21 @@ Required:
 Optional:
 
 - `password` (String, Sensitive) Password for basic auth (credential). Required when credential_type is `basic`.
+- `tls_config` (Block List, Max: 1) TLS configuration for the registry. If omitted, no TLS configuration is sent. (see [below for nested schema](#nestedblock--credentials--tls_config))
 - `token` (String, Sensitive) Auth token (credential). Required when credential_type is `token`.
 - `username` (String) The username for basic authentication. Required if 'credential_type' is set to 'basic'.
+
+<a id="nestedblock--credentials--tls_config"></a>
+### Nested Schema for `credentials.tls_config`
+
+Optional:
+
+- `ca` (String) The certificate authority (CA) certificate, in PEM format, used to validate the Helm registry's TLS certificate.
+- `certificate` (String) The client certificate, in PEM format, used for mutual TLS (mTLS) authentication with the Helm registry.
+- `enabled` (Boolean) Specifies whether TLS is enabled for the connection to the Helm registry. Default value is `true`.
+- `insecure_skip_verify` (Boolean) Disables TLS certificate verification when set to true. ⚠️ WARNING: Setting this to true disables SSL certificate verification and makes connections vulnerable to man-in-the-middle attacks. Only use this when connecting to registries with self-signed certificates in trusted networks.
+- `key` (String, Sensitive) The private key, in PEM format, corresponding to the client certificate used for mutual TLS (mTLS) authentication with the Helm registry.
+
 
 
 <a id="nestedblock--timeouts"></a>

--- a/spectrocloud/resource_registry_helm.go
+++ b/spectrocloud/resource_registry_helm.go
@@ -83,6 +83,44 @@ func resourceRegistryHelm() *schema.Resource {
 							Sensitive:   true,
 							Description: "Auth token (credential). Required when credential_type is `token`.",
 						},
+						"tls_config": {
+							Type:        schema.TypeList,
+							Optional:    true,
+							MaxItems:    1,
+							Description: "TLS configuration for the registry. If omitted, no TLS configuration is sent.",
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"enabled": {
+										Type:        schema.TypeBool,
+										Optional:    true,
+										Default:     true,
+										Description: "Specifies whether TLS is enabled for the connection to the Helm registry. Default value is `true`.",
+									},
+									"ca": {
+										Type:        schema.TypeString,
+										Optional:    true,
+										Description: "The certificate authority (CA) certificate, in PEM format, used to validate the Helm registry's TLS certificate.",
+									},
+									"certificate": {
+										Type:        schema.TypeString,
+										Optional:    true,
+										Description: "The client certificate, in PEM format, used for mutual TLS (mTLS) authentication with the Helm registry.",
+									},
+									"key": {
+										Type:        schema.TypeString,
+										Optional:    true,
+										Sensitive:   true,
+										Description: "The private key, in PEM format, corresponding to the client certificate used for mutual TLS (mTLS) authentication with the Helm registry.",
+									},
+									"insecure_skip_verify": {
+										Type:        schema.TypeBool,
+										Optional:    true,
+										Default:     false,
+										Description: "Disables TLS certificate verification when set to true. ⚠️ WARNING: Setting this to true disables SSL certificate verification and makes connections vulnerable to man-in-the-middle attacks. Only use this when connecting to registries with self-signed certificates in trusted networks.",
+									},
+								},
+							},
+						},
 					},
 				},
 			},
@@ -121,6 +159,36 @@ func resourceRegistryHelmCreate(ctx context.Context, d *schema.ResourceData, m i
 	return diags
 }
 
+// helmRegistryTLSConfigForRead flattens the API TLS payload back into state.
+// It mirrors ociBasicTLSConfigForRead: the block is only emitted when the
+// practitioner configured one or the API returned something meaningful, so a
+// registry stored without TLS does not produce a diff.
+func helmRegistryTLSConfigForRead(d *schema.ResourceData, apiTLS *models.V1TLSConfiguration) []interface{} {
+	tlsConfig := make([]interface{}, 0, 1)
+	if apiTLS == nil {
+		return tlsConfig
+	}
+	hasStateTLS := false
+	if credsRaw, ok := d.Get("credentials").([]interface{}); ok && len(credsRaw) > 0 {
+		if credMap, ok := credsRaw[0].(map[string]interface{}); ok {
+			if tlsRaw, ok := credMap["tls_config"].([]interface{}); ok && len(tlsRaw) > 0 {
+				hasStateTLS = true
+			}
+		}
+	}
+	hasMeaningfulTLS := apiTLS.Ca != "" || apiTLS.Certificate != "" || apiTLS.Key != "" || apiTLS.InsecureSkipVerify
+	if hasStateTLS || hasMeaningfulTLS {
+		tlsConfig = append(tlsConfig, map[string]interface{}{
+			"enabled":              apiTLS.Enabled,
+			"ca":                   apiTLS.Ca,
+			"certificate":          apiTLS.Certificate,
+			"key":                  apiTLS.Key,
+			"insecure_skip_verify": apiTLS.InsecureSkipVerify,
+		})
+	}
+	return tlsConfig
+}
+
 func resourceRegistryHelmRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	c := getV1ClientWithResourceContext(m, "tenant")
 	var diags diag.Diagnostics
@@ -151,11 +219,14 @@ func resourceRegistryHelmRead(ctx context.Context, d *schema.ResourceData, m int
 		return diag.FromErr(err)
 	}
 
+	tlsConfig := helmRegistryTLSConfigForRead(d, registry.Spec.Auth.TLS)
+
 	switch registry.Spec.Auth.Type {
 	case "noAuth":
 		credentials := make([]interface{}, 0, 1)
 		acc := make(map[string]interface{})
 		acc["credential_type"] = "noAuth"
+		acc["tls_config"] = tlsConfig
 		credentials = append(credentials, acc)
 		if err := d.Set("credentials", credentials); err != nil {
 			return diag.FromErr(err)
@@ -166,6 +237,7 @@ func resourceRegistryHelmRead(ctx context.Context, d *schema.ResourceData, m int
 		acc["credential_type"] = "basic"
 		acc["username"] = registry.Spec.Auth.Username
 		acc["password"] = registry.Spec.Auth.Password.String()
+		acc["tls_config"] = tlsConfig
 		credentials = append(credentials, acc)
 		if err := d.Set("credentials", credentials); err != nil {
 			return diag.FromErr(err)
@@ -176,6 +248,7 @@ func resourceRegistryHelmRead(ctx context.Context, d *schema.ResourceData, m int
 		acc["credential_type"] = "token"
 		acc["username"] = registry.Spec.Auth.Username
 		acc["token"] = registry.Spec.Auth.Token.String()
+		acc["tls_config"] = tlsConfig
 		credentials = append(credentials, acc)
 		if err := d.Set("credentials", credentials); err != nil {
 			return diag.FromErr(err)
@@ -269,6 +342,19 @@ func toRegistryHelmCredential(regCred map[string]interface{}) *models.V1Registry
 		auth.Username = regCred["username"].(string)
 		auth.Token = strfmt.Password(regCred["token"].(string))
 	}
+
+	// TLS is only sent when configured, so existing configs are unaffected.
+	if tlsCfg, ok := regCred["tls_config"].([]interface{}); ok && len(tlsCfg) > 0 && tlsCfg[0] != nil {
+		tlsMap := tlsCfg[0].(map[string]interface{})
+		auth.TLS = &models.V1TLSConfiguration{
+			Enabled:            tlsMap["enabled"].(bool),
+			Ca:                 tlsMap["ca"].(string),
+			Certificate:        tlsMap["certificate"].(string),
+			Key:                tlsMap["key"].(string),
+			InsecureSkipVerify: tlsMap["insecure_skip_verify"].(bool),
+		}
+	}
+
 	return auth
 }
 

--- a/spectrocloud/resource_registry_helm_test.go
+++ b/spectrocloud/resource_registry_helm_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/spectrocloud/palette-sdk-go/api/models"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -91,4 +92,172 @@ func TestResourceRegistryHelmUpdateWithWaitForSync(t *testing.T) {
 	diags = resourceRegistryHelmUpdate(ctx, d, unitTestMockAPIClient)
 	// Should complete successfully with no errors or warnings
 	assert.Equal(t, 0, len(diags))
+}
+
+// PLT-2356: spectrocloud_registry_helm had no TLS knob and
+// toRegistryHelmCredential never populated V1RegistryAuth.TLS, so custom CA,
+// mTLS and insecureSkipVerify were unreachable from Terraform. The block is
+// nested under credentials as tls_config, matching spectrocloud_registry_oci
+// and the API's spec.auth.tls shape, and is sent only when configured.
+
+func helmCredentialsWithTLS(tls []interface{}) []interface{} {
+	cred := map[string]interface{}{
+		"credential_type": "basic",
+		"username":        "test-username",
+		"password":        "test-password",
+	}
+	if tls != nil {
+		cred["tls_config"] = tls
+	}
+	return []interface{}{cred}
+}
+
+func TestPLT2356_HelmRegistryTLSSchema(t *testing.T) {
+	creds := resourceRegistryHelm().Schema["credentials"].Elem.(*schema.Resource).Schema
+	tlsSchema, ok := creds["tls_config"]
+	assert.True(t, ok, "expected a tls_config block inside credentials")
+	assert.Equal(t, schema.TypeList, tlsSchema.Type)
+	assert.True(t, tlsSchema.Optional)
+	assert.Equal(t, 1, tlsSchema.MaxItems)
+
+	_, topLevel := resourceRegistryHelm().Schema["tls"]
+	assert.False(t, topLevel, "tls must live under credentials, not at the top level")
+
+	fields := tlsSchema.Elem.(*schema.Resource).Schema
+
+	tests := []struct {
+		name        string
+		field       string
+		wantType    schema.ValueType
+		wantDefault interface{}
+		sensitive   bool
+	}{
+		{"enabled defaults to true", "enabled", schema.TypeBool, true, false},
+		{"ca is a plain string", "ca", schema.TypeString, nil, false},
+		{"certificate is a plain string", "certificate", schema.TypeString, nil, false},
+		{"key is sensitive", "key", schema.TypeString, nil, true},
+		{"insecure_skip_verify defaults to false", "insecure_skip_verify", schema.TypeBool, false, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f, ok := fields[tt.field]
+			assert.True(t, ok, "missing tls_config field %q", tt.field)
+			assert.Equal(t, tt.wantType, f.Type)
+			assert.True(t, f.Optional)
+			assert.Equal(t, tt.wantDefault, f.Default)
+			assert.Equal(t, tt.sensitive, f.Sensitive)
+		})
+	}
+}
+
+func TestPLT2356_HelmRegistryTLSPayload(t *testing.T) {
+	tests := []struct {
+		name string
+		tls  []interface{}
+		want *models.V1TLSConfiguration
+	}{
+		{
+			name: "omitted block sends no tls",
+			tls:  nil,
+			want: nil,
+		},
+		{
+			name: "enabled with ca only",
+			tls: []interface{}{map[string]interface{}{
+				"enabled": true, "ca": "ca-pem", "certificate": "", "key": "", "insecure_skip_verify": false,
+			}},
+			want: &models.V1TLSConfiguration{Enabled: true, Ca: "ca-pem"},
+		},
+		{
+			name: "mutual tls with client certificate",
+			tls: []interface{}{map[string]interface{}{
+				"enabled": true, "ca": "ca-pem", "certificate": "cert-pem", "key": "key-pem", "insecure_skip_verify": false,
+			}},
+			want: &models.V1TLSConfiguration{Enabled: true, Ca: "ca-pem", Certificate: "cert-pem", Key: "key-pem"},
+		},
+		{
+			name: "insecure skip verify",
+			tls: []interface{}{map[string]interface{}{
+				"enabled": true, "ca": "", "certificate": "", "key": "", "insecure_skip_verify": true,
+			}},
+			want: &models.V1TLSConfiguration{Enabled: true, InsecureSkipVerify: true},
+		},
+		{
+			name: "explicitly disabled",
+			tls: []interface{}{map[string]interface{}{
+				"enabled": false, "ca": "", "certificate": "", "key": "", "insecure_skip_verify": false,
+			}},
+			want: &models.V1TLSConfiguration{Enabled: false},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			d := prepareResourceRegistryHelm()
+			_ = d.Set("credentials", helmCredentialsWithTLS(tt.tls))
+			// Create and update build separate payload types from the same block.
+			assert.Equal(t, tt.want, toRegistryEntityHelm(d).Spec.Auth.TLS, "create path")
+			assert.Equal(t, tt.want, toRegistryHelm(d).Spec.Auth.TLS, "update path")
+		})
+	}
+}
+
+// Read emits tls_config only when the practitioner configured one or the API
+// returned something meaningful, so registries stored without TLS show no diff.
+func TestPLT2356_HelmRegistryTLSRead(t *testing.T) {
+	tests := []struct {
+		name       string
+		configured bool
+		want       []interface{}
+	}{
+		{
+			name:       "configured block round-trips from the api",
+			configured: true,
+			want: []interface{}{map[string]interface{}{
+				"enabled": true, "ca": "test-ca-pem", "certificate": "test-cert-pem",
+				"key": "test-key-pem", "insecure_skip_verify": true,
+			}},
+		},
+		{
+			name:       "unconfigured block still surfaces meaningful api tls",
+			configured: false,
+			want: []interface{}{map[string]interface{}{
+				"enabled": true, "ca": "test-ca-pem", "certificate": "test-cert-pem",
+				"key": "test-key-pem", "insecure_skip_verify": true,
+			}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			d := resourceRegistryHelm().TestResourceData()
+			d.SetId("helm-uid-tls")
+			if tt.configured {
+				_ = d.Set("credentials", helmCredentialsWithTLS([]interface{}{
+					map[string]interface{}{"enabled": true},
+				}))
+			}
+
+			diags := resourceRegistryHelmRead(context.Background(), d, unitTestMockAPIClient)
+			assert.False(t, diags.HasError(), "unexpected error: %v", diags)
+
+			creds := d.Get("credentials").([]interface{})
+			assert.Len(t, creds, 1)
+			assert.Equal(t, tt.want, creds[0].(map[string]interface{})["tls_config"])
+		})
+	}
+}
+
+// A registry whose API payload carries no meaningful TLS emits no tls_config.
+func TestPLT2356_HelmRegistryTLSReadOmittedWhenEmpty(t *testing.T) {
+	d := resourceRegistryHelm().TestResourceData()
+	d.SetId("test-registry-uid")
+
+	diags := resourceRegistryHelmRead(context.Background(), d, unitTestMockAPIClient)
+	assert.False(t, diags.HasError(), "unexpected error: %v", diags)
+
+	creds := d.Get("credentials").([]interface{})
+	assert.Len(t, creds, 1)
+	assert.Empty(t, creds[0].(map[string]interface{})["tls_config"])
 }

--- a/templates/resources/registry_helm.md.tmpl
+++ b/templates/resources/registry_helm.md.tmpl
@@ -20,6 +20,15 @@ resource "spectrocloud_registry_helm" "r1" {
     credential_type = "noAuth"
     username        = "abc"
     password        = "def"
+    # Optional: TLS configuration. Omit the block to send no TLS configuration.
+    # Certificates are PEM content, not paths - use file() to read them from disk.
+    # tls_config {
+    #   enabled              = true
+    #   ca                   = file("${path.module}/ca.pem")
+    #   certificate          = file("${path.module}/client.pem")
+    #   key                  = file("${path.module}/client-key.pem")
+    #   insecure_skip_verify = false
+    # }
   }
   # Optional: Wait for the registry to complete synchronization
   # wait_for_sync = true

--- a/tests/mockApiServer/routes/mockRegistries.go
+++ b/tests/mockApiServer/routes/mockRegistries.go
@@ -69,6 +69,38 @@ func getHelmRegistryPayload() *models.V1HelmRegistry {
 	}
 }
 
+// helmRegistryFixtureFor dispatches GET /v1/registries/helm/{uid} by UID,
+// mirroring ecrRegistryFixtureFor/basicRegistryFixtureFor below. PLT-2356:
+// added the "helm-uid-tls" case so resourceRegistryHelmRead's TLS mapping
+// (registry.Spec.Auth.TLS != nil branch) can be exercised directly. The
+// default branch preserves the original static payload so every pre-existing
+// helm registry test keeps passing unmodified.
+func helmRegistryFixtureFor(uid string) (*models.V1HelmRegistry, int) {
+	switch uid {
+	case "helm-uid-tls":
+		r := getHelmRegistryPayload()
+		r.Metadata.UID = uid
+		r.Spec.Auth.TLS = &models.V1TLSConfiguration{
+			Ca:                 "test-ca-pem",
+			Certificate:        "test-cert-pem",
+			Enabled:            true,
+			InsecureSkipVerify: true,
+			Key:                "test-key-pem",
+		}
+		return r, http.StatusOK
+	default:
+		return getHelmRegistryPayload(), http.StatusOK
+	}
+}
+
+func helmRegistryGetHandler(w http.ResponseWriter, r *http.Request) {
+	uid := mux.Vars(r)["uid"]
+	payload, status := helmRegistryFixtureFor(uid)
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(payload)
+}
+
 // ecrRegistryFixtureFor dispatches GET /v1/registries/oci/{uid}/ecr by UID so
 // resourceRegistryEcrRead's credential-type switch and the TLS nil/non-nil
 // branch can each be exercised directly. The default branch preserves the
@@ -412,12 +444,9 @@ func RegistriesRoutes() []Route {
 			},
 		},
 		{
-			Method: "GET",
-			Path:   "/v1/registries/helm/{uid}",
-			Response: ResponseData{
-				StatusCode: http.StatusOK,
-				Payload:    getHelmRegistryPayload(),
-			},
+			Method:  "GET",
+			Path:    "/v1/registries/helm/{uid}",
+			Handler: helmRegistryGetHandler,
 		},
 		{
 			Method: "GET",


### PR DESCRIPTION
## Problem

`spectrocloud_registry_helm` exposes no way to configure TLS. `toRegistryHelmCredential` never populated `V1RegistryAuth.TLS`, and hubble only maps TLS when the client sends it (`if registryAuth.TLS != nil`), so a Terraform-created Helm registry was stored with `tls.enabled: false` — while the equivalent UI create stores `tls.enabled: true`.

Practical impact: custom/internal CA trust, client certificates (mTLS), and `insecureSkipVerify` were all unreachable from Terraform. Public-CA HTTPS endpoints were unaffected (Go's default transport still verifies against system roots), so this bites private, on-prem and airgapped registries.

Reported by a customer via SCS-4727 as *"Private Helm registry creation via Terraform is setting tls.enabled = false"*, root-caused under SUS-1977.

## Root cause

- `spectrocloud/resource_registry_helm.go` — schema had no TLS field at any level; `toRegistryHelmCredential` built `V1RegistryAuth` without ever touching `.TLS`.
- `hubble/svcclient/converter/v1/registry_converter.go:74` — `if registryAuth.TLS != nil { ... }`, so an omitted block is stored as the zero value.
- `hubble/domain/registry.go:116-144` — `GetTlsConfig` returns `nil` when `!Enabled`; the trust anchor comes only from `Ca`, and a client key pair is built only when `Certificate` **and** `Key` are both set.

The API model (`V1TLSConfiguration`) has always carried all five fields. This was purely a provider-side gap.

## Fix

Adds an optional `tls_config` block **under `credentials`**, matching the existing `spectrocloud_registry_oci` pattern and mirroring the API's `spec.auth.tls` shape:

```hcl
credentials {
  credential_type = "basic"
  username        = var.u
  password        = var.p

  tls_config {
    enabled              = true
    ca                   = file("${path.module}/ca.pem")
    certificate          = file("${path.module}/client.pem")
    key                  = file("${path.module}/client-key.pem")
    insecure_skip_verify = false
  }
}
```

Certificates are PEM **content**, not paths — consistent with `backup_storage_location.ca_cert` and `sso.identity_provider_ca_certificate`.

**Backward compatible by design: TLS is sent only when the block is configured.** A config without `tls_config` produces a byte-identical payload to the current released provider, so no existing resource is mutated on the next apply. Read is guarded the same way (`helmRegistryTLSConfigForRead`, modelled on `ociBasicTLSConfigForRead`), so registries stored without TLS produce no phantom diff.

`key` is marked `Sensitive`. The `insecure_skip_verify` description reuses the MITM warning already used by the OCI resource.

## Verification

Unit tests — table-driven, merged into `resource_registry_helm_test.go` (14 subtests):

```
go test ./spectrocloud/ -run TestPLT2356 -v
```
Covers schema shape/defaults/sensitivity, payload mapping on **both** create and update paths (omitted, ca-only, mTLS, insecure-skip, explicitly-disabled), read round-trip, and read-omitted-when-empty. Also asserts no top-level `tls` key exists, so the earlier shape cannot creep back.

Full suite green: `go test ./spectrocloud/...` → exit 0. `gofmt`, `go build`, `go vet`, `golangci-lint` clean (one pre-existing `resource_developer_setting.go` gofmt finding is untouched and also present on `main`).

**End-to-end against a live Palette tenant**, provider built from this branch via `dev_overrides`:

| Config | Stored `spec.auth.tls` |
|---|---|
| no `tls_config` block | `{enabled: false, insecureSkipVerify: false}` — unchanged from released provider |
| `tls_config { enabled = true }` | `{enabled: true, insecureSkipVerify: false}` — matches a UI-created registry |

`terraform plan` after apply reported **No changes** (no drift), and both test registries were destroyed afterwards (confirmed HTTP 404).

## Notes for review

- `tests/mockApiServer/routes/mockRegistries.go` gains a UID-dispatched `helm-uid-tls` fixture, following the existing `ecrRegistryFixtureFor` / `basicRegistryFixtureFor` pattern. Default UID behavior is unchanged, so no pre-existing fixture data moved.
- `docs/resources/registry_helm.md` is regenerated via `go generate ./...` (tfplugindocs), not hand-edited.
- `resource_registry_helm_import.go` needed no change — it delegates to Read.
- Related, filed separately: **PLT-2357** — `spectrocloud_registry_oci`'s existing `tls_config` is missing `ca` and `key`, so custom-CA trust and mTLS are unreachable there too and `certificate` set alone is inert. Not addressed here.

## Backport

None yet. If this is wanted on a release line, it should be a separate PR after this merges to `main`.

Refs: PLT-2356, SUS-1977, SCS-4727
