### PR TITLE
fix: preserve helm registry password/token from state on Read (PLT-2400)

### DIFF
--- a/spectrocloud/resource_registry_helm.go
+++ b/spectrocloud/resource_registry_helm.go
@@ -121,6 +121,23 @@ func resourceRegistryHelmCreate(ctx context.Context, d *schema.ResourceData, m i
 	return diags
 }
 
+// helmRegistryCredentialFieldForRead preserves a sensitive credential field
+// (password, token) from state instead of the value the API just returned.
+// Palette's GET does not echo back the plaintext secret (empty or masked),
+// so writing it into state on every Read produces perpetual plan drift
+// against the value configured in HCL. Mirrors the fix already applied to
+// spectrocloud_registry_oci for the same root cause (see PLT-2400).
+func helmRegistryCredentialFieldForRead(d *schema.ResourceData, field string, apiValue string) interface{} {
+	if credsRaw, ok := d.Get("credentials").([]interface{}); ok && len(credsRaw) > 0 {
+		if credMap, ok := credsRaw[0].(map[string]interface{}); ok {
+			if val, exists := credMap[field]; exists && val != nil {
+				return val
+			}
+		}
+	}
+	return apiValue
+}
+
 func resourceRegistryHelmRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	c := getV1ClientWithResourceContext(m, "tenant")
 	var diags diag.Diagnostics
@@ -165,7 +182,7 @@ func resourceRegistryHelmRead(ctx context.Context, d *schema.ResourceData, m int
 		acc := make(map[string]interface{})
 		acc["credential_type"] = "basic"
 		acc["username"] = registry.Spec.Auth.Username
-		acc["password"] = registry.Spec.Auth.Password.String()
+		acc["password"] = helmRegistryCredentialFieldForRead(d, "password", registry.Spec.Auth.Password.String())
 		credentials = append(credentials, acc)
 		if err := d.Set("credentials", credentials); err != nil {
 			return diag.FromErr(err)
@@ -175,7 +192,7 @@ func resourceRegistryHelmRead(ctx context.Context, d *schema.ResourceData, m int
 		acc := make(map[string]interface{})
 		acc["credential_type"] = "token"
 		acc["username"] = registry.Spec.Auth.Username
-		acc["token"] = registry.Spec.Auth.Token.String()
+		acc["token"] = helmRegistryCredentialFieldForRead(d, "token", registry.Spec.Auth.Token.String())
 		credentials = append(credentials, acc)
 		if err := d.Set("credentials", credentials); err != nil {
 			return diag.FromErr(err)

--- a/spectrocloud/resource_registry_helm_test.go
+++ b/spectrocloud/resource_registry_helm_test.go
@@ -92,3 +92,49 @@ func TestResourceRegistryHelmUpdateWithWaitForSync(t *testing.T) {
 	// Should complete successfully with no errors or warnings
 	assert.Equal(t, 0, len(diags))
 }
+
+// The mock's helm registry payload returns password "test=pwd" and token "as",
+// which differ from what's set in state below. Read must preserve the
+// state values rather than overwriting them with the API's response, or
+// every subsequent plan reports spurious drift (PLT-2400).
+func TestResourceRegistryHelmReadPreservesCredentialsFromState(t *testing.T) {
+	d := prepareResourceRegistryHelm()
+	d.SetId("test-registry-uid")
+	var cred []interface{}
+	cred = append(cred, map[string]interface{}{
+		"credential_type": "token",
+		"username":        "test-username",
+		"password":        "",
+		"token":           "state-token",
+	})
+	_ = d.Set("credentials", cred)
+
+	var diags diag.Diagnostics
+	ctx := context.Background()
+	diags = resourceRegistryHelmRead(ctx, d, unitTestMockAPIClient)
+	assert.Equal(t, 0, len(diags))
+
+	creds := d.Get("credentials").([]interface{})[0].(map[string]interface{})
+	assert.Equal(t, "state-token", creds["token"])
+}
+
+func TestResourceRegistryHelmReadPreservesPasswordFromState(t *testing.T) {
+	d := prepareResourceRegistryHelm()
+	d.SetId("test-helm-basic-uid")
+	var cred []interface{}
+	cred = append(cred, map[string]interface{}{
+		"credential_type": "basic",
+		"username":        "test-username",
+		"password":        "state-password",
+		"token":           "",
+	})
+	_ = d.Set("credentials", cred)
+
+	var diags diag.Diagnostics
+	ctx := context.Background()
+	diags = resourceRegistryHelmRead(ctx, d, unitTestMockAPIClient)
+	assert.Equal(t, 0, len(diags))
+
+	creds := d.Get("credentials").([]interface{})[0].(map[string]interface{})
+	assert.Equal(t, "state-password", creds["password"])
+}

--- a/tests/mockApiServer/routes/mockRegistries.go
+++ b/tests/mockApiServer/routes/mockRegistries.go
@@ -31,6 +31,34 @@ func getPackRegistryPayload() *models.V1PackRegistry {
 	}
 }
 
+// helmRegistryFixtureFor dispatches GET /v1/registries/helm/{uid} by UID so
+// resourceRegistryHelmRead's "basic" branch can be exercised directly, in
+// addition to the default "token" payload. The default branch preserves the
+// original static payload so every pre-existing test keeps passing
+// unmodified.
+func helmRegistryFixtureFor(uid string) *models.V1HelmRegistry {
+	switch uid {
+	case "test-helm-basic-uid":
+		r := getHelmRegistryPayload()
+		r.Spec.Auth = &models.V1RegistryAuth{
+			Password: "api-returned-password",
+			TLS:      nil,
+			Type:     "basic",
+			Username: "sf",
+		}
+		return r
+	default:
+		return getHelmRegistryPayload()
+	}
+}
+
+func helmRegistryGetHandler(w http.ResponseWriter, r *http.Request) {
+	uid := mux.Vars(r)["uid"]
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	_ = json.NewEncoder(w).Encode(helmRegistryFixtureFor(uid))
+}
+
 func getHelmRegistryPayload() *models.V1HelmRegistry {
 	return &models.V1HelmRegistry{
 		APIVersion: "",
@@ -412,12 +440,9 @@ func RegistriesRoutes() []Route {
 			},
 		},
 		{
-			Method: "GET",
-			Path:   "/v1/registries/helm/{uid}",
-			Response: ResponseData{
-				StatusCode: http.StatusOK,
-				Payload:    getHelmRegistryPayload(),
-			},
+			Method:  "GET",
+			Path:    "/v1/registries/helm/{uid}",
+			Handler: helmRegistryGetHandler,
 		},
 		{
 			Method: "GET",


### PR DESCRIPTION
Palette's GET for a Helm registry never echoes back the plaintext password/token, so writing that response straight into state on every Read produced a perpetual credentials.password (and credentials.token) diff against the value configured in HCL. Preserve the value already in state instead, mirroring the fix already applied to spectrocloud_registry_oci for the same root cause.