### PR TITLE
PLT-2379: Port getting-started-multicloud tutorial example

### DIFF
--- a/examples/tutorials/README.md
+++ b/examples/tutorials/README.md
@@ -13,7 +13,7 @@ following [PORTING_CHECKLIST.md](PORTING_CHECKLIST.md).
 | Folder | Docs tutorial | Status |
 |---|---|---|
 | [`custom-pack/`](custom-pack) | [Deploy a Custom Pack](https://docs.spectrocloud.com/tutorials/packs-registries/deploy-pack/) | Done |
-| [`getting-started-multicloud/`](getting-started-multicloud) | [Cluster Management with Terraform (Getting Started)](https://docs.spectrocloud.com/tutorials/getting-started/palette/aws/deploy-manage-k8s-cluster-tf/) | Planned |
+| [`getting-started-multicloud/`](getting-started-multicloud) | [Cluster Management with Terraform (Getting Started)](https://docs.spectrocloud.com/tutorials/getting-started/palette/aws/deploy-manage-k8s-cluster-tf/) | Done |
 | [`profile-variables/`](profile-variables) | [Deploy Cluster with Profile Variables](https://docs.spectrocloud.com/tutorials/profiles/cluster-profile-variables/) | Planned |
 | [`cluster-templates/`](cluster-templates) | [Standardize Clusters with Cluster Templates (Terraform)](https://docs.spectrocloud.com/tutorials/clusters/cluster-templates/standardize-clusters-with-cluster-templates-terraform/) | Planned |
 | [`pcg-vmware-app/`](pcg-vmware-app) | [Deploy App Workloads with a PCG](https://docs.spectrocloud.com/tutorials/clusters/pcg/deploy-app-pcg/) | Planned |

--- a/examples/tutorials/getting-started-multicloud/README.md
+++ b/examples/tutorials/getting-started-multicloud/README.md
@@ -1,0 +1,67 @@
+# Getting started multi-cloud deployment tutorial example
+
+End-to-end example accompanying the Spectro Cloud Getting Started tutorials:
+[Cluster Management with Terraform](https://docs.spectrocloud.com/tutorials/getting-started/palette/aws/deploy-manage-k8s-cluster-tf/)
+(the same Terraform pattern is used across the AWS, Azure, GCP, and VMware variants of this tutorial
+under Getting Started → Palette).
+
+This single Terraform configuration can deploy a Kubernetes cluster to any combination of AWS, Azure,
+GCP, and VMware vSphere, each with a cluster profile that includes the "Hello Universe" sample application
+and an optional Kubecost add-on. It will provision, per enabled cloud:
+- A Cluster Profile (OS, Kubernetes, CNI, CSI layers, plus Hello Universe and optionally Kubecost)
+- A Kubernetes Cluster on that cloud
+
+## Choosing which cloud(s) to deploy to
+
+The Terraform code has four main toggle variables, each independent — enable as many as you want, as
+long as you provide the required values for each:
+
+| Variable | Provider | Description | Default |
+|---|---|---|---|
+| `deploy-aws` | AWS | Enable to deploy a cluster to AWS. | `false` |
+| `deploy-azure` | Azure | Enable to deploy a cluster to Azure. | `false` |
+| `deploy-gcp` | GCP | Enable to deploy a cluster to GCP. | `false` |
+| `deploy-vmware` | VMware vSphere | Enable to deploy a cluster to VMware vSphere. | `false` |
+
+Each cloud also has a matching `deploy-<cloud>-kubecost` toggle that, when enabled, adds the Kubecost
+add-on pack to that cloud's cluster profile (deployed as profile version `1.1.0` instead of `1.0.0`).
+
+VMware additionally supports static IP placement via `deploy-vmware-static` (see the PCG-related variables
+in `terraform.template.tfvars` if you enable it).
+
+## Prerequisites
+
+You will need the following before getting started:
+1. A Palette API key, exported as the `SPECTROCLOUD_APIKEY` environment variable (or supplied via the
+   `sc_api_key` variable).
+2. A cloud account already registered in your Palette project settings for each cloud you enable.
+3. For AWS: an existing EC2 key pair in the region you deploy to.
+4. For VMware: a Private Cloud Gateway (PCG) already installed — see
+   [Spectro Cloud VMware Cluster](https://docs.spectrocloud.com/getting-started/?getting_started=vmware#yourfirstvmwarecluster)
+   — and its cloud account name.
+5. Terraform 1.9 or later.
+
+## Instructions
+
+Clone this repository to a local directory, and change directory to
+`examples/tutorials/getting-started-multicloud`. Proceed with the following:
+1. From the current directory, copy the template variable file `terraform.template.tfvars` to a new
+   file `terraform.tfvars`.
+2. Set the `deploy-*` toggle(s) for the cloud(s) you want, and fill in all the placeholder
+   (`REPLACE ME`) values relevant to those clouds. Values for clouds you leave disabled don't need to
+   be filled in.
+3. Initialize and run terraform: `terraform init && terraform apply`.
+4. Wait for the cluster creation to finish.
+
+Once a cluster is provisioned, its Hello Universe application becomes reachable through the cluster's
+load balancer — see the `advisory` output for a note on DNS propagation timing. For VMware deployments
+without a supplied SSH key, see the `ssh_key_location` / `ssh_connection_command` outputs for how to
+access the nodes.
+
+## Clean up
+
+Run the destroy operation:
+
+```shell
+terraform destroy
+```

--- a/examples/tutorials/getting-started-multicloud/cluster_profiles.tf
+++ b/examples/tutorials/getting-started-multicloud/cluster_profiles.tf
@@ -1,0 +1,528 @@
+############################
+# AWS Cluster Profile v1.0.0
+############################
+resource "spectrocloud_cluster_profile" "aws-profile" {
+  count = var.deploy-aws ? 1 : 0
+
+  name        = "tf-aws-profile"
+  description = "A basic cluster profile for AWS"
+  tags        = concat(var.tags, ["env:aws"])
+  cloud       = "aws"
+  type        = "cluster"
+  version     = "1.0.0"
+
+  pack {
+    name   = data.spectrocloud_pack.aws_ubuntu.name
+    tag    = data.spectrocloud_pack.aws_ubuntu.version
+    uid    = data.spectrocloud_pack.aws_ubuntu.id
+    values = data.spectrocloud_pack.aws_ubuntu.values
+    type   = "spectro"
+  }
+
+  pack {
+    name   = data.spectrocloud_pack.aws_k8s.name
+    tag    = data.spectrocloud_pack.aws_k8s.version
+    uid    = data.spectrocloud_pack.aws_k8s.id
+    values = data.spectrocloud_pack.aws_k8s.values
+    type   = "spectro"
+  }
+
+  pack {
+    name   = data.spectrocloud_pack.aws_cni.name
+    tag    = data.spectrocloud_pack.aws_cni.version
+    uid    = data.spectrocloud_pack.aws_cni.id
+    values = data.spectrocloud_pack.aws_cni.values
+    type   = "spectro"
+  }
+
+  pack {
+    name   = data.spectrocloud_pack.aws_csi.name
+    tag    = data.spectrocloud_pack.aws_csi.version
+    uid    = data.spectrocloud_pack.aws_csi.id
+    values = data.spectrocloud_pack.aws_csi.values
+    type   = "spectro"
+  }
+
+  pack {
+    name = data.spectrocloud_pack.hellouniverse.name
+    tag  = data.spectrocloud_pack.hellouniverse.version
+    uid  = data.spectrocloud_pack.hellouniverse.id
+    values = templatefile("manifests/values-3tier.yaml", {
+      namespace   = var.app_namespace,
+      port        = var.app_port,
+      replicas    = var.replicas_number,
+      db_password = base64encode(var.db_password),
+      auth_token  = base64encode(var.auth_token)
+    })
+    type = "oci"
+  }
+}
+
+############################
+# AWS Cluster Profile v1.1.0
+############################
+resource "spectrocloud_cluster_profile" "aws-profile-kubecost" {
+  count = var.deploy-aws ? 1 : 0
+
+  name        = "tf-aws-profile"
+  description = "A basic cluster profile for AWS with Kubecost"
+  tags        = concat(var.tags, ["env:aws"])
+  cloud       = "aws"
+  type        = "cluster"
+  version     = "1.1.0"
+
+  pack {
+    name   = data.spectrocloud_pack.aws_ubuntu.name
+    tag    = data.spectrocloud_pack.aws_ubuntu.version
+    uid    = data.spectrocloud_pack.aws_ubuntu.id
+    values = data.spectrocloud_pack.aws_ubuntu.values
+    type   = "spectro"
+  }
+
+  pack {
+    name   = data.spectrocloud_pack.aws_k8s.name
+    tag    = data.spectrocloud_pack.aws_k8s.version
+    uid    = data.spectrocloud_pack.aws_k8s.id
+    values = data.spectrocloud_pack.aws_k8s.values
+    type   = "spectro"
+  }
+
+  pack {
+    name   = data.spectrocloud_pack.aws_cni.name
+    tag    = data.spectrocloud_pack.aws_cni.version
+    uid    = data.spectrocloud_pack.aws_cni.id
+    values = data.spectrocloud_pack.aws_cni.values
+    type   = "spectro"
+  }
+
+  pack {
+    name   = data.spectrocloud_pack.aws_csi.name
+    tag    = data.spectrocloud_pack.aws_csi.version
+    uid    = data.spectrocloud_pack.aws_csi.id
+    values = data.spectrocloud_pack.aws_csi.values
+    type   = "spectro"
+  }
+
+  pack {
+    name = data.spectrocloud_pack.hellouniverse.name
+    tag  = data.spectrocloud_pack.hellouniverse.version
+    uid  = data.spectrocloud_pack.hellouniverse.id
+    values = templatefile("manifests/values-3tier.yaml", {
+      namespace   = var.app_namespace,
+      port        = var.app_port,
+      replicas    = var.replicas_number,
+      db_password = base64encode(var.db_password),
+      auth_token  = base64encode(var.auth_token)
+    })
+    type = "oci"
+  }
+
+  pack {
+    name   = data.spectrocloud_pack.kubecost.name
+    tag    = data.spectrocloud_pack.kubecost.version
+    uid    = data.spectrocloud_pack.kubecost.id
+    values = data.spectrocloud_pack.kubecost.values
+    type   = "oci"
+  }
+}
+
+##############################
+# Azure Cluster Profile v1.0.0
+##############################
+resource "spectrocloud_cluster_profile" "azure-profile" {
+  count = var.deploy-azure ? 1 : 0
+
+  name        = "tf-azure-profile"
+  description = "A basic cluster profile for Azure"
+  tags        = concat(var.tags, ["env:azure"])
+  cloud       = "azure"
+  type        = "cluster"
+  version     = "1.0.0"
+
+  pack {
+    name   = data.spectrocloud_pack.azure_ubuntu.name
+    tag    = data.spectrocloud_pack.azure_ubuntu.version
+    uid    = data.spectrocloud_pack.azure_ubuntu.id
+    values = data.spectrocloud_pack.azure_ubuntu.values
+    type   = "spectro"
+  }
+
+  pack {
+    name   = data.spectrocloud_pack.azure_k8s.name
+    tag    = data.spectrocloud_pack.azure_k8s.version
+    uid    = data.spectrocloud_pack.azure_k8s.id
+    values = data.spectrocloud_pack.azure_k8s.values
+    type   = "spectro"
+  }
+
+  pack {
+    name   = data.spectrocloud_pack.azure_cni.name
+    tag    = data.spectrocloud_pack.azure_cni.version
+    uid    = data.spectrocloud_pack.azure_cni.id
+    values = data.spectrocloud_pack.azure_cni.values
+    type   = "spectro"
+  }
+
+  pack {
+    name   = data.spectrocloud_pack.azure_csi.name
+    tag    = data.spectrocloud_pack.azure_csi.version
+    uid    = data.spectrocloud_pack.azure_csi.id
+    values = data.spectrocloud_pack.azure_csi.values
+    type   = "spectro"
+  }
+
+  pack {
+    name = data.spectrocloud_pack.hellouniverse.name
+    tag  = data.spectrocloud_pack.hellouniverse.version
+    uid  = data.spectrocloud_pack.hellouniverse.id
+    values = templatefile("manifests/values-3tier.yaml", {
+      namespace   = var.app_namespace,
+      port        = var.app_port,
+      replicas    = var.replicas_number,
+      db_password = base64encode(var.db_password),
+      auth_token  = base64encode(var.auth_token)
+    })
+    type = "oci"
+  }
+}
+
+##############################
+# Azure Cluster Profile v1.1.0
+##############################
+resource "spectrocloud_cluster_profile" "azure-profile-kubecost" {
+  count = var.deploy-azure ? 1 : 0
+
+  name        = "tf-azure-profile"
+  description = "A basic cluster profile for Azure with Kubecost"
+  tags        = concat(var.tags, ["env:azure"])
+  cloud       = "azure"
+  type        = "cluster"
+  version     = "1.1.0"
+
+  pack {
+    name   = data.spectrocloud_pack.azure_ubuntu.name
+    tag    = data.spectrocloud_pack.azure_ubuntu.version
+    uid    = data.spectrocloud_pack.azure_ubuntu.id
+    values = data.spectrocloud_pack.azure_ubuntu.values
+    type   = "spectro"
+  }
+
+  pack {
+    name   = data.spectrocloud_pack.azure_k8s.name
+    tag    = data.spectrocloud_pack.azure_k8s.version
+    uid    = data.spectrocloud_pack.azure_k8s.id
+    values = data.spectrocloud_pack.azure_k8s.values
+    type   = "spectro"
+  }
+
+  pack {
+    name   = data.spectrocloud_pack.azure_cni.name
+    tag    = data.spectrocloud_pack.azure_cni.version
+    uid    = data.spectrocloud_pack.azure_cni.id
+    values = data.spectrocloud_pack.azure_cni.values
+    type   = "spectro"
+  }
+
+  pack {
+    name   = data.spectrocloud_pack.azure_csi.name
+    tag    = data.spectrocloud_pack.azure_csi.version
+    uid    = data.spectrocloud_pack.azure_csi.id
+    values = data.spectrocloud_pack.azure_csi.values
+    type   = "spectro"
+  }
+
+  pack {
+    name = data.spectrocloud_pack.hellouniverse.name
+    tag  = data.spectrocloud_pack.hellouniverse.version
+    uid  = data.spectrocloud_pack.hellouniverse.id
+    values = templatefile("manifests/values-3tier.yaml", {
+      namespace   = var.app_namespace,
+      port        = var.app_port,
+      replicas    = var.replicas_number,
+      db_password = base64encode(var.db_password),
+      auth_token  = base64encode(var.auth_token)
+    })
+    type = "oci"
+  }
+
+  pack {
+    name   = data.spectrocloud_pack.kubecost.name
+    tag    = data.spectrocloud_pack.kubecost.version
+    uid    = data.spectrocloud_pack.kubecost.id
+    values = data.spectrocloud_pack.kubecost.values
+    type   = "oci"
+  }
+}
+
+
+############################
+# GCP Cluster Profile v1.0.0
+############################
+resource "spectrocloud_cluster_profile" "gcp-profile" {
+  count = var.deploy-gcp ? 1 : 0
+
+  name        = "tf-gcp-profile"
+  description = "A basic cluster profile for GCP"
+  tags        = concat(var.tags, ["env:GCP"])
+  cloud       = "gcp"
+  type        = "cluster"
+  version     = "1.0.0"
+
+  pack {
+    name   = data.spectrocloud_pack.gcp_ubuntu.name
+    tag    = data.spectrocloud_pack.gcp_ubuntu.version
+    uid    = data.spectrocloud_pack.gcp_ubuntu.id
+    values = data.spectrocloud_pack.gcp_ubuntu.values
+    type   = "spectro"
+  }
+
+  pack {
+    name   = data.spectrocloud_pack.gcp_k8s.name
+    tag    = data.spectrocloud_pack.gcp_k8s.version
+    uid    = data.spectrocloud_pack.gcp_k8s.id
+    values = data.spectrocloud_pack.gcp_k8s.values
+    type   = "spectro"
+  }
+
+  pack {
+    name   = data.spectrocloud_pack.gcp_cni.name
+    tag    = data.spectrocloud_pack.gcp_cni.version
+    uid    = data.spectrocloud_pack.gcp_cni.id
+    values = data.spectrocloud_pack.gcp_cni.values
+    type   = "spectro"
+  }
+
+  pack {
+    name   = data.spectrocloud_pack.gcp_csi.name
+    tag    = data.spectrocloud_pack.gcp_csi.version
+    uid    = data.spectrocloud_pack.gcp_csi.id
+    values = data.spectrocloud_pack.gcp_csi.values
+    type   = "spectro"
+  }
+
+  pack {
+    name = data.spectrocloud_pack.hellouniverse.name
+    tag  = data.spectrocloud_pack.hellouniverse.version
+    uid  = data.spectrocloud_pack.hellouniverse.id
+    values = templatefile("manifests/values-3tier.yaml", {
+      namespace   = var.app_namespace,
+      port        = var.app_port,
+      replicas    = var.replicas_number,
+      db_password = base64encode(var.db_password),
+      auth_token  = base64encode(var.auth_token)
+    })
+    type = "oci"
+  }
+}
+
+############################
+# GCP Cluster Profile v1.1.0
+############################
+resource "spectrocloud_cluster_profile" "gcp-profile-kubecost" {
+  count = var.deploy-gcp ? 1 : 0
+
+  name        = "tf-gcp-profile"
+  description = "A basic cluster profile for GCP with Kubecost"
+  tags        = concat(var.tags, ["env:GCP"])
+  cloud       = "gcp"
+  type        = "cluster"
+  version     = "1.1.0"
+
+  pack {
+    name   = data.spectrocloud_pack.gcp_ubuntu.name
+    tag    = data.spectrocloud_pack.gcp_ubuntu.version
+    uid    = data.spectrocloud_pack.gcp_ubuntu.id
+    values = data.spectrocloud_pack.gcp_ubuntu.values
+    type   = "spectro"
+  }
+
+  pack {
+    name   = data.spectrocloud_pack.gcp_k8s.name
+    tag    = data.spectrocloud_pack.gcp_k8s.version
+    uid    = data.spectrocloud_pack.gcp_k8s.id
+    values = data.spectrocloud_pack.gcp_k8s.values
+    type   = "spectro"
+  }
+
+  pack {
+    name   = data.spectrocloud_pack.gcp_cni.name
+    tag    = data.spectrocloud_pack.gcp_cni.version
+    uid    = data.spectrocloud_pack.gcp_cni.id
+    values = data.spectrocloud_pack.gcp_cni.values
+    type   = "spectro"
+  }
+
+  pack {
+    name   = data.spectrocloud_pack.gcp_csi.name
+    tag    = data.spectrocloud_pack.gcp_csi.version
+    uid    = data.spectrocloud_pack.gcp_csi.id
+    values = data.spectrocloud_pack.gcp_csi.values
+    type   = "spectro"
+  }
+
+  pack {
+    name = data.spectrocloud_pack.hellouniverse.name
+    tag  = data.spectrocloud_pack.hellouniverse.version
+    uid  = data.spectrocloud_pack.hellouniverse.id
+    values = templatefile("manifests/values-3tier.yaml", {
+      namespace   = var.app_namespace,
+      port        = var.app_port,
+      replicas    = var.replicas_number,
+      db_password = base64encode(var.db_password),
+      auth_token  = base64encode(var.auth_token)
+    })
+    type = "oci"
+  }
+
+  pack {
+    name   = data.spectrocloud_pack.kubecost.name
+    tag    = data.spectrocloud_pack.kubecost.version
+    uid    = data.spectrocloud_pack.kubecost.id
+    values = data.spectrocloud_pack.kubecost.values
+    type   = "oci"
+  }
+}
+
+################################
+# VMware Cluster Profile v.1.0.0
+################################
+resource "spectrocloud_cluster_profile" "vmware-profile" {
+  count = var.deploy-vmware ? 1 : 0
+
+  name        = "tf-vmware-profile"
+  description = "A basic cluster profile for VMware"
+  tags        = concat(var.tags, ["env:VMware"])
+  cloud       = "vsphere"
+  type        = "cluster"
+  version     = "1.0.0"
+
+  pack {
+    name   = data.spectrocloud_pack.vmware_ubuntu.name
+    tag    = data.spectrocloud_pack.vmware_ubuntu.version
+    uid    = data.spectrocloud_pack.vmware_ubuntu.id
+    values = data.spectrocloud_pack.vmware_ubuntu.values
+    type   = "spectro"
+  }
+
+  pack {
+    name   = data.spectrocloud_pack.vmware_k8s.name
+    tag    = data.spectrocloud_pack.vmware_k8s.version
+    uid    = data.spectrocloud_pack.vmware_k8s.id
+    values = data.spectrocloud_pack.vmware_k8s.values
+    type   = "spectro"
+  }
+
+  pack {
+    name   = data.spectrocloud_pack.vmware_cni.name
+    tag    = data.spectrocloud_pack.vmware_cni.version
+    uid    = data.spectrocloud_pack.vmware_cni.id
+    values = data.spectrocloud_pack.vmware_cni.values
+    type   = "spectro"
+  }
+
+  pack {
+    name   = data.spectrocloud_pack.vmware_csi.name
+    tag    = data.spectrocloud_pack.vmware_csi.version
+    uid    = data.spectrocloud_pack.vmware_csi.id
+    values = data.spectrocloud_pack.vmware_csi.values
+    type   = "spectro"
+  }
+
+  pack {
+    name   = data.spectrocloud_pack.vmware_metallb.name
+    tag    = data.spectrocloud_pack.vmware_metallb.version
+    uid    = data.spectrocloud_pack.vmware_metallb.id
+    values = replace(data.spectrocloud_pack.vmware_metallb.values, "192.168.10.0/24", var.metallb_ip)
+    type   = "spectro"
+  }
+
+  pack {
+    name = data.spectrocloud_pack.hellouniverse.name
+    tag  = data.spectrocloud_pack.hellouniverse.version
+    uid  = data.spectrocloud_pack.hellouniverse.id
+    values = templatefile("manifests/values-3tier.yaml", {
+      namespace   = var.app_namespace,
+      port        = var.app_port,
+      replicas    = var.replicas_number,
+      db_password = base64encode(var.db_password),
+      auth_token  = base64encode(var.auth_token)
+    })
+    type = "oci"
+  }
+}
+
+###############################
+# VMware Cluster Profile v1.1.0
+###############################
+resource "spectrocloud_cluster_profile" "vmware-profile-kubecost" {
+  count = var.deploy-vmware ? 1 : 0
+
+  name        = "tf-vmware-profile"
+  description = "A basic cluster profile for VMware with Kubecost"
+  tags        = concat(var.tags, ["env:VMware"])
+  cloud       = "vsphere"
+  type        = "cluster"
+  version     = "1.1.0"
+
+  pack {
+    name   = data.spectrocloud_pack.vmware_ubuntu.name
+    tag    = data.spectrocloud_pack.vmware_ubuntu.version
+    uid    = data.spectrocloud_pack.vmware_ubuntu.id
+    values = data.spectrocloud_pack.vmware_ubuntu.values
+    type   = "spectro"
+  }
+
+  pack {
+    name   = data.spectrocloud_pack.vmware_k8s.name
+    tag    = data.spectrocloud_pack.vmware_k8s.version
+    uid    = data.spectrocloud_pack.vmware_k8s.id
+    values = data.spectrocloud_pack.vmware_k8s.values
+    type   = "spectro"
+  }
+
+  pack {
+    name   = data.spectrocloud_pack.vmware_cni.name
+    tag    = data.spectrocloud_pack.vmware_cni.version
+    uid    = data.spectrocloud_pack.vmware_cni.id
+    values = data.spectrocloud_pack.vmware_cni.values
+    type   = "spectro"
+  }
+
+  pack {
+    name   = data.spectrocloud_pack.vmware_csi.name
+    tag    = data.spectrocloud_pack.vmware_csi.version
+    uid    = data.spectrocloud_pack.vmware_csi.id
+    values = data.spectrocloud_pack.vmware_csi.values
+    type   = "spectro"
+  }
+
+  pack {
+    name   = data.spectrocloud_pack.vmware_metallb.name
+    tag    = data.spectrocloud_pack.vmware_metallb.version
+    uid    = data.spectrocloud_pack.vmware_metallb.id
+    values = replace(data.spectrocloud_pack.vmware_metallb.values, "192.168.10.0/24", var.metallb_ip)
+    type   = "spectro"
+  }
+
+  pack {
+    name = data.spectrocloud_pack.hellouniverse.name
+    tag  = data.spectrocloud_pack.hellouniverse.version
+    uid  = data.spectrocloud_pack.hellouniverse.id
+    values = templatefile("manifests/values-3tier.yaml", {
+      namespace   = var.app_namespace,
+      port        = var.app_port,
+      replicas    = var.replicas_number,
+      db_password = base64encode(var.db_password),
+      auth_token  = base64encode(var.auth_token)
+    })
+    type = "oci"
+  }
+
+  pack {
+    name   = data.spectrocloud_pack.kubecost.name
+    tag    = data.spectrocloud_pack.kubecost.version
+    uid    = data.spectrocloud_pack.kubecost.id
+    values = data.spectrocloud_pack.kubecost.values
+    type   = "oci"
+  }
+}

--- a/examples/tutorials/getting-started-multicloud/clusters.tf
+++ b/examples/tutorials/getting-started-multicloud/clusters.tf
@@ -1,0 +1,208 @@
+#############
+# AWS Cluster
+#############
+resource "spectrocloud_cluster_aws" "aws-cluster" {
+  count = var.deploy-aws ? 1 : 0
+
+  name             = "aws-cluster"
+  tags             = concat(var.tags, ["env:aws"])
+  cloud_account_id = data.spectrocloud_cloudaccount_aws.account[0].id
+
+  cloud_config {
+    region       = var.aws-region
+    ssh_key_name = var.aws-key-pair-name
+  }
+
+  cluster_profile {
+    id = var.deploy-aws && var.deploy-aws-kubecost ? resource.spectrocloud_cluster_profile.aws-profile-kubecost[0].id : resource.spectrocloud_cluster_profile.aws-profile[0].id
+  }
+
+  machine_pool {
+    control_plane           = true
+    control_plane_as_worker = true
+    name                    = "control-plane-pool"
+    count                   = var.aws_control_plane_nodes.count
+    instance_type           = var.aws_control_plane_nodes.instance_type
+    disk_size_gb            = var.aws_control_plane_nodes.disk_size_gb
+    azs                     = var.aws_control_plane_nodes.availability_zones
+  }
+
+  machine_pool {
+    name          = "worker-pool"
+    count         = var.aws_worker_nodes.count
+    instance_type = var.aws_worker_nodes.instance_type
+    disk_size_gb  = var.aws_worker_nodes.disk_size_gb
+    azs           = var.aws_worker_nodes.availability_zones
+  }
+
+  timeouts {
+    create = "45m"
+    delete = "45m"
+  }
+}
+###############
+# Azure Cluster
+###############
+resource "spectrocloud_cluster_azure" "azure-cluster" {
+  count = var.deploy-azure ? 1 : 0
+
+  name             = "azure-cluster"
+  tags             = concat(var.tags, ["env:azure"])
+  cloud_account_id = data.spectrocloud_cloudaccount_azure.account[0].id
+
+  cloud_config {
+    subscription_id = var.azure_subscription_id
+    resource_group  = var.azure_resource_group
+    region          = var.azure-region
+    ssh_key         = tls_private_key.tutorial_ssh_key_azure[0].public_key_openssh
+  }
+
+  cluster_profile {
+    id = var.deploy-azure && var.deploy-azure-kubecost ? resource.spectrocloud_cluster_profile.azure-profile-kubecost[0].id : resource.spectrocloud_cluster_profile.azure-profile[0].id
+  }
+
+  machine_pool {
+    control_plane           = true
+    control_plane_as_worker = true
+    name                    = "control-plane-pool"
+    count                   = var.azure_control_plane_nodes.count
+    instance_type           = var.azure_control_plane_nodes.instance_type
+    azs                     = var.azure-use-azs ? var.azure_control_plane_nodes.azs : [""]
+    is_system_node_pool     = var.azure_control_plane_nodes.is_system_node_pool
+    disk {
+      size_gb = var.azure_control_plane_nodes.disk_size_gb
+      type    = "Standard_LRS"
+    }
+  }
+
+  machine_pool {
+    name                = "worker-basic"
+    count               = var.azure_worker_nodes.count
+    instance_type       = var.azure_worker_nodes.instance_type
+    azs                 = var.azure-use-azs ? var.azure_worker_nodes.azs : [""]
+    is_system_node_pool = var.azure_worker_nodes.is_system_node_pool
+  }
+
+  timeouts {
+    create = "45m"
+    delete = "45m"
+  }
+}
+
+#############
+# GCP Cluster
+#############
+resource "spectrocloud_cluster_gcp" "gcp-cluster" {
+  count = var.deploy-gcp ? 1 : 0
+
+  name             = "gcp-cluster"
+  tags             = concat(var.tags, ["env:gcp"])
+  cloud_account_id = data.spectrocloud_cloudaccount_gcp.account[0].id
+
+  cloud_config {
+    project = var.gcp_project_name
+    region  = var.gcp-region
+  }
+
+  cluster_profile {
+    id = var.deploy-gcp && var.deploy-gcp-kubecost ? resource.spectrocloud_cluster_profile.gcp-profile-kubecost[0].id : resource.spectrocloud_cluster_profile.gcp-profile[0].id
+  }
+
+  machine_pool {
+    control_plane           = true
+    control_plane_as_worker = true
+    name                    = "control-plane-pool"
+    count                   = var.gcp_control_plane_nodes.count
+    instance_type           = var.gcp_control_plane_nodes.instance_type
+    disk_size_gb            = var.gcp_control_plane_nodes.disk_size_gb
+    azs                     = var.gcp_control_plane_nodes.availability_zones
+  }
+
+  machine_pool {
+    name          = "worker-pool"
+    count         = var.gcp_worker_nodes.count
+    instance_type = var.gcp_worker_nodes.instance_type
+    disk_size_gb  = var.gcp_worker_nodes.disk_size_gb
+    azs           = var.gcp_worker_nodes.availability_zones
+  }
+
+  timeouts {
+    create = "45m"
+    delete = "45m"
+  }
+}
+
+################
+# VMware Cluster
+################
+
+resource "spectrocloud_cluster_vsphere" "vmware-cluster" {
+  count = var.deploy-vmware ? 1 : 0
+
+  name             = "vmware-cluster"
+  tags             = concat(var.tags, ["env:vmware"])
+  cloud_account_id = data.spectrocloud_cloudaccount_vsphere.account[0].id
+
+  cloud_config {
+    ssh_keys              = [local.ssh_public_key]
+    datacenter            = var.datacenter_name
+    folder                = var.folder_name
+    static_ip             = var.deploy-vmware-static # If true, the cluster will use static IP placement. If false, the cluster will use DDNS.
+    network_search_domain = var.search_domain
+  }
+
+  cluster_profile {
+    id = var.deploy-vmware && var.deploy-vmware-kubecost ? resource.spectrocloud_cluster_profile.vmware-profile-kubecost[0].id : resource.spectrocloud_cluster_profile.vmware-profile[0].id
+  }
+
+  scan_policy {
+    configuration_scan_schedule = "0 0 * * SUN"
+    penetration_scan_schedule   = "0 0 * * SUN"
+    conformance_scan_schedule   = "0 0 1 * *"
+  }
+
+  machine_pool {
+    name                    = "control-plane-pool"
+    count                   = 1
+    control_plane           = true
+    control_plane_as_worker = true
+
+    instance_type {
+      cpu          = 4
+      disk_size_gb = 60
+      memory_mb    = 8000
+    }
+
+    placement {
+      cluster       = var.vsphere_cluster
+      datastore     = var.datastore_name
+      network       = var.network_name
+      resource_pool = var.resource_pool_name
+      # Required for static IP placement.
+      static_ip_pool_id = var.deploy-vmware-static ? resource.spectrocloud_privatecloudgateway_ippool.ippool[0].id : null
+    }
+
+  }
+
+  machine_pool {
+    name          = "worker-pool"
+    count         = 1
+    control_plane = false
+
+    instance_type {
+      cpu          = 4
+      disk_size_gb = 60
+      memory_mb    = 8000
+    }
+
+    placement {
+      cluster       = var.vsphere_cluster
+      datastore     = var.datastore_name
+      network       = var.network_name
+      resource_pool = var.resource_pool_name
+      # Required for static IP placement.
+      static_ip_pool_id = var.deploy-vmware-static ? resource.spectrocloud_privatecloudgateway_ippool.ippool[0].id : null
+    }
+  }
+
+}

--- a/examples/tutorials/getting-started-multicloud/data.tf
+++ b/examples/tutorials/getting-started-multicloud/data.tf
@@ -1,0 +1,171 @@
+########################################
+# Data resources for the cluster profile
+########################################
+data "spectrocloud_registry" "public_registry" {
+  name = "Public Repo"
+}
+
+data "spectrocloud_registry" "community_registry" {
+  name = "Palette Community Registry"
+}
+
+#############
+# AWS
+#############
+
+data "spectrocloud_cloudaccount_aws" "account" {
+  count = var.deploy-aws ? 1 : 0
+  name  = var.aws-cloud-account-name
+}
+
+data "spectrocloud_pack" "aws_csi" {
+  name         = "csi-aws-ebs"
+  version      = "1.53.0"
+  registry_uid = data.spectrocloud_registry.public_registry.id
+}
+
+data "spectrocloud_pack" "aws_cni" {
+  name         = "cni-calico"
+  version      = "3.30.3"
+  registry_uid = data.spectrocloud_registry.public_registry.id
+}
+
+data "spectrocloud_pack" "aws_k8s" {
+  name         = "kubernetes"
+  version      = "1.32.10"
+  registry_uid = data.spectrocloud_registry.public_registry.id
+}
+
+data "spectrocloud_pack" "aws_ubuntu" {
+  name         = "ubuntu-aws"
+  version      = "22.04"
+  registry_uid = data.spectrocloud_registry.public_registry.id
+}
+
+#############
+# Azure
+#############
+data "spectrocloud_cloudaccount_azure" "account" {
+  count = var.deploy-azure ? 1 : 0
+  name  = var.azure-cloud-account-name
+}
+
+data "spectrocloud_pack" "azure_csi" {
+  name         = "csi-azure"
+  version      = "1.32.0"
+  registry_uid = data.spectrocloud_registry.public_registry.id
+}
+
+data "spectrocloud_pack" "azure_cni" {
+  name         = "cni-calico-azure"
+  version      = "3.29.3"
+  registry_uid = data.spectrocloud_registry.public_registry.id
+}
+
+data "spectrocloud_pack" "azure_k8s" {
+  name         = "kubernetes"
+  version      = "1.32.3"
+  registry_uid = data.spectrocloud_registry.public_registry.id
+}
+
+data "spectrocloud_pack" "azure_ubuntu" {
+  name         = "ubuntu-azure"
+  version      = "22.04"
+  registry_uid = data.spectrocloud_registry.public_registry.id
+}
+#############
+# GCP
+#############
+data "spectrocloud_cloudaccount_gcp" "account" {
+  count = var.deploy-gcp ? 1 : 0
+  name  = var.gcp-cloud-account-name
+}
+
+data "spectrocloud_pack" "gcp_csi" {
+  name         = "csi-gcp-driver"
+  version      = "1.15.4"
+  registry_uid = data.spectrocloud_registry.public_registry.id
+}
+
+data "spectrocloud_pack" "gcp_cni" {
+  name         = "cni-calico"
+  version      = "3.29.3"
+  registry_uid = data.spectrocloud_registry.public_registry.id
+}
+
+data "spectrocloud_pack" "gcp_k8s" {
+  name         = "kubernetes"
+  version      = "1.32.3"
+  registry_uid = data.spectrocloud_registry.public_registry.id
+}
+
+data "spectrocloud_pack" "gcp_ubuntu" {
+  name         = "ubuntu-gcp"
+  version      = "22.04"
+  registry_uid = data.spectrocloud_registry.public_registry.id
+}
+
+#############
+# VMware
+#############
+
+data "spectrocloud_cloudaccount_vsphere" "account" {
+  count = var.deploy-vmware ? 1 : 0
+  name  = var.pcg_name
+}
+
+data "spectrocloud_pack" "vmware_ubuntu" {
+  name         = "ubuntu-vsphere"
+  version      = "22.04"
+  registry_uid = data.spectrocloud_registry.public_registry.id
+}
+
+data "spectrocloud_pack" "vmware_k8s" {
+  name         = "kubernetes"
+  version      = "1.32.3"
+  registry_uid = data.spectrocloud_registry.public_registry.id
+}
+
+data "spectrocloud_pack" "vmware_cni" {
+  name         = "cni-calico"
+  version      = "3.29.3"
+  registry_uid = data.spectrocloud_registry.public_registry.id
+}
+
+data "spectrocloud_pack" "vmware_csi" {
+  name         = "csi-vsphere-csi"
+  version      = "3.3.1"
+  registry_uid = data.spectrocloud_registry.public_registry.id
+}
+
+data "spectrocloud_pack" "vmware_metallb" {
+  name         = "lb-metallb-helm"
+  version      = "0.14.9"
+  registry_uid = data.spectrocloud_registry.public_registry.id
+}
+
+# Required for static IP placement
+data "spectrocloud_private_cloud_gateway" "pcg" {
+  count = var.deploy-vmware-static ? 1 : 0
+  name  = var.pcg_name
+}
+
+#####################
+# Hello Universe Pack
+#####################
+
+data "spectrocloud_pack" "hellouniverse" {
+  name         = "hello-universe"
+  version      = "1.2.0"
+  registry_uid = data.spectrocloud_registry.community_registry.id
+}
+
+#####################
+# Kubecost Pack
+#####################
+
+data "spectrocloud_pack" "kubecost" {
+  name         = "cost-analyzer"
+  version      = "1.103.3"
+  registry_uid = data.spectrocloud_registry.community_registry.id
+}

--- a/examples/tutorials/getting-started-multicloud/ippool.tf
+++ b/examples/tutorials/getting-started-multicloud/ippool.tf
@@ -1,0 +1,12 @@
+# Required for static IP placement.
+resource "spectrocloud_privatecloudgateway_ippool" "ippool" {
+  count                    = var.deploy-vmware-static ? 1 : 0
+  gateway                  = var.network_gateway
+  name                     = "vsphere-vmware-ippool"
+  network_type             = "range"
+  prefix                   = var.network_prefix
+  private_cloud_gateway_id = data.spectrocloud_private_cloud_gateway.pcg[0].id
+  ip_start_range           = var.ip_range_start
+  ip_end_range             = var.ip_range_end
+  nameserver_addresses     = var.nameserver_addr
+}

--- a/examples/tutorials/getting-started-multicloud/manifests/values-3tier.yaml
+++ b/examples/tutorials/getting-started-multicloud/manifests/values-3tier.yaml
@@ -1,0 +1,38 @@
+# Copyright (c) Spectro Cloud
+# SPDX-License-Identifier: Apache-2.0
+
+pack:
+  content:
+    images:
+      - image: ghcr.io/spectrocloud/hello-universe:1.2.0
+
+manifests:
+  hello-universe:
+    images:
+      hellouniverse: ghcr.io/spectrocloud/hello-universe:1.2.0-proxy
+      hellouniverseapi: ghcr.io/spectrocloud/hello-universe-api:1.1.0
+      hellouniversedb: ghcr.io/spectrocloud/hello-universe-db:1.1.0
+    apiEnabled: true
+    namespace: ${namespace}
+    port: ${port}
+    replicas: ${replicas}
+    dbPassword: ${db_password} # Add base64 encoded password
+    authToken: ${auth_token} # Add base64 encoded token
+    ui:
+      useTolerations: false
+      tolerations:
+        effect: PreferNoSchedule
+        key: app
+        value: ui
+    api:
+      useTolerations: false
+      tolerations:
+        effect: PreferNoSchedule
+        key: app
+        value: api
+    postgres:
+      useTolerations: false
+      tolerations:
+        effect: PreferNoSchedule
+        key: app
+        value: postgres

--- a/examples/tutorials/getting-started-multicloud/outputs.tf
+++ b/examples/tutorials/getting-started-multicloud/outputs.tf
@@ -1,0 +1,30 @@
+output "advisory" {
+  value = <<-EOT
+    It takes between one to three minutes for DNS to properly resolve the public load balancer URL.
+    We recommend waiting a few minutes before clicking on the service URL to prevent the browser from caching an unresolved DNS request.
+  EOT
+}
+
+#######################
+# VMware SSH Key Output
+#######################
+
+output "ssh_key_location" {
+  description = "Location of the generated private SSH key file."
+  value       = length(tls_private_key.tutorial_ssh_key) > 0 && var.deploy-vmware == true ? "This is the location of the generated private SSH key file: ${local_sensitive_file.private_key_file[0].filename}." : null
+}
+
+output "ssh_public_key_location" {
+  description = "Location of the generated public SSH key file."
+  value       = length(tls_private_key.tutorial_ssh_key) > 0 && var.deploy-vmware == true ? "This is the location of the generated public SSH key file: ${local_file.public_key_file[0].filename}." : null
+}
+
+output "ssh_connection_command" {
+  description = "Command to use the generated private SSH key to access the nodes."
+  value       = length(tls_private_key.tutorial_ssh_key) > 0 && var.deploy-vmware == true ? "To access your nodes, use the following command, replacing <username> with the username and <hostname> with the IP address of your node:  ssh -i ${local_sensitive_file.private_key_file[0].filename} <username>@<hostname>" : null
+}
+
+output "ssh_connection_command_user" {
+  description = "Command to use the user's private SSH key to access the nodes."
+  value       = var.ssh_key != "" && var.deploy-vmware == true ? "To access your nodes, use the following command, replacing <username> with the username and <hostname> with the IP address of your node:  ssh -i ${var.ssh_key_private} <username>@<hostname>" : null
+}

--- a/examples/tutorials/getting-started-multicloud/providers.tf
+++ b/examples/tutorials/getting-started-multicloud/providers.tf
@@ -1,0 +1,41 @@
+terraform {
+  required_providers {
+    spectrocloud = {
+      version = ">= 0.20.6"
+      source  = "spectrocloud/spectrocloud"
+    }
+
+    tls = {
+      source  = "hashicorp/tls"
+      version = "4.0.4"
+    }
+
+    vsphere = {
+      source  = "hashicorp/vsphere"
+      version = ">= 2.6.1"
+    }
+
+    local = {
+      source  = "hashicorp/local"
+      version = "2.4.1"
+    }
+  }
+
+  required_version = ">= 1.9"
+}
+
+variable "sc_host" {
+  description = "The Palette API endpoint to connect to."
+  default     = "api.spectrocloud.com"
+}
+
+variable "sc_api_key" {
+  description = "Your Palette API key. Can also be set via the SPECTROCLOUD_APIKEY environment variable instead of this variable."
+  default     = null
+}
+
+provider "spectrocloud" {
+  host         = var.sc_host
+  api_key      = var.sc_api_key
+  project_name = var.palette-project
+}

--- a/examples/tutorials/getting-started-multicloud/ssh-key.tf
+++ b/examples/tutorials/getting-started-multicloud/ssh-key.tf
@@ -1,0 +1,36 @@
+###############
+# Azure SSH Key
+###############
+
+resource "tls_private_key" "tutorial_ssh_key_azure" {
+  count     = var.deploy-azure ? 1 : 0
+  algorithm = "RSA"
+  rsa_bits  = "4096"
+}
+
+################
+# VMware SSH Key
+################
+
+resource "tls_private_key" "tutorial_ssh_key" {
+  count     = var.ssh_key == "" && var.ssh_key_private == "" && var.deploy-vmware == true ? 1 : 0
+  algorithm = "RSA"
+  rsa_bits  = "4096"
+}
+
+locals {
+  ssh_public_key = var.ssh_key != "" ? var.ssh_key : length(tls_private_key.tutorial_ssh_key) > 0 ? tls_private_key.tutorial_ssh_key[0].public_key_openssh : null
+}
+
+resource "local_sensitive_file" "private_key_file" {
+  count           = length(tls_private_key.tutorial_ssh_key) > 0 ? 1 : 0
+  content         = tls_private_key.tutorial_ssh_key[0].private_key_openssh
+  filename        = "${path.module}/tutorial_ssh_key"
+  file_permission = "0600"
+}
+
+resource "local_file" "public_key_file" {
+  count    = length(tls_private_key.tutorial_ssh_key) > 0 ? 1 : 0
+  content  = tls_private_key.tutorial_ssh_key[0].public_key_openssh
+  filename = "${path.module}/tutorial_ssh_key.pub"
+}

--- a/examples/tutorials/getting-started-multicloud/terraform.template.tfvars
+++ b/examples/tutorials/getting-started-multicloud/terraform.template.tfvars
@@ -1,0 +1,122 @@
+#####################
+# Palette Settings
+#####################
+palette-project = "Default" # The name of your project in Palette.
+
+##############################
+# Hello Universe Configuration
+##############################
+app_namespace   = "hello-universe" # The namespace in which the application will be deployed.
+app_port        = 8080             # The cluster port number on which the service will listen for incoming traffic.
+replicas_number = 1                # The number of pods to be created.
+db_password     = "REPLACE ME"     # The database password to connect to the API database.
+auth_token      = "REPLACE ME"     # The auth token for the API connection.
+
+###########################
+# AWS Deployment Settings
+############################
+deploy-aws          = false # Set to true to deploy to AWS.
+deploy-aws-kubecost = false # Set to true to deploy to AWS and include Kubecost to your cluster profile.
+
+aws-cloud-account-name = "REPLACE ME"
+aws-region             = "REPLACE ME"
+aws-key-pair-name      = "REPLACE ME"
+
+aws_control_plane_nodes = {
+  count              = "1"
+  control_plane      = true
+  instance_type      = "m4.2xlarge"
+  disk_size_gb       = "60"
+  availability_zones = ["REPLACE ME"] # If you want to deploy to multiple AZs, add them here. Example: ["us-east-1a", "us-east-1b"].
+}
+
+aws_worker_nodes = {
+  count              = "1"
+  control_plane      = false
+  instance_type      = "m4.2xlarge"
+  disk_size_gb       = "60"
+  availability_zones = ["REPLACE ME"] # If you want to deploy to multiple AZs, add them here. Example: ["us-east-1a", "us-east-1b"].
+}
+
+###########################
+# Azure Deployment Settings
+############################
+deploy-azure          = false # Set to true to deploy to Azure.
+deploy-azure-kubecost = false # Set to true to deploy to Azure and include Kubecost to your cluster profile.
+azure-use-azs         = true  # Set to false when you deploy to a region without AZs.
+
+azure-cloud-account-name = "REPLACE ME"
+azure-region             = "REPLACE ME"
+azure_subscription_id    = "REPLACE ME"
+azure_resource_group     = "REPLACE ME"
+
+
+azure_control_plane_nodes = {
+  count               = "1"
+  control_plane       = true
+  instance_type       = "Standard_D4s_v3"
+  disk_size_gb        = "60"
+  azs                 = ["1"] # If you want to deploy to multiple AZs, add them here.
+  is_system_node_pool = false
+}
+
+azure_worker_nodes = {
+  count               = "1"
+  control_plane       = false
+  instance_type       = "Standard_D4s_v3"
+  disk_size_gb        = "60"
+  azs                 = ["1"] # If you want to deploy to multiple AZs, add them here.
+  is_system_node_pool = false
+}
+
+###########################
+# GCP Deployment Settings
+############################
+deploy-gcp          = false # Set to true to deploy to GCP.
+deploy-gcp-kubecost = false # Set to true to deploy to GCP and include Kubecost to your cluster profile.
+
+gcp-cloud-account-name = "REPLACE ME"
+gcp-region             = "REPLACE ME"
+gcp_project_name       = "REPLACE ME"
+
+gcp_control_plane_nodes = {
+  count              = "1"
+  control_plane      = true
+  instance_type      = "n2-standard-4"
+  disk_size_gb       = "60"
+  availability_zones = ["REPLACE ME"] # If you want to deploy to multiple AZs, add them here. Example: ["us-central1-a", "us-central1-b"].
+}
+
+gcp_worker_nodes = {
+  count              = "1"
+  control_plane      = false
+  instance_type      = "n2-standard-4"
+  disk_size_gb       = "60"
+  availability_zones = ["REPLACE ME"] # If you want to deploy to multiple AZs, add them here. Example: ["us-central1-a", "us-central1-b"].
+}
+
+############################
+# VMware Deployment Settings
+############################
+deploy-vmware          = false # Set to true to deploy to VMware.
+deploy-vmware-kubecost = false # Set to true to deploy to VMware and include Kubecost to your cluster profile.
+
+metallb_ip         = "REPLACE ME" # Provide a range of IP addresses for your Metallb load balancer. This range must be included in the PCG's static IP pool range if using static IP placement.
+pcg_name           = "REPLACE ME" # Provide the name of the PCG that will be used to deploy the Palette cluster.
+datacenter_name    = "REPLACE ME" # Provide the name of the datacenter in vSphere.
+folder_name        = "REPLACE ME" # Provide the name of the folder in vSphere.
+search_domain      = "REPLACE ME" # Provide the name of the network search domain.
+vsphere_cluster    = "REPLACE ME" # Provide the cluster name for the machine pool as it appears in vSphere.
+datastore_name     = "REPLACE ME" # Provide the datastore name for the machine pool as it appears in vSphere.
+network_name       = "REPLACE ME" # Provide the network name for the machine pool as it appears in vSphere.
+resource_pool_name = "REPLACE ME" # Provide the resource pool name for the machine pool as it appears in vSphere.
+ssh_key            = ""           # Provide the path to your public SSH key. If not provided, a new key pair will be created.
+ssh_key_private    = ""           # Provide the path to your private SSH key. If not provided, a new key pair will be created.
+
+# Static IP Pool Variables - Required for static IP placement only.
+deploy-vmware-static = false          # Set to true to deploy to VMware using static IP placement.
+network_gateway      = "REPLACE ME"   # Provide the IP address of the vSphere network gateway.
+network_prefix       = 0              # Provide the prefix of your vSphere network. Valid values are network CIDR subnet masks from the range 0-32. Example: 18.
+ip_range_start       = "REPLACE ME"   # Provide the first IP address of your PCG IP pool range.
+ip_range_end         = "REPLACE ME"   # Provide the second IP address of your PCG IP pool range.
+nameserver_addr      = ["REPLACE ME"] # Provide a comma-separated list of DNS name server IP addresses.

--- a/examples/tutorials/getting-started-multicloud/variables.tf
+++ b/examples/tutorials/getting-started-multicloud/variables.tf
@@ -1,0 +1,507 @@
+#########
+# Palette
+#########
+
+variable "palette-project" {
+  type        = string
+  description = "The name of your project in Palette."
+
+  validation {
+    condition     = var.palette-project != ""
+    error_message = "Provide the correct Palette project."
+  }
+
+}
+
+#######
+# AWS
+#######
+variable "aws-cloud-account-name" {
+  type        = string
+  description = "The name of your AWS account as assigned in Palette."
+
+  validation {
+    condition     = var.deploy-aws ? var.aws-cloud-account-name != "REPLACE ME" && var.aws-cloud-account-name != "" : true
+    error_message = "Provide the correct AWS cloud account name."
+  }
+}
+
+variable "deploy-aws" {
+  type        = bool
+  description = "A flag for enabling a deployment on AWS."
+}
+
+variable "deploy-aws-kubecost" {
+  type        = bool
+  description = "A flag for enabling a deployment on AWS with Kubecost."
+}
+
+variable "aws-region" {
+  type        = string
+  description = "AWS region"
+  default     = "us-east-1"
+
+  validation {
+    condition     = var.deploy-aws ? var.aws-region != "REPLACE ME" && var.aws-region != "" : true
+    error_message = "Provide the correct AWS region."
+  }
+}
+
+variable "aws-key-pair-name" {
+  type        = string
+  description = "The name of the AWS key pair to use for SSH access to the cluster."
+
+  validation {
+    condition     = var.deploy-aws ? var.aws-key-pair-name != "REPLACE ME" && var.aws-key-pair-name != "" : true
+    error_message = "Provide the correct AWS SSH key pair name."
+  }
+}
+
+variable "aws_control_plane_nodes" {
+  type = object({
+    count              = string
+    control_plane      = bool
+    instance_type      = string
+    disk_size_gb       = string
+    availability_zones = list(string)
+  })
+  default = {
+    count              = "1"
+    control_plane      = true
+    instance_type      = "m4.2xlarge"
+    disk_size_gb       = "60"
+    availability_zones = ["us-east-1a"]
+  }
+  description = "AWS control plane nodes configuration."
+
+  validation {
+    condition     = var.deploy-aws ? length(var.aws_control_plane_nodes.availability_zones) > 0 && !contains(var.aws_control_plane_nodes.availability_zones, "REPLACE ME") : true
+    error_message = "The availability_zones parameter must be set correctly"
+  }
+}
+variable "aws_worker_nodes" {
+  type = object({
+    count              = string
+    control_plane      = bool
+    instance_type      = string
+    disk_size_gb       = string
+    availability_zones = list(string)
+  })
+  default = {
+    count              = "1"
+    control_plane      = false
+    instance_type      = "m4.2xlarge"
+    disk_size_gb       = "60"
+    availability_zones = ["us-east-1a"]
+  }
+  description = "AWS worker nodes configuration."
+
+  validation {
+    condition     = var.deploy-aws ? length(var.aws_worker_nodes.availability_zones) > 0 && !contains(var.aws_worker_nodes.availability_zones, "REPLACE ME") : true
+    error_message = "The availability_zones parameter must be set correctly"
+  }
+}
+
+#######
+# Azure
+#######
+variable "azure-cloud-account-name" {
+  type        = string
+  description = "The name of your Azure account as assigned in Palette."
+  default     = ""
+
+  validation {
+    condition     = var.deploy-azure ? var.azure-cloud-account-name != "REPLACE ME" && var.azure-cloud-account-name != "" : true
+    error_message = "Provide the correct Azure cloud account name."
+  }
+}
+
+variable "deploy-azure" {
+  type        = bool
+  description = "A flag for enabling a deployment on Azure."
+}
+
+variable "deploy-azure-kubecost" {
+  type        = bool
+  description = "A flag for enabling a deployment on Azure with Kubecost."
+}
+
+variable "azure_subscription_id" {
+  type        = string
+  description = "Azure subscription ID."
+  default     = ""
+
+  validation {
+    condition     = var.deploy-azure ? var.azure_subscription_id != "REPLACE ME" && var.azure_subscription_id != "" : true
+    error_message = "Provide the correct Azure subscription ID."
+  }
+}
+
+variable "azure_resource_group" {
+  type        = string
+  description = "Azure resource group."
+  default     = ""
+
+  validation {
+    condition     = var.deploy-azure ? var.azure_resource_group != "REPLACE ME" && var.azure_resource_group != "" : true
+    error_message = "Provide the correct Azure resource group name."
+  }
+}
+
+variable "azure-use-azs" {
+  type        = bool
+  description = "A flag for configuring whether to use Azure Availability Zones. Check if your Azure region supports availability zones by reviewing the [Azure Regions and Availability Zones](https://learn.microsoft.com/en-us/azure/reliability/availability-zones-service-support#azure-regions-with-availability-zone-support) resource."
+}
+
+variable "azure-region" {
+  type        = string
+  description = "Azure region."
+  default     = "eastus"
+
+  validation {
+    condition     = var.deploy-azure ? var.azure-region != "REPLACE ME" && var.azure-region != "" : true
+    error_message = "Provide the correct Azure region name."
+  }
+}
+
+variable "azure_control_plane_nodes" {
+  type = object({
+    count               = string
+    control_plane       = bool
+    instance_type       = string
+    disk_size_gb        = string
+    azs                 = list(string)
+    is_system_node_pool = bool
+  })
+  default = {
+    count               = "1"
+    control_plane       = true
+    instance_type       = "Standard_A8_v2"
+    disk_size_gb        = "60"
+    azs                 = ["1"]
+    is_system_node_pool = false
+  }
+  description = "Azure control plane nodes configuration."
+}
+
+variable "azure_worker_nodes" {
+  type = object({
+    count               = string
+    control_plane       = bool
+    instance_type       = string
+    disk_size_gb        = string
+    azs                 = list(string)
+    is_system_node_pool = bool
+  })
+  default = {
+    count               = "1"
+    control_plane       = false
+    instance_type       = "Standard_A8_v2"
+    disk_size_gb        = "60"
+    azs                 = ["1"]
+    is_system_node_pool = false
+  }
+  description = "Azure worker nodes configuration."
+}
+
+#######
+# GCP
+#######
+variable "gcp-cloud-account-name" {
+  type        = string
+  description = "The name of your GCP account as assigned in Palette."
+  default     = ""
+
+  validation {
+    condition     = var.deploy-gcp ? var.gcp-cloud-account-name != "REPLACE ME" && var.gcp-cloud-account-name != "" : true
+    error_message = "Provide the correct GCP cloud account name."
+  }
+}
+
+variable "gcp_project_name" {
+  type        = string
+  description = "The name of your GCP project."
+  default     = ""
+
+  validation {
+    condition     = var.deploy-gcp ? var.gcp_project_name != "REPLACE ME" && var.gcp_project_name != "" : true
+    error_message = "Provide the correct GCP project name."
+  }
+}
+
+variable "deploy-gcp" {
+  type        = bool
+  description = "A flag for enabling a deployment on GCP."
+}
+
+variable "deploy-gcp-kubecost" {
+  type        = bool
+  description = "A flag for enabling a deployment on GCP with Kubecost."
+}
+
+variable "gcp-region" {
+  type        = string
+  description = "GCP region"
+  default     = "us-central1"
+
+  validation {
+    condition     = var.deploy-gcp ? var.gcp-region != "REPLACE ME" && var.gcp-region != "" : true
+    error_message = "Provide the correct GCP region."
+  }
+}
+
+variable "gcp_control_plane_nodes" {
+  type = object({
+    count              = string
+    control_plane      = bool
+    instance_type      = string
+    disk_size_gb       = string
+    availability_zones = list(string)
+  })
+  default = {
+    count              = "1"
+    control_plane      = true
+    instance_type      = "n1-standard-4"
+    disk_size_gb       = "60"
+    availability_zones = ["us-central1-a"]
+  }
+  description = "GCP control plane nodes configuration."
+
+  validation {
+    condition     = var.deploy-gcp ? length(var.gcp_control_plane_nodes.availability_zones) > 0 && !contains(var.gcp_control_plane_nodes.availability_zones, "REPLACE ME") : true
+    error_message = "The availability_zones parameter must be set correctly"
+  }
+}
+
+variable "gcp_worker_nodes" {
+  type = object({
+    count              = string
+    control_plane      = bool
+    instance_type      = string
+    disk_size_gb       = string
+    availability_zones = list(string)
+  })
+  default = {
+    count              = "1"
+    control_plane      = false
+    instance_type      = "n1-standard-4"
+    disk_size_gb       = "60"
+    availability_zones = ["us-central1-a"]
+  }
+  description = "GCP worker nodes configuration."
+
+  validation {
+    condition     = var.deploy-gcp ? length(var.gcp_worker_nodes.availability_zones) > 0 && !contains(var.gcp_worker_nodes.availability_zones, "REPLACE ME") : true
+    error_message = "The availability_zones parameter must be set correctly"
+  }
+}
+
+variable "tags" {
+  type        = list(string)
+  description = "The default tags to apply to Palette resources."
+  default = [
+    "spectro-cloud-education",
+    "app:hello-universe",
+    "spectrocloud:tutorials",
+    "terraform_managed:true",
+    "tutorial:getting-started-terraform"
+  ]
+}
+
+
+########
+# VMware
+########
+
+variable "deploy-vmware" {
+  type        = bool
+  description = "A flag for enabling a deployment on VMware."
+}
+
+variable "deploy-vmware-kubecost" {
+  type        = bool
+  description = "A flag for enabling a deployment on VMware with Kubecost."
+}
+
+variable "metallb_ip" {
+  type        = string
+  description = "The IP address range for your MetalLB load balancer."
+
+  validation {
+    condition     = var.deploy-vmware ? var.metallb_ip != "REPLACE ME" && var.metallb_ip != "" : true
+    error_message = "Provide the correct MetalLB IP."
+  }
+}
+
+variable "ssh_key" {
+  type        = string
+  description = "The path to the public key that will be added to the cluster nodes. If not provided, a new key pair will be generated."
+
+  validation {
+    condition     = var.ssh_key == "" ? true : fileexists(var.ssh_key)
+    error_message = "The provided SSH key file does not exist. Please, provide a valid path."
+  }
+}
+
+variable "ssh_key_private" {
+  type        = string
+  description = "The path to the private key that will be used to access the cluster nodes. If not provided, a new key pair will be generated."
+
+  validation {
+    condition     = var.ssh_key_private == "" ? true : fileexists(var.ssh_key_private)
+    error_message = "The provided SSH key file does not exist. Please, provide a valid path."
+  }
+}
+
+variable "datacenter_name" {
+  type        = string
+  description = "The name of the datacenter in vSphere."
+
+  validation {
+    condition     = var.deploy-vmware ? var.datacenter_name != "REPLACE ME" && var.datacenter_name != "" : true
+    error_message = "Provide the correct VMware vSphere datacenter name."
+  }
+}
+
+variable "folder_name" {
+  type        = string
+  description = "The name of the folder in vSphere."
+
+  validation {
+    condition     = var.deploy-vmware ? var.folder_name != "REPLACE ME" && var.folder_name != "" : true
+    error_message = "Provide the correct VMware vSphere folder name."
+  }
+}
+
+variable "search_domain" {
+  type        = string
+  description = "The name of network search domain."
+
+  validation {
+    condition     = var.deploy-vmware ? var.search_domain != "REPLACE ME" && var.search_domain != "" : true
+    error_message = "Provide the correct VMware vSphere search domain."
+  }
+}
+
+# Input resources for the cluster - Placement
+variable "vsphere_cluster" {
+  type        = string
+  description = "The name of your vSphere cluster."
+
+  validation {
+    condition     = var.deploy-vmware ? var.vsphere_cluster != "REPLACE ME" && var.vsphere_cluster != "" : true
+    error_message = "Provide the correct VMware vSphere cluster name."
+  }
+}
+
+variable "datastore_name" {
+  type        = string
+  description = "The name of the vSphere datastore."
+
+  validation {
+    condition     = var.deploy-vmware ? var.datastore_name != "REPLACE ME" && var.datastore_name != "" : true
+    error_message = "Provide the correct VMware vSphere datastore name."
+  }
+}
+
+variable "network_name" {
+  type        = string
+  description = "The name of the vSphere network."
+
+  validation {
+    condition     = var.deploy-vmware ? var.network_name != "REPLACE ME" && var.network_name != "" : true
+    error_message = "Provide the correct VMware vSphere network name."
+  }
+}
+
+variable "resource_pool_name" {
+  type        = string
+  description = "The name of the vSphere resource pool."
+
+  validation {
+    condition     = var.deploy-vmware ? var.resource_pool_name != "REPLACE ME" && var.resource_pool_name != "" : true
+    error_message = "Provide the correct VMware vSphere resource pool name."
+  }
+}
+
+variable "pcg_name" {
+  type        = string
+  description = "The name of the PCG that will be used to deploy the cluster."
+
+  validation {
+    condition     = var.deploy-vmware ? var.pcg_name != "REPLACE ME" && var.pcg_name != "" : true
+    error_message = "Provide the correct VMware vSphere PCG name."
+  }
+}
+
+# Input resources for the Static IP Pool (required for static IP placement only)
+variable "deploy-vmware-static" {
+  type        = bool
+  description = "A flag for enabling a deployment on VMware using static IP placement."
+}
+
+variable "network_gateway" {
+  type        = string
+  description = "The IP address of the vSphere network gateway."
+}
+
+variable "network_prefix" {
+  type        = number
+  description = "The prefix of your vSphere network. Valid values are network CIDR subnet masks from the range 0-32. Example: 18."
+}
+
+variable "ip_range_start" {
+  type        = string
+  description = "The first IP address of your PCG IP pool range."
+}
+
+variable "ip_range_end" {
+  type        = string
+  description = "The last IP address of your PCG IP pool range."
+}
+
+variable "nameserver_addr" {
+  type        = set(string)
+  description = "A comma-separated list of DNS nameserver IP addresses of your network."
+}
+
+
+##############################
+# Hello Universe App Variables
+##############################
+variable "app_namespace" {
+  type        = string
+  description = "The namespace in which the application will be deployed."
+}
+
+variable "app_port" {
+  type        = number
+  description = "The cluster port number on which the service will listen for incoming traffic."
+}
+
+variable "replicas_number" {
+  type        = number
+  description = "The number of pods to be created."
+}
+
+variable "db_password" {
+  type        = string
+  description = "The base64 encoded database password to connect to the API database."
+  sensitive   = true
+
+  validation {
+    condition     = var.deploy-aws || var.deploy-azure || var.deploy-gcp || var.deploy-vmware ? var.db_password != "REPLACE ME" && var.db_password != "" : true
+    error_message = "Provide the correct database password."
+  }
+}
+
+variable "auth_token" {
+  type        = string
+  description = "The base64 encoded auth token for the API connection."
+  sensitive   = true
+
+  validation {
+    condition     = var.deploy-aws || var.deploy-azure || var.deploy-gcp || var.deploy-vmware ? var.auth_token != "REPLACE ME" && var.auth_token != "" : true
+    error_message = "Provide the correct authentication token."
+  }
+}


### PR DESCRIPTION
Ports the getting-started-deployment-tf example (pinned to tag v1.3.3, matching what the docs tutorial references) from
github.com/spectrocloud/tutorials into
examples/tutorials/getting-started-multicloud/, reshaped to this repo's file-naming convention.

Covers AWS/Azure/GCP/VMware cloud toggles, optional Kubecost add-on per cloud, and the Hello Universe sample app baked into each cluster profile.

All attributes verified against the current provider schema (spectrocloud_cluster_aws/azure/gcp/vsphere, cluster_profile, privatecloudgateway_ippool, and all referenced data sources) - no drift found. terraform validate passes against the published provider.

Covers PLT-2379 (port) and PLT-2380 (README); PLT-2381 (validation) is done as part of this same change.