### PR TITLE
PLT-2375: Port custom-pack tutorial example into examples/tutorials/

### DIFF
--- a/examples/tutorials/custom-pack/README.md
+++ b/examples/tutorials/custom-pack/README.md
@@ -1,0 +1,50 @@
+# Custom pack tutorial example
+
+End-to-end example accompanying the Spectro Cloud tutorial
+[Deploy a Custom Pack](https://docs.spectrocloud.com/tutorials/packs-registries/deploy-pack/).
+
+This terraform configuration provisions a new AWS Kubernetes cluster whose cluster profile layers in
+a custom add-on pack (the "Hello Universe" sample application from the tutorial) on top of the standard
+OS, Kubernetes, CNI, and CSI layers. It will provision the following resources on Spectro Cloud:
+- Cluster Profile (Ubuntu, Kubernetes, Calico CNI, AWS EBS CSI, plus your custom add-on pack)
+- AWS Kubernetes Cluster
+
+## Prerequisites
+
+You will need the following before getting started:
+1. A Palette API key, exported as the `SPECTROCLOUD_APIKEY` environment variable (or supplied via the
+   `sc_api_key` variable).
+2. An AWS cloud account already registered in your Palette project settings.
+3. An AWS EC2 key pair created in the region where you will deploy the cluster.
+4. The custom add-on pack itself, already created and published to a Palette pack registry (OCI or
+   standard) by following the [Deploy a Custom Pack](https://docs.spectrocloud.com/tutorials/packs-registries/deploy-pack/)
+   tutorial. This example deploys that pack — it does not create it.
+5. Standard AWS credentials available via the environment (for example `AWS_ACCESS_KEY_ID` /
+   `AWS_SECRET_ACCESS_KEY`), since this example also uses the `hashicorp/aws` provider to look up
+   available Availability Zones.
+
+## Instructions
+
+Clone this repository to a local directory, and change directory to `examples/tutorials/custom-pack`.
+Proceed with the following:
+1. From the current directory, copy the template variable file `terraform.template.tfvars` to a new
+   file `terraform.tfvars`.
+2. Specify and update all the placeholder (`REPLACE ME`) values in the `terraform.tfvars` file.
+3. Initialize and run terraform: `terraform init && terraform apply`.
+4. Wait for the cluster creation to finish.
+
+## Deploying to a different cloud
+
+This example is written for AWS. To adapt it to Azure or GCP instead:
+- Change the `cloud` argument on `spectrocloud_cluster_profile.profile` in `profile.tf`.
+- Swap the OS, CNI, and CSI pack names/versions in `data.tf` for the equivalents on that cloud.
+- Replace the `spectrocloud_cluster_aws` resource in `cluster.tf` with `spectrocloud_cluster_azure` or
+  `spectrocloud_cluster_gcp`, and update `cloud_config` to match.
+
+## Clean up
+
+Run the destroy operation:
+
+```shell
+terraform destroy
+```

--- a/examples/tutorials/custom-pack/cluster.tf
+++ b/examples/tutorials/custom-pack/cluster.tf
@@ -1,0 +1,54 @@
+resource "spectrocloud_cluster_aws" "cluster" {
+  name             = var.cluster_name
+  tags             = var.tags
+  cloud_account_id = data.spectrocloud_cloudaccount_aws.account.id
+  depends_on       = [spectrocloud_cluster_profile.profile]
+
+  cloud_config {
+    ssh_key_name = var.ssh_key_name
+    region       = var.aws_region_name
+  }
+
+  cluster_profile {
+    id = spectrocloud_cluster_profile.profile.id
+  }
+
+  scan_policy {
+    configuration_scan_schedule = "0 0 * * SUN"
+    penetration_scan_schedule   = "0 0 * * SUN"
+    conformance_scan_schedule   = "0 0 1 * *"
+  }
+
+  ##############################
+  # control-plane-pool
+  ##############################
+  machine_pool {
+    additional_labels = {
+      "owner"   = "docs"
+      "purpose" = "tutorial"
+      "type"    = "control-plane-node"
+    }
+    control_plane           = true
+    control_plane_as_worker = true
+    name                    = "control-plane-pool"
+    count                   = 1
+    instance_type           = var.instance_type
+    disk_size_gb            = 60
+    azs                     = local.azs
+  }
+
+  ##############################
+  # worker-pool
+  ##############################
+  machine_pool {
+    additional_labels = {
+      "owner"   = "docs"
+      "purpose" = "tutorial"
+      "type"    = "worker-node"
+    }
+    name          = "worker-basic"
+    count         = 1
+    instance_type = var.instance_type
+    azs           = local.azs
+  }
+}

--- a/examples/tutorials/custom-pack/data.tf
+++ b/examples/tutorials/custom-pack/data.tf
@@ -1,0 +1,69 @@
+####################################
+# Data resources for the profile
+####################################
+data "spectrocloud_registry" "public_registry" {
+  name = "Public Repo"
+}
+
+####################################
+# Core Infrastructure Layers
+# The following core infrastructure layers are configured for deployment to AWS.
+# Change the name and version of the following core infrastructure layers if you want to create the profile for other cloud service providers, such as Azure or GCP.
+# See the "Deploying to a different cloud" section in the README for more details.
+####################################
+data "spectrocloud_pack" "ubuntu" {
+  name         = "ubuntu-aws"
+  version      = "22.04"
+  registry_uid = data.spectrocloud_registry.public_registry.id
+}
+
+data "spectrocloud_pack" "k8s" {
+  name         = "kubernetes"
+  version      = "1.32.3"
+  registry_uid = data.spectrocloud_registry.public_registry.id
+}
+
+data "spectrocloud_pack" "cni" {
+  name         = "cni-calico"
+  version      = "3.29.3"
+  registry_uid = data.spectrocloud_registry.public_registry.id
+}
+
+data "spectrocloud_pack" "csi" {
+  name         = "csi-aws-ebs"
+  version      = "1.41.0"
+  registry_uid = data.spectrocloud_registry.public_registry.id
+}
+
+####################################
+# Add-On Layer: the custom pack created in the tutorial
+####################################
+
+# Select the correct registry (OCI or non-OCI) for the custom add-on pack
+data "spectrocloud_pack" "hellouniverse" {
+  name         = var.custom_addon_pack
+  version      = var.custom_addon_pack_version
+  registry_uid = var.use_oci_registry ? data.spectrocloud_registry_oci.hellouniverseregistry[0].id : data.spectrocloud_registry.hellouniverseregistry[0].id
+}
+
+data "spectrocloud_registry" "hellouniverseregistry" {
+  count = var.use_oci_registry ? 0 : 1
+  name  = var.private_pack_registry
+}
+
+data "spectrocloud_registry_oci" "hellouniverseregistry" {
+  count = var.use_oci_registry ? 1 : 0
+  name  = var.private_pack_registry
+}
+
+####################################
+# Data resources for the cluster
+####################################
+data "spectrocloud_cloudaccount_aws" "account" {
+  name = var.cluster_cloud_account_aws_name
+}
+
+####################################
+# AWS
+####################################
+data "aws_availability_zones" "available" {}

--- a/examples/tutorials/custom-pack/outputs.tf
+++ b/examples/tutorials/custom-pack/outputs.tf
@@ -1,0 +1,11 @@
+output "advisory" {
+  value = <<-EOT
+    It takes between one to three minutes for DNS to properly resolve the public load balancer URL.
+    We recommend waiting a few moments before clicking on the service URL to prevent the browser from caching an unresolved DNS request.
+  EOT
+}
+
+output "profile_id" {
+  description = "The ID of the cluster profile created by this example."
+  value       = spectrocloud_cluster_profile.profile.id
+}

--- a/examples/tutorials/custom-pack/profile.tf
+++ b/examples/tutorials/custom-pack/profile.tf
@@ -1,0 +1,48 @@
+resource "spectrocloud_cluster_profile" "profile" {
+  name        = var.cluster_profile_name
+  description = var.cluster_profile_description
+  tags        = var.tags
+  cloud       = "aws"     # Possible values: "aws", "azure", "gcp"
+  type        = "cluster" # Possible values: "cluster", "add-on"
+
+  ############################
+  # Core layers
+  ############################
+  pack {
+    name   = "ubuntu-aws"
+    tag    = "22.04"
+    uid    = data.spectrocloud_pack.ubuntu.id
+    values = data.spectrocloud_pack.ubuntu.values
+  }
+
+  pack {
+    name   = "kubernetes"
+    tag    = "1.32.3"
+    uid    = data.spectrocloud_pack.k8s.id
+    values = data.spectrocloud_pack.k8s.values
+  }
+
+  pack {
+    name   = "cni-calico"
+    tag    = "3.29.3"
+    uid    = data.spectrocloud_pack.cni.id
+    values = data.spectrocloud_pack.cni.values
+  }
+
+  pack {
+    name   = "csi-aws-ebs"
+    tag    = "1.41.0"
+    uid    = data.spectrocloud_pack.csi.id
+    values = data.spectrocloud_pack.csi.values
+  }
+
+  ############################
+  # Add-on layer: the custom pack created in the tutorial
+  ############################
+  pack {
+    name   = "hellouniverse"
+    tag    = "1.2.0"
+    uid    = data.spectrocloud_pack.hellouniverse.id
+    values = data.spectrocloud_pack.hellouniverse.values
+  }
+}

--- a/examples/tutorials/custom-pack/providers.tf
+++ b/examples/tutorials/custom-pack/providers.tf
@@ -1,0 +1,37 @@
+terraform {
+  required_providers {
+    spectrocloud = {
+      version = ">= 0.16.1"
+      source  = "spectrocloud/spectrocloud"
+    }
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
+variable "sc_host" {
+  description = "The Palette API endpoint to connect to."
+  default     = "api.spectrocloud.com"
+}
+
+variable "sc_api_key" {
+  description = "Your Palette API key. Can also be set via the SPECTROCLOUD_APIKEY environment variable instead of this variable."
+  default     = null
+}
+
+variable "sc_project_name" {
+  description = "The Palette project to deploy resources into (e.g. Default)."
+  default     = "Default"
+}
+
+provider "spectrocloud" {
+  host         = var.sc_host
+  api_key      = var.sc_api_key
+  project_name = var.sc_project_name
+}
+
+# The aws provider is used only to look up available Availability Zones (see data.tf).
+# It relies on the standard AWS credential chain (environment variables, ~/.aws/credentials, etc.)
+# and needs no explicit configuration here.

--- a/examples/tutorials/custom-pack/terraform.template.tfvars
+++ b/examples/tutorials/custom-pack/terraform.template.tfvars
@@ -1,0 +1,6 @@
+cluster_cloud_account_aws_name = "REPLACE ME" # Name of the AWS cloud account already registered in your Palette project settings
+aws_region_name                = "REPLACE ME" # An AWS region, e.g. "us-east-1"
+aws_az_names                   = []           # Optional: AWS Availability Zones to use, e.g. ["us-east-1a", "us-east-1b"]. Leave empty to auto-select one.
+ssh_key_name                   = "REPLACE ME" # Name of an existing AWS EC2 key pair in aws_region_name
+private_pack_registry          = "REPLACE ME" # Name, in Palette, of the registry hosting the custom add-on pack from the tutorial
+use_oci_registry               = true         # true if private_pack_registry is an OCI registry, false for a standard Palette pack registry

--- a/examples/tutorials/custom-pack/variables.tf
+++ b/examples/tutorials/custom-pack/variables.tf
@@ -1,0 +1,88 @@
+variable "cluster_profile_name" {
+  type        = string
+  description = "The name to give the cluster profile that will be created."
+  default     = "pack-tutorial-profile"
+}
+
+variable "cluster_profile_description" {
+  type        = string
+  description = "A human-readable description for the cluster profile."
+  default     = "My cluster profile as part of the packs tutorial."
+}
+
+variable "cluster_name" {
+  type        = string
+  description = "The name to give the AWS cluster that will be created."
+  default     = "pack-tutorial-cluster"
+}
+
+variable "instance_type" {
+  type        = string
+  description = "The AWS EC2 instance type to use for both the control plane and worker nodes."
+  default     = "m4.xlarge"
+}
+
+# ToDo: Provide a value for the variable below. The value will be the actual cloud account name added to your Palette project settings.
+variable "cluster_cloud_account_aws_name" {
+  type        = string
+  description = "The name of the AWS cloud account already registered in your Palette project settings (Tenant Settings > Cloud Accounts)."
+}
+
+# ToDo: Provide a value for the variable below. The value will be one of the [AWS regions](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Concepts.RegionsAndAvailabilityZones.html)
+# The tutorial example uses "us-east-1" region.
+variable "aws_region_name" {
+  type        = string
+  description = "The AWS region to deploy the cluster into, for example \"us-east-1\"."
+}
+
+# ToDo: Provide a value for the variable below. The value will be one of the [AWS Availability Zones](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Concepts.RegionsAndAvailabilityZones.html)
+# The tutorial example uses "us-east-1a" availability zone.
+variable "aws_az_names" {
+  type        = list(string)
+  description = "The AWS Availability Zones to deploy into, for example [\"us-east-1a\", \"us-east-1b\"]. If left empty, the first available AZ in aws_region_name is used automatically."
+  default     = []
+}
+
+# ToDo: Provide a value for the variable below. The value will be the SSH key created in the AWS region where you will deploy the cluster.
+variable "ssh_key_name" {
+  type        = string
+  description = "The name of an existing AWS EC2 key pair in aws_region_name, used for SSH access to the cluster nodes."
+}
+
+# ToDo: Provide the name of your private registry server.
+# The tutorial example uses "private-pack-registry".
+variable "private_pack_registry" {
+  type        = string
+  description = "The name, in Palette, of the pack registry that hosts the custom add-on pack from the tutorial (used only when use_oci_registry is false)."
+}
+
+variable "custom_addon_pack" {
+  type        = string
+  description = "The name of the custom add-on pack (created in the tutorial) to add to the cluster profile."
+  default     = "hellouniverse"
+}
+
+variable "custom_addon_pack_version" {
+  type        = string
+  description = "The version of the custom add-on pack to add to the cluster profile."
+  default     = "1.0.0"
+}
+
+# ToDo: Set the use of OCI registry to true or false.
+# The default value is set as true.
+variable "use_oci_registry" {
+  type        = bool
+  description = "Whether the custom add-on pack is hosted in an OCI registry (true) or a standard Palette pack registry (false)."
+  default     = true
+}
+
+variable "tags" {
+  type        = list(string)
+  description = "Tags applied to the Palette resources created by this example. Each tag must be 63 characters or fewer, start and end with an alphanumeric character, and contain only alphanumeric characters, dots, dashes, or underscores (no slashes)."
+  default     = ["spectro-cloud-education", "app:hello-universe", "terraform_managed:true"]
+}
+
+locals {
+  # If aws_az_names is left empty, fall back to the first AZ Terraform discovers as available in aws_region_name.
+  azs = length(var.aws_az_names) != 0 ? var.aws_az_names : slice(data.aws_availability_zones.available.names, 0, 1)
+}


### PR DESCRIPTION
Ports the custom-pack example from github.com/spectrocloud/tutorials (terraform/pack-tf) into examples/tutorials/custom-pack/, reshaped to this repo's file-naming convention. All attributes verified against the current provider schema (no drift found); terraform validate passes against the published provider v0.30.0.

Covers PLT-2375 (port), PLT-2376 (README), and PLT-2377 (validation).