### PR TITLE
ps-week-37-2026

### DIFF
--- a/spectrocloud/cluster_common_fields.go
+++ b/spectrocloud/cluster_common_fields.go
@@ -31,12 +31,17 @@ func readCommonFields(c *client.V1Client, d *schema.ResourceData, cluster *model
 			return diag.FromErr(err), true
 		}
 	}
+	// Skip gracefully if the caller lacks `cluster.adminKubeconfigDownload` -
+	// this is a separate, more restrictive permission than what's needed to
+	// manage the cluster itself, so a 403 here must not fail the whole read.
 	adminKubeConfig, err := c.GetClusterAdminKubeConfig(d.Id())
-	if err != nil {
+	if err != nil && !isForbiddenErr(err) {
 		return diag.FromErr(err), true
 	}
-	if err := d.Set("admin_kube_config", adminKubeConfig); err != nil {
-		return diag.FromErr(err), true
+	if adminKubeConfig != "" {
+		if err := d.Set("admin_kube_config", adminKubeConfig); err != nil {
+			return diag.FromErr(err), true
+		}
 	}
 
 	if err := d.Set("tags", flattenTags(cluster.Metadata.Labels)); err != nil {

--- a/spectrocloud/cluster_common_fields_test.go
+++ b/spectrocloud/cluster_common_fields_test.go
@@ -1,0 +1,25 @@
+package spectrocloud
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/spectrocloud/terraform-provider-spectrocloud/tests/mockApiServer/routes"
+)
+
+// TestResourceClusterAwsRead_AdminKubeConfigForbidden covers PLT-2355: a
+// caller without the cluster.adminKubeconfigDownload permission gets a 403
+// from GetClusterAdminKubeConfig on every plan/apply. Read must tolerate
+// that specific failure (leaving admin_kube_config unset) instead of
+// aborting the whole read, since the permission is unrelated to the
+// caller's ability to manage the cluster itself.
+func TestResourceClusterAwsRead_AdminKubeConfigForbidden(t *testing.T) {
+	d := prepareAwsClusterResourceData(t)
+	d.SetId(routes.AdminKubeConfigForbiddenUID)
+
+	diags := resourceClusterAwsRead(context.Background(), d, unitTestMockAPIClient)
+	assert.False(t, diags.HasError(), "diags: %+v", diags)
+	assert.Empty(t, d.Get("admin_kube_config"))
+}

--- a/spectrocloud/common_utils.go
+++ b/spectrocloud/common_utils.go
@@ -4,9 +4,18 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/spectrocloud/palette-sdk-go/client"
+	"github.com/spectrocloud/palette-sdk-go/client/apiutil"
 	"github.com/spectrocloud/palette-sdk-go/client/herr"
 	"log"
 )
+
+// isForbiddenErr returns true if the error represents an API authorization
+// failure (e.g. the caller lacks a specific permission such as
+// `cluster.adminKubeconfigDownload`), as opposed to a genuine failure.
+func isForbiddenErr(err error) bool {
+	code := apiutil.ToV1ErrorObj(err).Code
+	return code == "OperationForbidden" || code == "ResOperationForbidden"
+}
 
 func getV1ClientWithResourceContext(m interface{}, resourceContext string) *client.V1Client {
 	c := m.(*client.V1Client)

--- a/spectrocloud/common_utils_test.go
+++ b/spectrocloud/common_utils_test.go
@@ -1,0 +1,48 @@
+package spectrocloud
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/spectrocloud/palette-sdk-go/api/apiutil/transport"
+	"github.com/spectrocloud/palette-sdk-go/api/models"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestIsForbiddenErr covers isForbiddenErr's classification of API errors,
+// added for PLT-2355 (admin_kube_config reads must tolerate a caller that
+// lacks cluster.adminKubeconfigDownload, but must still fail hard on any
+// other error).
+func TestIsForbiddenErr(t *testing.T) {
+	t.Run("OperationForbidden", func(t *testing.T) {
+		err := &transport.TransportError{
+			HttpCode: 403,
+			Payload:  &models.V1Error{Code: "OperationForbidden"},
+		}
+		assert.True(t, isForbiddenErr(err))
+	})
+
+	t.Run("ResOperationForbidden", func(t *testing.T) {
+		err := &transport.TransportError{
+			HttpCode: 403,
+			Payload:  &models.V1Error{Code: "ResOperationForbidden"},
+		}
+		assert.True(t, isForbiddenErr(err))
+	})
+
+	t.Run("unrelated error code does not match", func(t *testing.T) {
+		err := &transport.TransportError{
+			HttpCode: 404,
+			Payload:  &models.V1Error{Code: "ResourceNotFound"},
+		}
+		assert.False(t, isForbiddenErr(err))
+	})
+
+	t.Run("plain go error does not match", func(t *testing.T) {
+		assert.False(t, isForbiddenErr(errors.New("boom")))
+	})
+
+	t.Run("nil error does not match", func(t *testing.T) {
+		assert.False(t, isForbiddenErr(nil))
+	})
+}

--- a/tests/mockApiServer/routes/mockCluster.go
+++ b/tests/mockApiServer/routes/mockCluster.go
@@ -38,6 +38,33 @@ func clusterGetHandler(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
+// AdminKubeConfigForbiddenUID is the sentinel cluster UID that makes
+// adminKubeConfigHandler return 403 OperationForbidden, simulating a caller
+// that lacks the cluster.adminKubeconfigDownload permission (PLT-2355).
+const AdminKubeConfigForbiddenUID = "cluster-uid-admin-kubeconfig-forbidden"
+
+// adminKubeConfigHandler serves GET
+// /v1/spectroclusters/{uid}/assets/adminKubeconfig. Any UID other than
+// AdminKubeConfigForbiddenUID keeps the original 200 behavior every
+// pre-existing test relies on; that sentinel UID returns a 403 so tests can
+// exercise the provider's tolerance for a missing
+// cluster.adminKubeconfigDownload permission.
+func adminKubeConfigHandler(w http.ResponseWriter, r *http.Request) {
+	uid := mux.Vars(r)["uid"]
+	w.Header().Set("Content-Type", "application/json")
+	if uid == AdminKubeConfigForbiddenUID {
+		w.WriteHeader(http.StatusForbidden)
+		_ = json.NewEncoder(w).Encode(getError("OperationForbidden", "Operation 'cluster.adminKubeconfigDownload' is forbidden"))
+		return
+	}
+	w.WriteHeader(http.StatusOK)
+	var buf bytes.Buffer
+	_ = json.NewEncoder(w).Encode(&v1.V1SpectroClustersUIDKubeConfigOK{
+		ContentDisposition: "test-content",
+		Payload:            &buf,
+	})
+}
+
 // clusterFixtureFor is a pure lookup — no side effects, no state — so tests
 // can rely on repeated GETs against the same UID returning the same payload.
 // Add a new case here (and a corresponding constant) when a new
@@ -547,15 +574,13 @@ func ClusterRoutes() []Route {
 			},
 		},
 		{
-			Method: "GET",
-			Path:   "/v1/spectroclusters/{uid}/assets/adminKubeconfig",
-			Response: ResponseData{
-				StatusCode: 200,
-				Payload: &v1.V1SpectroClustersUIDKubeConfigOK{
-					ContentDisposition: "test-content",
-					Payload:            &buffer,
-				},
-			},
+			// UID-dispatched so tests can exercise the
+			// cluster.adminKubeconfigDownload 403 tolerance (PLT-2355)
+			// via the "cluster-uid-admin-kubeconfig-forbidden" sentinel,
+			// while every other UID keeps the original 200 behavior.
+			Method:  "GET",
+			Path:    "/v1/spectroclusters/{uid}/assets/adminKubeconfig",
+			Handler: adminKubeConfigHandler,
 		},
 		{
 			Method: "GET",


### PR DESCRIPTION
…() (#992)

The Terraform provider's cluster Read() (readCommonFields, shared by all 13 cluster resource types) unconditionally fetches admin_kube_config on every plan/apply and aborts the whole read if that call fails. Since Palette 4.8.a, downloading the admin kubeconfig requires the separate cluster.adminKubeconfigDownload permission, so a caller who can otherwise fully manage a cluster but lacks that specific permission gets a hard OperationForbidden error on every plan/apply (SCS-5211).

Add isForbiddenErr (mirroring the existing herr.IsNotFound idiom) and use it to skip setting admin_kube_config on a 403 instead of failing Read().