### PR TITLE
PLT-2382: Port profile-variables tutorial example

### DIFF
--- a/examples/tutorials/README.md
+++ b/examples/tutorials/README.md
@@ -14,7 +14,7 @@ following [PORTING_CHECKLIST.md](PORTING_CHECKLIST.md).
 |---|---|---|
 | [`custom-pack/`](custom-pack) | [Deploy a Custom Pack](https://docs.spectrocloud.com/tutorials/packs-registries/deploy-pack/) | Done |
 | [`getting-started-multicloud/`](getting-started-multicloud) | [Cluster Management with Terraform (Getting Started)](https://docs.spectrocloud.com/tutorials/getting-started/palette/aws/deploy-manage-k8s-cluster-tf/) | Done |
-| [`profile-variables/`](profile-variables) | [Deploy Cluster with Profile Variables](https://docs.spectrocloud.com/tutorials/profiles/cluster-profile-variables/) | Planned |
+| [`profile-variables/`](profile-variables) | [Deploy Cluster with Profile Variables](https://docs.spectrocloud.com/tutorials/profiles/cluster-profile-variables/) | Done |
 | [`cluster-templates/`](cluster-templates) | [Standardize Clusters with Cluster Templates (Terraform)](https://docs.spectrocloud.com/tutorials/clusters/cluster-templates/standardize-clusters-with-cluster-templates-terraform/) | Planned |
 | [`pcg-vmware-app/`](pcg-vmware-app) | [Deploy App Workloads with a PCG](https://docs.spectrocloud.com/tutorials/clusters/pcg/deploy-app-pcg/) | Planned |
 | [`pde-virtual-cluster-app/`](pde-virtual-cluster-app) | [Deploy an Application using Palette Dev Engine](https://docs.spectrocloud.com/tutorials/pde/deploy-app/) | Planned |

--- a/examples/tutorials/profile-variables/README.md
+++ b/examples/tutorials/profile-variables/README.md
@@ -1,0 +1,58 @@
+# Cluster profile variables tutorial example
+
+End-to-end example accompanying the Spectro Cloud tutorial
+[Deploy Cluster with Profile Variables](https://docs.spectrocloud.com/tutorials/profiles/cluster-profile-variables/).
+
+This example deploys a WordPress application on a Kubernetes cluster (AWS, Azure, and/or GCP), and
+demonstrates the difference between a cluster profile with no variables and one using
+[profile variables](https://registry.terraform.io/providers/spectrocloud/spectrocloud/latest/docs/resources/cluster_profile#profile_variables)
+to make Day-2 configuration changes without editing the manifest itself:
+- **Profile version `1.0.0`** deploys WordPress with fixed values baked into `manifests/wordpress-default.yaml`
+  (namespace `wordpress`, 1 replica, port 80).
+- **Profile version `1.1.0`** deploys the same chart via `manifests/wordpress-variables.yaml`, which
+  references `{{ .spectro.var.wordpress_namespace }}`, `{{ .spectro.var.wordpress_replica }}`, and
+  `{{ .spectro.var.wordpress_port }}` instead — with a `profile_variables` block on the profile resource
+  supplying those values, so they can be changed later via Palette without editing the manifest.
+
+## Choosing which cloud(s) to deploy to, and which profile version
+
+| Variable | Provider | Description | Default |
+|---|---|---|---|
+| `deploy-aws` | AWS | Enable to deploy a cluster to AWS. | `false` |
+| `deploy-azure` | Azure | Enable to deploy a cluster to Azure. | `false` |
+| `deploy-gcp` | GCP | Enable to deploy a cluster to GCP. | `false` |
+
+Each cloud also has a `deploy-<cloud>-var` toggle: when `false` (default), the cluster deploys profile
+version `1.0.0` (no variables); when `true`, it deploys version `1.1.0` (with `profile_variables`), reading
+its values from `wordpress_replica`, `wordpress_namespace`, and `wordpress_port`.
+
+## Prerequisites
+
+You will need the following before getting started:
+1. A Palette API key, exported as the `SPECTROCLOUD_APIKEY` environment variable (or supplied via the
+   `sc_api_key` variable).
+2. A cloud account already registered in your Palette project settings for each cloud you enable.
+3. For AWS: an existing EC2 key pair in the region you deploy to.
+4. Terraform 1.9 or later.
+
+## Instructions
+
+Clone this repository to a local directory, and change directory to
+`examples/tutorials/profile-variables`. Proceed with the following:
+1. From the current directory, copy the template variable file `terraform.template.tfvars` to a new
+   file `terraform.tfvars`.
+2. Set the `deploy-<cloud>` toggle(s) for the cloud(s) you want, and fill in all the placeholder
+   (`REPLACE ME`) values relevant to those clouds.
+3. Initialize and run terraform: `terraform init && terraform apply`.
+4. Wait for the cluster creation to finish.
+5. To see profile variables in action, set the matching `deploy-<cloud>-var` to `true`, fill in
+   `wordpress_replica`, `wordpress_namespace`, and `wordpress_port`, and re-apply. The cluster switches
+   from profile version `1.0.0` to `1.1.0` in place.
+
+## Clean up
+
+Run the destroy operation:
+
+```shell
+terraform destroy
+```

--- a/examples/tutorials/profile-variables/cluster_profiles.tf
+++ b/examples/tutorials/profile-variables/cluster_profiles.tf
@@ -1,0 +1,401 @@
+#############################
+# AWS Cluster Profile v1.0.0
+#############################
+resource "spectrocloud_cluster_profile" "aws-profile" {
+  count = var.deploy-aws ? 1 : 0
+
+  name        = "aws-profile-var-tf"
+  description = "A basic cluster profile for AWS"
+  tags        = concat(var.tags, ["env:aws"])
+  cloud       = "aws"
+  type        = "cluster"
+  version     = "1.0.0"
+  pack {
+    name   = data.spectrocloud_pack.aws_ubuntu.name
+    tag    = data.spectrocloud_pack.aws_ubuntu.version
+    uid    = data.spectrocloud_pack.aws_ubuntu.id
+    values = data.spectrocloud_pack.aws_ubuntu.values
+    type   = "spectro"
+  }
+
+  pack {
+    name   = data.spectrocloud_pack.aws_k8s.name
+    tag    = data.spectrocloud_pack.aws_k8s.version
+    uid    = data.spectrocloud_pack.aws_k8s.id
+    values = data.spectrocloud_pack.aws_k8s.values
+    type   = "spectro"
+  }
+
+  pack {
+    name   = data.spectrocloud_pack.aws_cni.name
+    tag    = data.spectrocloud_pack.aws_cni.version
+    uid    = data.spectrocloud_pack.aws_cni.id
+    values = data.spectrocloud_pack.aws_cni.values
+    type   = "spectro"
+  }
+
+  pack {
+    name   = data.spectrocloud_pack.aws_csi.name
+    tag    = data.spectrocloud_pack.aws_csi.version
+    uid    = data.spectrocloud_pack.aws_csi.id
+    values = data.spectrocloud_pack.aws_csi.values
+    type   = "spectro"
+  }
+  pack {
+    name   = data.spectrocloud_pack.wordpress_chart.name
+    tag    = data.spectrocloud_pack.wordpress_chart.version
+    uid    = data.spectrocloud_pack.wordpress_chart.id
+    values = file("manifests/wordpress-default.yaml")
+    type   = "oci"
+  }
+}
+
+############################
+# AWS Cluster Profile v1.1.0
+############################
+
+resource "spectrocloud_cluster_profile" "aws-profile-var" {
+  count = var.deploy-aws ? 1 : 0
+
+  name        = "aws-profile-var-tf"
+  description = "Updated version with new profile variable values"
+  tags        = concat(var.tags, ["env:aws"])
+  cloud       = "aws"
+  type        = "cluster"
+  version     = "1.1.0"
+
+  pack {
+    name   = data.spectrocloud_pack.aws_ubuntu.name
+    tag    = data.spectrocloud_pack.aws_ubuntu.version
+    uid    = data.spectrocloud_pack.aws_ubuntu.id
+    values = data.spectrocloud_pack.aws_ubuntu.values
+    type   = "spectro"
+  }
+
+  pack {
+    name   = data.spectrocloud_pack.aws_k8s.name
+    tag    = data.spectrocloud_pack.aws_k8s.version
+    uid    = data.spectrocloud_pack.aws_k8s.id
+    values = data.spectrocloud_pack.aws_k8s.values
+    type   = "spectro"
+  }
+
+  pack {
+    name   = data.spectrocloud_pack.aws_cni.name
+    tag    = data.spectrocloud_pack.aws_cni.version
+    uid    = data.spectrocloud_pack.aws_cni.id
+    values = data.spectrocloud_pack.aws_cni.values
+    type   = "spectro"
+  }
+
+  pack {
+    name   = data.spectrocloud_pack.aws_csi.name
+    tag    = data.spectrocloud_pack.aws_csi.version
+    uid    = data.spectrocloud_pack.aws_csi.id
+    values = data.spectrocloud_pack.aws_csi.values
+    type   = "spectro"
+  }
+
+  pack {
+    name   = data.spectrocloud_pack.wordpress_chart.name
+    tag    = data.spectrocloud_pack.wordpress_chart.version
+    uid    = data.spectrocloud_pack.wordpress_chart.id
+    values = file("manifests/wordpress-variables.yaml")
+    type   = "oci"
+  }
+  profile_variables {
+    variable {
+      name          = "wordpress_replica"
+      display_name  = "Number of replicas"
+      format        = "number"
+      description   = "Number of replicas to deploy for Wordpress"
+      default_value = var.wordpress_replica
+      required      = true
+    }
+    variable {
+      name          = "wordpress_namespace"
+      display_name  = "WordPress: Namespace"
+      format        = "string"
+      description   = "Namespace for the Wordpress pack"
+      default_value = var.wordpress_namespace
+      required      = true
+    }
+    variable {
+      name          = "wordpress_port"
+      display_name  = "WordPress: Port"
+      format        = "number"
+      description   = "Port for Wordpress HTTP"
+      default_value = var.wordpress_port
+      required      = true
+    }
+  }
+}
+
+##############################
+# Azure Cluster Profile v1.0.0
+##############################
+resource "spectrocloud_cluster_profile" "azure-profile" {
+  count = var.deploy-azure ? 1 : 0
+
+  name        = "azure-profile-variables-tf"
+  description = "A basic cluster profile for Azure"
+  tags        = concat(var.tags, ["env:azure"])
+  cloud       = "azure"
+  type        = "cluster"
+  version     = "1.0.0"
+
+  pack {
+    name   = data.spectrocloud_pack.azure_ubuntu.name
+    tag    = data.spectrocloud_pack.azure_ubuntu.version
+    uid    = data.spectrocloud_pack.azure_ubuntu.id
+    values = data.spectrocloud_pack.azure_ubuntu.values
+    type   = "spectro"
+  }
+
+  pack {
+    name   = data.spectrocloud_pack.azure_k8s.name
+    tag    = data.spectrocloud_pack.azure_k8s.version
+    uid    = data.spectrocloud_pack.azure_k8s.id
+    values = data.spectrocloud_pack.azure_k8s.values
+    type   = "spectro"
+  }
+
+  pack {
+    name   = data.spectrocloud_pack.azure_cni.name
+    tag    = data.spectrocloud_pack.azure_cni.version
+    uid    = data.spectrocloud_pack.azure_cni.id
+    values = data.spectrocloud_pack.azure_cni.values
+    type   = "spectro"
+  }
+
+  pack {
+    name   = data.spectrocloud_pack.azure_csi.name
+    tag    = data.spectrocloud_pack.azure_csi.version
+    uid    = data.spectrocloud_pack.azure_csi.id
+    values = data.spectrocloud_pack.azure_csi.values
+    type   = "spectro"
+  }
+
+  pack {
+    name   = data.spectrocloud_pack.wordpress_chart.name
+    tag    = data.spectrocloud_pack.wordpress_chart.version
+    uid    = data.spectrocloud_pack.wordpress_chart.id
+    values = file("manifests/wordpress-default.yaml")
+    type   = "oci"
+  }
+}
+
+##############################
+# Azure Cluster Profile v1.1.0
+##############################
+resource "spectrocloud_cluster_profile" "azure-profile-var" {
+  count = var.deploy-azure ? 1 : 0
+
+  name        = "azure-profile-variables-tf"
+  description = "A basic cluster profile for Azure with cluster profile variables"
+  tags        = concat(var.tags, ["env:azure"])
+  cloud       = "azure"
+  type        = "cluster"
+  version     = "1.1.0"
+
+  pack {
+    name   = data.spectrocloud_pack.azure_ubuntu.name
+    tag    = data.spectrocloud_pack.azure_ubuntu.version
+    uid    = data.spectrocloud_pack.azure_ubuntu.id
+    values = data.spectrocloud_pack.azure_ubuntu.values
+    type   = "spectro"
+  }
+
+  pack {
+    name   = data.spectrocloud_pack.azure_k8s.name
+    tag    = data.spectrocloud_pack.azure_k8s.version
+    uid    = data.spectrocloud_pack.azure_k8s.id
+    values = data.spectrocloud_pack.azure_k8s.values
+    type   = "spectro"
+  }
+
+  pack {
+    name   = data.spectrocloud_pack.azure_cni.name
+    tag    = data.spectrocloud_pack.azure_cni.version
+    uid    = data.spectrocloud_pack.azure_cni.id
+    values = data.spectrocloud_pack.azure_cni.values
+    type   = "spectro"
+  }
+
+  pack {
+    name   = data.spectrocloud_pack.azure_csi.name
+    tag    = data.spectrocloud_pack.azure_csi.version
+    uid    = data.spectrocloud_pack.azure_csi.id
+    values = data.spectrocloud_pack.azure_csi.values
+    type   = "spectro"
+  }
+
+  pack {
+    name   = data.spectrocloud_pack.wordpress_chart.name
+    tag    = data.spectrocloud_pack.wordpress_chart.version
+    uid    = data.spectrocloud_pack.wordpress_chart.id
+    values = file("manifests/wordpress-variables.yaml")
+    type   = "oci"
+  }
+  profile_variables {
+    variable {
+      name          = "wordpress_replica"
+      display_name  = "Number of replicas"
+      format        = "number"
+      description   = "Number of replicas to deploy for Wordpress"
+      default_value = var.wordpress_replica
+      required      = true
+    }
+    variable {
+      name          = "wordpress_namespace"
+      display_name  = "WordPress: Namespace"
+      format        = "string"
+      description   = "Namespace for the Wordpress pack"
+      default_value = var.wordpress_namespace
+      required      = true
+    }
+    variable {
+      name          = "wordpress_port"
+      display_name  = "WordPress: Port"
+      format        = "number"
+      description   = "Port for Wordpress HTTP"
+      default_value = var.wordpress_port
+      required      = true
+    }
+  }
+}
+
+
+############################
+# GCP Cluster Profile v1.0.0
+############################
+resource "spectrocloud_cluster_profile" "gcp-profile" {
+  count = var.deploy-gcp ? 1 : 0
+
+  name        = "gcp-profile-variables-tf"
+  description = "A basic cluster profile for GCP"
+  tags        = concat(var.tags, ["env:GCP"])
+  cloud       = "gcp"
+  type        = "cluster"
+  version     = "1.0.0"
+
+  pack {
+    name   = data.spectrocloud_pack.gcp_ubuntu.name
+    tag    = data.spectrocloud_pack.gcp_ubuntu.version
+    uid    = data.spectrocloud_pack.gcp_ubuntu.id
+    values = data.spectrocloud_pack.gcp_ubuntu.values
+    type   = "spectro"
+  }
+
+  pack {
+    name   = data.spectrocloud_pack.gcp_k8s.name
+    tag    = data.spectrocloud_pack.gcp_k8s.version
+    uid    = data.spectrocloud_pack.gcp_k8s.id
+    values = data.spectrocloud_pack.gcp_k8s.values
+    type   = "spectro"
+  }
+
+  pack {
+    name   = data.spectrocloud_pack.gcp_cni.name
+    tag    = data.spectrocloud_pack.gcp_cni.version
+    uid    = data.spectrocloud_pack.gcp_cni.id
+    values = data.spectrocloud_pack.gcp_cni.values
+    type   = "spectro"
+  }
+
+  pack {
+    name   = data.spectrocloud_pack.gcp_csi.name
+    tag    = data.spectrocloud_pack.gcp_csi.version
+    uid    = data.spectrocloud_pack.gcp_csi.id
+    values = data.spectrocloud_pack.gcp_csi.values
+    type   = "spectro"
+  }
+
+  pack {
+    name   = data.spectrocloud_pack.wordpress_chart.name
+    tag    = data.spectrocloud_pack.wordpress_chart.version
+    uid    = data.spectrocloud_pack.wordpress_chart.id
+    values = file("manifests/wordpress-default.yaml")
+    type   = "oci"
+  }
+}
+
+############################
+# GCP Cluster Profile v1.1.0
+############################
+resource "spectrocloud_cluster_profile" "gcp-profile-var" {
+  count = var.deploy-gcp ? 1 : 0
+
+  name        = "gcp-profile-variables-tf"
+  description = "A basic cluster profile for GCP with cluster profile variables"
+  tags        = concat(var.tags, ["env:GCP"])
+  cloud       = "gcp"
+  type        = "cluster"
+  version     = "1.1.0"
+
+  pack {
+    name   = data.spectrocloud_pack.gcp_ubuntu.name
+    tag    = data.spectrocloud_pack.gcp_ubuntu.version
+    uid    = data.spectrocloud_pack.gcp_ubuntu.id
+    values = data.spectrocloud_pack.gcp_ubuntu.values
+    type   = "spectro"
+  }
+
+  pack {
+    name   = data.spectrocloud_pack.gcp_k8s.name
+    tag    = data.spectrocloud_pack.gcp_k8s.version
+    uid    = data.spectrocloud_pack.gcp_k8s.id
+    values = data.spectrocloud_pack.gcp_k8s.values
+    type   = "spectro"
+  }
+
+  pack {
+    name   = data.spectrocloud_pack.gcp_cni.name
+    tag    = data.spectrocloud_pack.gcp_cni.version
+    uid    = data.spectrocloud_pack.gcp_cni.id
+    values = data.spectrocloud_pack.gcp_cni.values
+    type   = "spectro"
+  }
+
+  pack {
+    name   = data.spectrocloud_pack.gcp_csi.name
+    tag    = data.spectrocloud_pack.gcp_csi.version
+    uid    = data.spectrocloud_pack.gcp_csi.id
+    values = data.spectrocloud_pack.gcp_csi.values
+    type   = "spectro"
+  }
+
+  pack {
+    name   = data.spectrocloud_pack.wordpress_chart.name
+    tag    = data.spectrocloud_pack.wordpress_chart.version
+    uid    = data.spectrocloud_pack.wordpress_chart.id
+    values = file("manifests/wordpress-variables.yaml")
+    type   = "oci"
+  }
+  profile_variables {
+    variable {
+      name          = "wordpress_replica"
+      display_name  = "Number of replicas"
+      format        = "number"
+      description   = "Number of replicas to deploy for Wordpress"
+      default_value = var.wordpress_replica
+      required      = true
+    }
+    variable {
+      name          = "wordpress_namespace"
+      display_name  = "WordPress: Namespace"
+      format        = "string"
+      description   = "Namespace for the Wordpress pack"
+      default_value = var.wordpress_namespace
+      required      = true
+    }
+    variable {
+      name          = "wordpress_port"
+      display_name  = "WordPress: Port"
+      format        = "number"
+      description   = "Port for Wordpress HTTP"
+      default_value = var.wordpress_port
+      required      = true
+    }
+  }
+}

--- a/examples/tutorials/profile-variables/clusters.tf
+++ b/examples/tutorials/profile-variables/clusters.tf
@@ -1,0 +1,134 @@
+##############
+# AWS Cluster
+##############
+resource "spectrocloud_cluster_aws" "aws-cluster" {
+  count = var.deploy-aws ? 1 : 0
+
+  name             = "aws-profile-var-tf" #Enter your unique AWS Cluster name
+  tags             = concat(var.tags, ["env:aws"])
+  cloud_account_id = data.spectrocloud_cloudaccount_aws.account[0].id
+
+  cloud_config {
+    region       = var.aws-region
+    ssh_key_name = var.aws-key-pair-name
+  }
+
+  cluster_profile {
+    id = var.deploy-aws && var.deploy-aws-var ? resource.spectrocloud_cluster_profile.aws-profile-var[0].id : resource.spectrocloud_cluster_profile.aws-profile[0].id
+  }
+
+  machine_pool {
+    control_plane           = true
+    control_plane_as_worker = true
+    name                    = "control-plane-pool"
+    count                   = var.aws_control_plane_nodes.count
+    instance_type           = var.aws_control_plane_nodes.instance_type
+    disk_size_gb            = var.aws_control_plane_nodes.disk_size_gb
+    azs                     = var.aws_control_plane_nodes.availability_zones
+  }
+
+  machine_pool {
+    name          = "worker-pool"
+    count         = var.aws_worker_nodes.count
+    instance_type = var.aws_worker_nodes.instance_type
+    disk_size_gb  = var.aws_worker_nodes.disk_size_gb
+    azs           = var.aws_worker_nodes.availability_zones
+  }
+
+  timeouts {
+    create = "45m"
+    delete = "45m"
+  }
+}
+
+###############
+# Azure Cluster
+###############
+resource "spectrocloud_cluster_azure" "azure-cluster" {
+  count = var.deploy-azure ? 1 : 0
+
+  name             = "azure-cluster-var-tf"
+  tags             = concat(var.tags, ["env:azure"])
+  cloud_account_id = data.spectrocloud_cloudaccount_azure.account[0].id
+
+  cloud_config {
+    subscription_id = var.azure_subscription_id
+    resource_group  = var.azure_resource_group
+    region          = var.azure-region
+    ssh_key         = tls_private_key.tutorial_ssh_key_azure[0].public_key_openssh
+  }
+
+  cluster_profile {
+    id = var.deploy-azure && var.deploy-azure-var ? resource.spectrocloud_cluster_profile.azure-profile-var[0].id : resource.spectrocloud_cluster_profile.azure-profile[0].id
+  }
+
+  machine_pool {
+    control_plane           = true
+    control_plane_as_worker = true
+    name                    = "control-plane-pool"
+    count                   = var.azure_control_plane_nodes.count
+    instance_type           = var.azure_control_plane_nodes.instance_type
+    azs                     = var.azure-use-azs ? var.azure_control_plane_nodes.azs : [""]
+    is_system_node_pool     = var.azure_control_plane_nodes.is_system_node_pool
+    disk {
+      size_gb = var.azure_control_plane_nodes.disk_size_gb
+      type    = "Standard_LRS"
+    }
+  }
+
+  machine_pool {
+    name                = "worker-basic"
+    count               = var.azure_worker_nodes.count
+    instance_type       = var.azure_worker_nodes.instance_type
+    azs                 = var.azure-use-azs ? var.azure_worker_nodes.azs : [""]
+    is_system_node_pool = var.azure_worker_nodes.is_system_node_pool
+  }
+
+  timeouts {
+    create = "45m"
+    delete = "45m"
+  }
+}
+
+#############
+# GCP Cluster
+#############
+resource "spectrocloud_cluster_gcp" "gcp-cluster" {
+  count = var.deploy-gcp ? 1 : 0
+
+  name             = "gcp-cluster-var-tf"
+  tags             = concat(var.tags, ["env:gcp"])
+  cloud_account_id = data.spectrocloud_cloudaccount_gcp.account[0].id
+
+  cloud_config {
+    project = var.gcp_project_name
+    region  = var.gcp-region
+  }
+
+  cluster_profile {
+    id = var.deploy-gcp && var.deploy-gcp-var ? resource.spectrocloud_cluster_profile.gcp-profile-var[0].id : resource.spectrocloud_cluster_profile.gcp-profile[0].id
+  }
+
+  machine_pool {
+    control_plane           = true
+    control_plane_as_worker = true
+    name                    = "control-plane-pool"
+    count                   = var.gcp_control_plane_nodes.count
+    instance_type           = var.gcp_control_plane_nodes.instance_type
+    disk_size_gb            = var.gcp_control_plane_nodes.disk_size_gb
+    azs                     = var.gcp_control_plane_nodes.availability_zones
+  }
+
+  machine_pool {
+    name          = "worker-pool"
+    count         = var.gcp_worker_nodes.count
+    instance_type = var.gcp_worker_nodes.instance_type
+    disk_size_gb  = var.gcp_worker_nodes.disk_size_gb
+    azs           = var.gcp_worker_nodes.availability_zones
+  }
+
+  timeouts {
+    create = "45m"
+    delete = "45m"
+  }
+}

--- a/examples/tutorials/profile-variables/data.tf
+++ b/examples/tutorials/profile-variables/data.tf
@@ -1,0 +1,116 @@
+########################################
+# Data resources for the cluster profile
+########################################
+data "spectrocloud_registry" "public_registry" {
+  name = "Public Repo"
+}
+
+data "spectrocloud_registry" "community_registry" {
+  name = "Palette Community Registry"
+}
+
+##############
+# AWS
+##############
+data "spectrocloud_cloudaccount_aws" "account" {
+  count = var.deploy-aws ? 1 : 0
+  name  = var.aws-cloud-account-name
+}
+
+data "spectrocloud_pack" "aws_csi" {
+  name         = "csi-aws-ebs"
+  version      = "1.41.0"
+  registry_uid = data.spectrocloud_registry.public_registry.id
+}
+
+data "spectrocloud_pack" "aws_cni" {
+  name         = "cni-calico"
+  version      = "3.29.3"
+  registry_uid = data.spectrocloud_registry.public_registry.id
+}
+
+data "spectrocloud_pack" "aws_k8s" {
+  name         = "kubernetes"
+  version      = "1.30.11"
+  registry_uid = data.spectrocloud_registry.public_registry.id
+}
+
+data "spectrocloud_pack" "aws_ubuntu" {
+  name         = "ubuntu-aws"
+  version      = "22.04"
+  registry_uid = data.spectrocloud_registry.public_registry.id
+}
+
+#############
+# Azure
+#############
+data "spectrocloud_cloudaccount_azure" "account" {
+  count = var.deploy-azure ? 1 : 0
+  name  = var.azure-cloud-account-name
+}
+
+data "spectrocloud_pack" "azure_csi" {
+  name         = "csi-azure"
+  version      = "1.32.0"
+  registry_uid = data.spectrocloud_registry.public_registry.id
+}
+
+data "spectrocloud_pack" "azure_cni" {
+  name         = "cni-calico-azure"
+  version      = "3.29.3"
+  registry_uid = data.spectrocloud_registry.public_registry.id
+}
+
+data "spectrocloud_pack" "azure_k8s" {
+  name         = "kubernetes"
+  version      = "1.30.11"
+  registry_uid = data.spectrocloud_registry.public_registry.id
+}
+
+data "spectrocloud_pack" "azure_ubuntu" {
+  name         = "ubuntu-azure"
+  version      = "22.04"
+  registry_uid = data.spectrocloud_registry.public_registry.id
+}
+
+#############
+# GCP
+#############
+data "spectrocloud_cloudaccount_gcp" "account" {
+  count = var.deploy-gcp ? 1 : 0
+  name  = var.gcp-cloud-account-name
+}
+
+data "spectrocloud_pack" "gcp_csi" {
+  name         = "csi-gcp-driver"
+  version      = "1.15.4"
+  registry_uid = data.spectrocloud_registry.public_registry.id
+}
+
+data "spectrocloud_pack" "gcp_cni" {
+  name         = "cni-calico"
+  version      = "3.29.3"
+  registry_uid = data.spectrocloud_registry.public_registry.id
+}
+
+data "spectrocloud_pack" "gcp_k8s" {
+  name         = "kubernetes"
+  version      = "1.30.11"
+  registry_uid = data.spectrocloud_registry.public_registry.id
+}
+
+data "spectrocloud_pack" "gcp_ubuntu" {
+  name         = "ubuntu-gcp"
+  version      = "22.04"
+  registry_uid = data.spectrocloud_registry.public_registry.id
+}
+
+
+#####################
+# Wordpress Chart
+#####################
+data "spectrocloud_pack" "wordpress_chart" {
+  name         = "wordpress-chart"
+  version      = "6.4.3"
+  registry_uid = data.spectrocloud_registry.community_registry.id
+}

--- a/examples/tutorials/profile-variables/manifests/wordpress-default.yaml
+++ b/examples/tutorials/profile-variables/manifests/wordpress-default.yaml
@@ -1,0 +1,1198 @@
+# Copyright (c) Spectro Cloud
+# SPDX-License-Identifier: Apache-2.0
+
+pack:
+  #The namespace (on the target cluster) to install this chart
+  #When not found, a new namespace will be created
+  content:
+    images:
+      - image: docker.io/bitnami/mariadb:11.2.3-debian-12-r4
+      - image: docker.io/bitnami/memcached:1.6.24-debian-12-r0
+      - image: docker.io/bitnami/wordpress:6.4.3-debian-12-r16
+    charts:
+      - repo: https://charts.bitnami.com/wordpress
+        name: wordpress
+        version: 19.4.3
+  namespace: "wordpress"
+  spectrocloud.com/install-priority: 0
+
+charts:
+  wordpress:
+
+    image:
+      registry: docker.io
+      repository: bitnami/wordpress
+      tag: 6.4.3-debian-12-r16
+      digest: ""
+      ## Specify a imagePullPolicy
+      ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
+      ## ref: https://kubernetes.io/docs/concepts/containers/images/#pre-pulled-images
+      ##
+      pullPolicy: IfNotPresent
+      ## Optionally specify an array of imagePullSecrets.
+      ## Secrets must be manually created in the namespace.
+      ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+      ## e.g:
+      ## pullSecrets:
+      ##   - myRegistryKeySecretName
+      ##
+      pullSecrets: []
+      ## Enable debug mode
+      ##
+      debug: false
+    ## @section WordPress Configuration parameters
+    ## WordPress settings based on environment variables
+    ## ref: https://github.com/bitnami/containers/tree/main/bitnami/wordpress#environment-variables
+    ##
+
+    ## @param wordpressUsername WordPress username
+    ##
+    wordpressUsername: admin
+    ## @param wordpressPassword WordPress user password
+    ## Defaults to a random 10-character alphanumeric string if not set
+    ##
+    wordpressPassword: welcome123
+    ## @param existingSecret Name of existing secret containing WordPress credentials
+    ## NOTE: Must contain key `wordpress-password`
+    ## NOTE: When it's set, the `wordpressPassword` parameter is ignored
+    ##
+    existingSecret: ""
+    ## @param wordpressEmail WordPress user email
+    ##
+    wordpressEmail: admin@spectrocloud.com
+    ## @param wordpressFirstName WordPress user first name
+    ##
+    wordpressFirstName: Administrator
+    ## @param wordpressLastName WordPress user last name
+    ##
+    wordpressLastName: Spectro
+    ## @param wordpressBlogName Blog name
+    ##
+    wordpressBlogName: Hello World !
+    ## @param wordpressTablePrefix Prefix to use for WordPress database tables
+    ##
+    wordpressTablePrefix: wp_
+    ## @param wordpressScheme Scheme to use to generate WordPress URLs
+    ##
+    wordpressScheme: http
+    ## @param wordpressSkipInstall Skip wizard installation
+    ## NOTE: useful if you use an external database that already contains WordPress data
+    ## ref: https://github.com/bitnami/containers/tree/main/bitnami/wordpress#connect-wordpress-docker-container-to-an-existing-database
+    ##
+    wordpressSkipInstall: false
+    ## @param wordpressExtraConfigContent Add extra content to the default wp-config.php file
+    ## e.g:
+    ## wordpressExtraConfigContent: |
+    ##   @ini_set( 'post_max_size', '128M');
+    ##   @ini_set( 'memory_limit', '256M' );
+    ##
+    wordpressExtraConfigContent: ""
+    ## @param wordpressConfiguration The content for your custom wp-config.php file (advanced feature)
+    ## NOTE: This will override configuring WordPress based on environment variables (including those set by the chart)
+    ## NOTE: Currently only supported when `wordpressSkipInstall=true`
+    ##
+    wordpressConfiguration: ""
+    ## @param existingWordPressConfigurationSecret The name of an existing secret with your custom wp-config.php file (advanced feature)
+    ## NOTE: When it's set the `wordpressConfiguration` parameter is ignored
+    ##
+    existingWordPressConfigurationSecret: ""
+    ## @param wordpressConfigureCache Enable W3 Total Cache plugin and configure cache settings
+    ## NOTE: useful if you deploy Memcached for caching database queries or you use an external cache server
+    ##
+    wordpressConfigureCache: false
+    ## @param wordpressPlugins Array of plugins to install and activate. Can be specified as `all` or `none`.
+    ## NOTE: If set to all, only plugins that are already installed will be activated, and if set to none, no plugins will be activated
+    ##
+    wordpressPlugins: none
+    ## @param apacheConfiguration The content for your custom httpd.conf file (advanced feature)
+    ##
+    apacheConfiguration: ""
+    ## @param existingApacheConfigurationConfigMap The name of an existing secret with your custom httpd.conf file (advanced feature)
+    ## NOTE: When it's set the `apacheConfiguration` parameter is ignored
+    ##
+    existingApacheConfigurationConfigMap: ""
+    ## @param customPostInitScripts Custom post-init.d user scripts
+    ## ref: https://github.com/bitnami/containers/tree/main/bitnami/wordpress
+    ## NOTE: supported formats are `.sh`, `.sql` or `.php`
+    ## NOTE: scripts are exclusively executed during the 1st boot of the container
+    ## e.g:
+    ## customPostInitScripts:
+    ##   enable-multisite.sh: |
+    ##     #!/bin/bash
+    ##     chmod +w /bitnami/wordpress/wp-config.php
+    ##     wp core multisite-install --url=example.com --title="Welcome to the WordPress Multisite" --admin_user="doesntmatternotreallyused" --admin_password="doesntmatternotreallyused" --admin_email="user@example.com"
+    ##     cat /docker-entrypoint-init.d/.htaccess > /bitnami/wordpress/.htaccess
+    ##     chmod -w bitnami/wordpress/wp-config.php
+    ##   .htaccess: |
+    ##     RewriteEngine On
+    ##     RewriteBase /
+    ##     ...
+    ##
+    customPostInitScripts: {}
+    ## SMTP mail delivery configuration
+    ## ref: https://github.com/bitnami/containers/tree/main/bitnami/wordpress/#smtp-configuration
+    ## @param smtpHost SMTP server host
+    ## @param smtpPort SMTP server port
+    ## @param smtpUser SMTP username
+    ## @param smtpPassword SMTP user password
+    ## @param smtpProtocol SMTP protocol
+    ##
+    smtpHost: ""
+    smtpPort: ""
+    smtpUser: ""
+    smtpPassword: ""
+    smtpProtocol: ""
+    ## @param smtpExistingSecret The name of an existing secret with SMTP credentials
+    ## NOTE: Must contain key `smtp-password`
+    ## NOTE: When it's set, the `smtpPassword` parameter is ignored
+    ##
+    smtpExistingSecret: ""
+    ## @param allowEmptyPassword Allow the container to be started with blank passwords
+    ##
+    allowEmptyPassword: true
+    ## @param allowOverrideNone Configure Apache to prohibit overriding directives with htaccess files
+    ##
+    allowOverrideNone: false
+    ## @param overrideDatabaseSettings Allow overriding the database settings persisted in wp-config.php
+    ##
+    overrideDatabaseSettings: false
+    ## @param htaccessPersistenceEnabled Persist custom changes on htaccess files
+    ## If `allowOverrideNone` is `false`, it will persist `/opt/bitnami/wordpress/wordpress-htaccess.conf`
+    ## If `allowOverrideNone` is `true`, it will persist `/opt/bitnami/wordpress/.htaccess`
+    ##
+    htaccessPersistenceEnabled: false
+    ## @param customHTAccessCM The name of an existing ConfigMap with custom htaccess rules
+    ## NOTE: Must contain key `wordpress-htaccess.conf` with the file content
+    ## NOTE: Requires setting `allowOverrideNone=false`
+    ##
+    customHTAccessCM: ""
+    ## @param command Override default container command (useful when using custom images)
+    ##
+    command: []
+    ## @param args Override default container args (useful when using custom images)
+    ##
+    args: []
+    ## @param extraEnvVars Array with extra environment variables to add to the WordPress container
+    ## e.g:
+    ## extraEnvVars:
+    ##   - name: FOO
+    ##     value: "bar"
+    ##
+    extraEnvVars: []
+    ## @param extraEnvVarsCM Name of existing ConfigMap containing extra env vars
+    ##
+    extraEnvVarsCM: ""
+    ## @param extraEnvVarsSecret Name of existing Secret containing extra env vars
+    ##
+    extraEnvVarsSecret: ""
+    ## @section WordPress Multisite Configuration parameters
+    ## ref: https://github.com/bitnami/containers/tree/main/bitnami/wordpress#multisite-configuration
+    ##
+
+    ## @param multisite.enable Whether to enable WordPress Multisite configuration.
+    ## @param multisite.host WordPress Multisite hostname/address. This value is mandatory when enabling Multisite mode.
+    ## @param multisite.networkType WordPress Multisite network type to enable. Allowed values: `subfolder`, `subdirectory` or `subdomain`.
+    ## @param multisite.enableNipIoRedirect Whether to enable IP address redirection to nip.io wildcard DNS. Useful when running on an IP address with subdomain network type.
+    ##
+    multisite:
+      enable: false
+      host: ""
+      networkType: subdomain
+      enableNipIoRedirect: false
+    ## @section WordPress deployment parameters
+    ##
+
+    ## @param replicaCount Number of WordPress replicas to deploy
+    ## NOTE: ReadWriteMany PVC(s) are required if replicaCount > 1
+    ##
+    replicaCount: 1
+    ## @param updateStrategy.type WordPress deployment strategy type
+    ## ref: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy
+    ## NOTE: Set it to `Recreate` if you use a PV that cannot be mounted on multiple pods
+    ## e.g:
+    ## updateStrategy:
+    ##  type: RollingUpdate
+    ##  rollingUpdate:
+    ##    maxSurge: 25%
+    ##    maxUnavailable: 25%
+    ##
+    updateStrategy:
+      type: RollingUpdate
+    ## @param schedulerName Alternate scheduler
+    ## ref: https://kubernetes.io/docs/tasks/administer-cluster/configure-multiple-schedulers/
+    ##
+    schedulerName: ""
+    ## @param terminationGracePeriodSeconds In seconds, time given to the WordPress pod to terminate gracefully
+    ## ref: https://kubernetes.io/docs/concepts/workloads/pods/pod/#termination-of-pods
+    ##
+    terminationGracePeriodSeconds: ""
+    ## @param topologySpreadConstraints Topology Spread Constraints for pod assignment spread across your cluster among failure-domains. Evaluated as a template
+    ## Ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/#spread-constraints-for-pods
+    ##
+    topologySpreadConstraints: []
+    ## @param priorityClassName Name of the existing priority class to be used by WordPress pods, priority class needs to be created beforehand
+    ## Ref: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/
+    ##
+    priorityClassName: ""
+    ## @param automountServiceAccountToken Mount Service Account token in pod
+    ##
+    automountServiceAccountToken: false
+    ## @param hostAliases [array] WordPress pod host aliases
+    ## https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/
+    ##
+    hostAliases:
+      ## Required for Apache exporter to work
+      ##
+      - ip: "127.0.0.1"
+        hostnames:
+          - "status.localhost"
+    ## @param extraVolumes Optionally specify extra list of additional volumes for WordPress pods
+    ##
+    extraVolumes: []
+    ## @param extraVolumeMounts Optionally specify extra list of additional volumeMounts for WordPress container(s)
+    ##
+    extraVolumeMounts: []
+    ## @param sidecars Add additional sidecar containers to the WordPress pod
+    ## e.g:
+    ## sidecars:
+    ##   - name: your-image-name
+    ##     image: your-image
+    ##     imagePullPolicy: Always
+    ##     ports:
+    ##       - name: portname
+    ##         containerPort: 1234
+    ##
+    sidecars: []
+    ## @param initContainers Add additional init containers to the WordPress pods
+    ## ref: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/
+    ## e.g:
+    ## initContainers:
+    ##  - name: your-image-name
+    ##    image: your-image
+    ##    imagePullPolicy: Always
+    ##    command: ['sh', '-c', 'copy themes and plugins from git and push to /bitnami/wordpress/wp-content. Should work with extraVolumeMounts and extraVolumes']
+    ##
+    initContainers: []
+    ## @param podLabels Extra labels for WordPress pods
+    ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
+    ##
+    podLabels: {}
+    ## @param podAnnotations Annotations for WordPress pods
+    ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
+    ##
+    podAnnotations: {}
+    ## @param podAffinityPreset Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`
+    ## ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity
+    ##
+    podAffinityPreset: ""
+    ## @param podAntiAffinityPreset Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`
+    ## Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity
+    ##
+    podAntiAffinityPreset: soft
+    ## Node affinity preset
+    ## Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#node-affinity
+    ##
+    nodeAffinityPreset:
+      ## @param nodeAffinityPreset.type Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`
+      ##
+      type: ""
+      ## @param nodeAffinityPreset.key Node label key to match. Ignored if `affinity` is set
+      ##
+      key: ""
+      ## @param nodeAffinityPreset.values Node label values to match. Ignored if `affinity` is set
+      ## E.g.
+      ## values:
+      ##   - e2e-az1
+      ##   - e2e-az2
+      ##
+      values: []
+    ## @param affinity Affinity for pod assignment
+    ## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+    ## NOTE: podAffinityPreset, podAntiAffinityPreset, and nodeAffinityPreset will be ignored when it's set
+    ##
+    affinity: {}
+    ## @param nodeSelector Node labels for pod assignment
+    ## ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/
+    ##
+    nodeSelector: {}
+    ## @param tolerations Tolerations for pod assignment
+    ## ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+    ##
+    tolerations: []
+    ## WordPress containers' resource requests and limits
+    ## ref: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/
+    ## @param resourcesPreset Set container resources according to one common preset (allowed values: none, nano, small, medium, large, xlarge, 2xlarge). This is ignored if resources is set (resources is recommended for production).
+    ## More information: https://github.com/bitnami/charts/blob/main/bitnami/common/templates/_resources.tpl#L15
+    ##
+    resourcesPreset: "none"
+    ## @param resources Set container requests and limits for different resources like CPU or memory (essential for production workloads)
+    ## Example:
+    ## resources:
+    ##   requests:
+    ##     cpu: 2
+    ##     memory: 512Mi
+    ##   limits:
+    ##     cpu: 3
+    ##     memory: 1024Mi
+    ##
+    resources: {}
+    ## Container ports
+    ## @param containerPorts.http WordPress HTTP container port
+    ## @param containerPorts.https WordPress HTTPS container port
+    ##
+    containerPorts:
+      http: 8080
+      https: 8443
+    ## @param extraContainerPorts Optionally specify extra list of additional ports for WordPress container(s)
+    ## e.g:
+    ## extraContainerPorts:
+    ##   - name: myservice
+    ##     containerPort: 9090
+    ##
+    extraContainerPorts: []
+    ## Configure Pods Security Context
+    ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
+    ## @param podSecurityContext.enabled Enabled WordPress pods' Security Context
+    ## @param podSecurityContext.fsGroupChangePolicy Set filesystem group change policy
+    ## @param podSecurityContext.sysctls Set kernel settings using the sysctl interface
+    ## @param podSecurityContext.supplementalGroups Set filesystem extra groups
+    ## @param podSecurityContext.fsGroup Set WordPress pod's Security Context fsGroup
+    ##
+    podSecurityContext:
+      enabled: true
+      fsGroupChangePolicy: Always
+      sysctls: []
+      supplementalGroups: []
+      fsGroup: 1001
+    ## Configure Container Security Context (only main container)
+    ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container
+    ## @param containerSecurityContext.enabled Enabled containers' Security Context
+    ## @param containerSecurityContext.seLinuxOptions [object,nullable] Set SELinux options in container
+    ## @param containerSecurityContext.runAsUser Set containers' Security Context runAsUser
+    ## @param containerSecurityContext.runAsNonRoot Set container's Security Context runAsNonRoot
+    ## @param containerSecurityContext.privileged Set container's Security Context privileged
+    ## @param containerSecurityContext.readOnlyRootFilesystem Set container's Security Context readOnlyRootFilesystem
+    ## @param containerSecurityContext.allowPrivilegeEscalation Set container's Security Context allowPrivilegeEscalation
+    ## @param containerSecurityContext.capabilities.drop List of capabilities to be dropped
+    ## @param containerSecurityContext.seccompProfile.type Set container's Security Context seccomp profile
+    ##
+    containerSecurityContext:
+      enabled: true
+      seLinuxOptions: null
+      runAsUser: 1001
+      runAsNonRoot: true
+      privileged: false
+      readOnlyRootFilesystem: false
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop: [ "ALL" ]
+      seccompProfile:
+        type: "RuntimeDefault"
+    ## Configure extra options for WordPress containers' liveness, readiness and startup probes
+    ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#configure-probes
+    ## @param livenessProbe.enabled Enable livenessProbe on WordPress containers
+    ## @skip livenessProbe.httpGet
+    ## @param livenessProbe.initialDelaySeconds Initial delay seconds for livenessProbe
+    ## @param livenessProbe.periodSeconds Period seconds for livenessProbe
+    ## @param livenessProbe.timeoutSeconds Timeout seconds for livenessProbe
+    ## @param livenessProbe.failureThreshold Failure threshold for livenessProbe
+    ## @param livenessProbe.successThreshold Success threshold for livenessProbe
+    ##
+    livenessProbe:
+      enabled: true
+      httpGet:
+        path: /wp-admin/install.php
+        port: '{{ .Values.wordpressScheme }}'
+        scheme: '{{ .Values.wordpressScheme | upper }}'
+        ## If using an HTTPS-terminating load-balancer, the probes may need to behave
+        ## like the balancer to prevent HTTP 302 responses. According to the Kubernetes
+        ## docs, 302 should be considered "successful", but this issue on GitHub
+        ## (https://github.com/kubernetes/kubernetes/issues/47893) shows that it isn't.
+        ## E.g.
+        ## httpHeaders:
+        ## - name: X-Forwarded-Proto
+        ##   value: https
+        ##
+        httpHeaders: []
+      initialDelaySeconds: 120
+      periodSeconds: 10
+      timeoutSeconds: 5
+      failureThreshold: 6
+      successThreshold: 1
+    ## @param readinessProbe.enabled Enable readinessProbe on WordPress containers
+    ## @skip readinessProbe.httpGet
+    ## @param readinessProbe.initialDelaySeconds Initial delay seconds for readinessProbe
+    ## @param readinessProbe.periodSeconds Period seconds for readinessProbe
+    ## @param readinessProbe.timeoutSeconds Timeout seconds for readinessProbe
+    ## @param readinessProbe.failureThreshold Failure threshold for readinessProbe
+    ## @param readinessProbe.successThreshold Success threshold for readinessProbe
+    ##
+    readinessProbe:
+      enabled: true
+      httpGet:
+        path: /wp-login.php
+        port: '{{ .Values.wordpressScheme }}'
+        scheme: '{{ .Values.wordpressScheme | upper }}'
+        ## If using an HTTPS-terminating load-balancer, the probes may need to behave
+        ## like the balancer to prevent HTTP 302 responses. According to the Kubernetes
+        ## docs, 302 should be considered "successful", but this issue on GitHub
+        ## (https://github.com/kubernetes/kubernetes/issues/47893) shows that it isn't.
+        ## E.g.
+        ## httpHeaders:
+        ## - name: X-Forwarded-Proto
+        ##   value: https
+        ##
+        httpHeaders: []
+      initialDelaySeconds: 30
+      periodSeconds: 10
+      timeoutSeconds: 5
+      failureThreshold: 6
+      successThreshold: 1
+    ## @param startupProbe.enabled Enable startupProbe on WordPress containers
+    ## @skip startupProbe.httpGet
+    ## @param startupProbe.initialDelaySeconds Initial delay seconds for startupProbe
+    ## @param startupProbe.periodSeconds Period seconds for startupProbe
+    ## @param startupProbe.timeoutSeconds Timeout seconds for startupProbe
+    ## @param startupProbe.failureThreshold Failure threshold for startupProbe
+    ## @param startupProbe.successThreshold Success threshold for startupProbe
+    ##
+    startupProbe:
+      enabled: false
+      httpGet:
+        path: /wp-login.php
+        port: '{{ .Values.wordpressScheme }}'
+        scheme: '{{ .Values.wordpressScheme | upper }}'
+        ## If using an HTTPS-terminating load-balancer, the probes may need to behave
+        ## like the balancer to prevent HTTP 302 responses. According to the Kubernetes
+        ## docs, 302 should be considered "successful", but this issue on GitHub
+        ## (https://github.com/kubernetes/kubernetes/issues/47893) shows that it isn't.
+        ## E.g.
+        ## httpHeaders:
+        ## - name: X-Forwarded-Proto
+        ##   value: https
+        ##
+        httpHeaders: []
+      initialDelaySeconds: 30
+      periodSeconds: 10
+      timeoutSeconds: 5
+      failureThreshold: 6
+      successThreshold: 1
+    ## @param customLivenessProbe Custom livenessProbe that overrides the default one
+    ##
+    customLivenessProbe: {}
+    ## @param customReadinessProbe Custom readinessProbe that overrides the default one
+    ##
+    customReadinessProbe: {}
+    ## @param customStartupProbe Custom startupProbe that overrides the default one
+    ##
+    customStartupProbe: {}
+    ## @param lifecycleHooks for the WordPress container(s) to automate configuration before or after startup
+    ##
+    lifecycleHooks: {}
+    ## @section Traffic Exposure Parameters
+    ##
+
+    ## WordPress service parameters
+    ##
+    service:
+      ## @param service.type WordPress service type
+      ##
+      type: LoadBalancer
+      ## @param service.ports.http WordPress service HTTP port
+      ## @param service.ports.https WordPress service HTTPS port
+      ##
+      ports:
+        http: 80
+        https: 443
+      ## @param service.httpsTargetPort Target port for HTTPS
+      ##
+      httpsTargetPort: https
+      ## Node ports to expose
+      ## @param service.nodePorts.http Node port for HTTP
+      ## @param service.nodePorts.https Node port for HTTPS
+      ## NOTE: choose port between <30000-32767>
+      ##
+      nodePorts:
+        http: ""
+        https: ""
+      ## @param service.sessionAffinity Control where client requests go, to the same pod or round-robin
+      ## Values: ClientIP or None
+      ## ref: https://kubernetes.io/docs/concepts/services-networking/service/
+      ##
+      sessionAffinity: None
+      ## @param service.sessionAffinityConfig Additional settings for the sessionAffinity
+      ## sessionAffinityConfig:
+      ##   clientIP:
+      ##     timeoutSeconds: 300
+      ##
+      sessionAffinityConfig: {}
+      ## @param service.clusterIP WordPress service Cluster IP
+      ## e.g.:
+      ## clusterIP: None
+      ##
+      clusterIP: ""
+      ## @param service.loadBalancerIP WordPress service Load Balancer IP
+      ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#type-loadbalancer
+      ##
+      loadBalancerIP: ""
+      ## @param service.loadBalancerSourceRanges WordPress service Load Balancer sources
+      ## ref: https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/#restrict-access-for-loadbalancer-service
+      ## e.g:
+      ## loadBalancerSourceRanges:
+      ##   - 10.10.10.0/24
+      ##
+      loadBalancerSourceRanges: []
+      ## @param service.externalTrafficPolicy WordPress service external traffic policy
+      ## ref https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#preserving-the-client-source-ip
+      ##
+      externalTrafficPolicy: Cluster
+      ## @param service.annotations Additional custom annotations for WordPress service
+      ##
+      annotations: {}
+      ## @param service.extraPorts Extra port to expose on WordPress service
+      ##
+      extraPorts: []
+    ## Configure the ingress resource that allows you to access the WordPress installation
+    ## ref: https://kubernetes.io/docs/concepts/services-networking/ingress/
+    ##
+    ingress:
+      ## @param ingress.enabled Enable ingress record generation for WordPress
+      ##
+      enabled: false
+      ## @param ingress.pathType Ingress path type
+      ##
+      pathType: ImplementationSpecific
+      ## @param ingress.apiVersion Force Ingress API version (automatically detected if not set)
+      ##
+      apiVersion: ""
+      ## @param ingress.ingressClassName IngressClass that will be be used to implement the Ingress (Kubernetes 1.18+)
+      ## This is supported in Kubernetes 1.18+ and required if you have more than one IngressClass marked as the default for your cluster .
+      ## ref: https://kubernetes.io/blog/2020/04/02/improvements-to-the-ingress-api-in-kubernetes-1.18/
+      ##
+      ingressClassName: ""
+      ## @param ingress.hostname Default host for the ingress record. The hostname is templated and thus can contain other variable references.
+      ##
+      hostname: wordpress.local
+      ## @param ingress.path Default path for the ingress record
+      ## NOTE: You may need to set this to '/*' in order to use this with ALB ingress controllers
+      ##
+      path: /
+      ## @param ingress.annotations Additional annotations for the Ingress resource. To enable certificate autogeneration, place here your cert-manager annotations.
+      ## For a full list of possible ingress annotations, please see
+      ## ref: https://github.com/kubernetes/ingress-nginx/blob/main/docs/user-guide/nginx-configuration/annotations.md
+      ## Use this parameter to set the required annotations for cert-manager, see
+      ## ref: https://cert-manager.io/docs/usage/ingress/#supported-annotations
+      ##
+      ## e.g:
+      ## annotations:
+      ##   kubernetes.io/ingress.class: nginx
+      ##   cert-manager.io/cluster-issuer: cluster-issuer-name
+      ##
+      annotations: {}
+      ## @param ingress.tls Enable TLS configuration for the host defined at `ingress.hostname` parameter
+      ## TLS certificates will be retrieved from a TLS secret with name: `{{- printf "%s-tls" .Values.ingress.hostname }}`
+      ## You can:
+      ##   - Use the `ingress.secrets` parameter to create this TLS secret
+      ##   - Rely on cert-manager to create it by setting the corresponding annotations
+      ##   - Rely on Helm to create self-signed certificates by setting `ingress.selfSigned=true`
+      ##
+      tls: false
+      ## @param ingress.tlsWwwPrefix Adds www subdomain to default cert
+      ## Creates tls host with ingress.hostname: {{ print "www.%s" .Values.ingress.hostname }}
+      ## Is enabled if "nginx.ingress.kubernetes.io/from-to-www-redirect" is "true"
+      tlsWwwPrefix: false
+      ## @param ingress.selfSigned Create a TLS secret for this ingress record using self-signed certificates generated by Helm
+      ##
+      selfSigned: false
+      ## @param ingress.extraHosts An array with additional hostname(s) to be covered with the ingress record. The host names are templated and thus can contain other variable references.
+      ## e.g:
+      ## extraHosts:
+      ##   - name: wordpress.local
+      ##     path: /
+      ##
+      extraHosts: []
+      ## @param ingress.extraPaths An array with additional arbitrary paths that may need to be added to the ingress under the main host
+      ## e.g:
+      ## extraPaths:
+      ## - path: /*
+      ##   backend:
+      ##     serviceName: ssl-redirect
+      ##     servicePort: use-annotation
+      ##
+      extraPaths: []
+      ## @param ingress.extraTls TLS configuration for additional hostname(s) to be covered with this ingress record
+      ## ref: https://kubernetes.io/docs/concepts/services-networking/ingress/#tls
+      ## e.g:
+      ## extraTls:
+      ## - hosts:
+      ##     - wordpress.local
+      ##   secretName: wordpress.local-tls
+      ##
+      extraTls: []
+      ## @param ingress.secrets Custom TLS certificates as secrets
+      ## NOTE: 'key' and 'certificate' are expected in PEM format
+      ## NOTE: 'name' should line up with a 'secretName' set further up
+      ## If it is not set and you're using cert-manager, this is unneeded, as it will create a secret for you with valid certificates
+      ## If it is not set and you're NOT using cert-manager either, self-signed certificates will be created valid for 365 days
+      ## It is also possible to create and manage the certificates outside of this helm chart
+      ## Please see README.md for more information
+      ## e.g:
+      ## secrets:
+      ##   - name: wordpress.local-tls
+      ##     key: |-
+      ##       -----BEGIN RSA PRIVATE KEY-----
+      ##       ...
+      ##       -----END RSA PRIVATE KEY-----
+      ##     certificate: |-
+      ##       -----BEGIN CERTIFICATE-----
+      ##       ...
+      ##       -----END CERTIFICATE-----
+      ##
+      secrets: []
+      ## @param ingress.extraRules Additional rules to be covered with this ingress record
+      ## ref: https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-rules
+      ## e.g:
+      ## extraRules:
+      ## - host: wordpress.local
+      ##     http:
+      ##       path: /
+      ##       backend:
+      ##         service:
+      ##           name: wordpress-svc
+      ##           port:
+      ##             name: http
+      ##
+      extraRules: []
+    ## @section Persistence Parameters
+    ##
+
+    ## Persistence Parameters
+    ## ref: https://kubernetes.io/docs/concepts/storage/persistent-volumes/
+    ##
+    persistence:
+      ## @param persistence.enabled Enable persistence using Persistent Volume Claims
+      ##
+      enabled: true
+      ## @param persistence.storageClass Persistent Volume storage class
+      ## If defined, storageClassName: <storageClass>
+      ## If set to "-", storageClassName: "", which disables dynamic provisioning
+      ## If undefined (the default) or set to null, no storageClassName spec is set, choosing the default provisioner
+      ##
+      storageClass: ""
+      ## @param persistence.accessModes [array] Persistent Volume access modes
+      ##
+      accessModes:
+        - ReadWriteOnce
+      ## @param persistence.accessMode Persistent Volume access mode (DEPRECATED: use `persistence.accessModes` instead)
+      ##
+      accessMode: ReadWriteOnce
+      ## @param persistence.size Persistent Volume size
+      ##
+      size: 10Gi
+      ## @param persistence.dataSource Custom PVC data source
+      ##
+      dataSource: {}
+      ## @param persistence.existingClaim The name of an existing PVC to use for persistence
+      ##
+      existingClaim: ""
+      ## @param persistence.selector Selector to match an existing Persistent Volume for WordPress data PVC
+      ## If set, the PVC can't have a PV dynamically provisioned for it
+      ## E.g.
+      ## selector:
+      ##   matchLabels:
+      ##     app: my-app
+      ##
+      selector: {}
+      ## @param persistence.annotations Persistent Volume Claim annotations
+      ##
+      annotations: {}
+    ## Init containers parameters:
+    ## volumePermissions: Change the owner and group of the persistent volume(s) mountpoint(s) to 'runAsUser:fsGroup' on each node
+    ##
+    volumePermissions:
+      ## @param volumePermissions.enabled Enable init container that changes the owner/group of the PV mount point to `runAsUser:fsGroup`
+      ##
+      enabled: false
+      ## OS Shell + Utility image
+      ## ref: https://hub.docker.com/r/bitnami/os-shell/tags/
+      ## @param volumePermissions.image.registry [default: REGISTRY_NAME] OS Shell + Utility image registry
+      ## @param volumePermissions.image.repository [default: REPOSITORY_NAME/os-shell] OS Shell + Utility image repository
+      ## @skip volumePermissions.image.tag OS Shell + Utility image tag (immutable tags are recommended)
+      ## @param volumePermissions.image.digest OS Shell + Utility image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
+      ## @param volumePermissions.image.pullPolicy OS Shell + Utility image pull policy
+      ## @param volumePermissions.image.pullSecrets OS Shell + Utility image pull secrets
+      ##
+      image:
+        registry: docker.io
+        repository: bitnami/os-shell
+        tag: 12-debian-12-r16
+        digest: ""
+        pullPolicy: IfNotPresent
+        ## Optionally specify an array of imagePullSecrets.
+        ## Secrets must be manually created in the namespace.
+        ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+        ## e.g:
+        ## pullSecrets:
+        ##   - myRegistryKeySecretName
+        ##
+        pullSecrets: []
+      ## Init container's resource requests and limits
+      ## ref: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/
+      ## @param volumePermissions.resourcesPreset Set container resources according to one common preset (allowed values: none, nano, small, medium, large, xlarge, 2xlarge). This is ignored if volumePermissions.resources is set (volumePermissions.resources is recommended for production).
+      ## More information: https://github.com/bitnami/charts/blob/main/bitnami/common/templates/_resources.tpl#L15
+      ##
+      resourcesPreset: "none"
+      ## @param volumePermissions.resources Set container requests and limits for different resources like CPU or memory (essential for production workloads)
+      ## Example:
+      ## resources:
+      ##   requests:
+      ##     cpu: 2
+      ##     memory: 512Mi
+      ##   limits:
+      ##     cpu: 3
+      ##     memory: 1024Mi
+      ##
+      resources: {}
+      ## Init container' Security Context
+      ## Note: the chown of the data folder is done to containerSecurityContext.runAsUser
+      ## and not the below volumePermissions.containerSecurityContext.runAsUser
+      ## @param volumePermissions.containerSecurityContext.seLinuxOptions [object,nullable] Set SELinux options in container
+      ## @param volumePermissions.containerSecurityContext.runAsUser User ID for the init container
+      ##
+      containerSecurityContext:
+        seLinuxOptions: null
+        runAsUser: 0
+    ## @section Other Parameters
+    ##
+
+    ## WordPress Service Account
+    ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
+    ##
+    serviceAccount:
+      ## @param serviceAccount.create Enable creation of ServiceAccount for WordPress pod
+      ##
+      create: true
+      ## @param serviceAccount.name The name of the ServiceAccount to use.
+      ## If not set and create is true, a name is generated using the common.names.fullname template
+      ##
+      name: ""
+      ## @param serviceAccount.automountServiceAccountToken Allows auto mount of ServiceAccountToken on the serviceAccount created
+      ## Can be set to false if pods using this serviceAccount do not need to use K8s API
+      ##
+      automountServiceAccountToken: false
+      ## @param serviceAccount.annotations Additional custom annotations for the ServiceAccount
+      ##
+      annotations: {}
+    ## WordPress Pod Disruption Budget configuration
+    ## ref: https://kubernetes.io/docs/tasks/run-application/configure-pdb/
+    ## @param pdb.create Enable a Pod Disruption Budget creation
+    ## @param pdb.minAvailable Minimum number/percentage of pods that should remain scheduled
+    ## @param pdb.maxUnavailable Maximum number/percentage of pods that may be made unavailable
+    ##
+    pdb:
+      create: false
+      minAvailable: 1
+      maxUnavailable: ""
+    ## WordPress Autoscaling configuration
+    ## ref: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/
+    ## @param autoscaling.enabled Enable Horizontal POD autoscaling for WordPress
+    ## @param autoscaling.minReplicas Minimum number of WordPress replicas
+    ## @param autoscaling.maxReplicas Maximum number of WordPress replicas
+    ## @param autoscaling.targetCPU Target CPU utilization percentage
+    ## @param autoscaling.targetMemory Target Memory utilization percentage
+    ##
+    autoscaling:
+      enabled: false
+      minReplicas: 1
+      maxReplicas: 11
+      targetCPU: 50
+      targetMemory: 50
+    ## @section Metrics Parameters
+    ##
+
+    ## Prometheus Exporter / Metrics configuration
+    ##
+    metrics:
+      ## @param metrics.enabled Start a sidecar prometheus exporter to expose metrics
+      ##
+      enabled: false
+      ## Bitnami Apache exporter image
+      ## ref: https://hub.docker.com/r/bitnami/apache-exporter/tags/
+      ## @param metrics.image.registry [default: REGISTRY_NAME] Apache exporter image registry
+      ## @param metrics.image.repository [default: REPOSITORY_NAME/apache-exporter] Apache exporter image repository
+      ## @skip metrics.image.tag Apache exporter image tag (immutable tags are recommended)
+      ## @param metrics.image.digest Apache exporter image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
+      ## @param metrics.image.pullPolicy Apache exporter image pull policy
+      ## @param metrics.image.pullSecrets Apache exporter image pull secrets
+      ##
+      image:
+        registry: docker.io
+        repository: bitnami/apache-exporter
+        tag: 1.0.6-debian-12-r7
+        digest: ""
+        pullPolicy: IfNotPresent
+        ## Optionally specify an array of imagePullSecrets.
+        ## Secrets must be manually created in the namespace.
+        ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+        ## e.g:
+        ## pullSecrets:
+        ##   - myRegistryKeySecretName
+        ##
+        pullSecrets: []
+      ## @param metrics.containerPorts.metrics Prometheus exporter container port
+      ##
+      containerPorts:
+        metrics: 9117
+      ## Configure extra options for Prometheus exporter containers' liveness, readiness and startup probes
+      ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#configure-probes
+      ## @param metrics.livenessProbe.enabled Enable livenessProbe on Prometheus exporter containers
+      ## @param metrics.livenessProbe.initialDelaySeconds Initial delay seconds for livenessProbe
+      ## @param metrics.livenessProbe.periodSeconds Period seconds for livenessProbe
+      ## @param metrics.livenessProbe.timeoutSeconds Timeout seconds for livenessProbe
+      ## @param metrics.livenessProbe.failureThreshold Failure threshold for livenessProbe
+      ## @param metrics.livenessProbe.successThreshold Success threshold for livenessProbe
+      ##
+      livenessProbe:
+        enabled: true
+        initialDelaySeconds: 15
+        periodSeconds: 10
+        timeoutSeconds: 5
+        failureThreshold: 3
+        successThreshold: 1
+      ## @param metrics.readinessProbe.enabled Enable readinessProbe on Prometheus exporter containers
+      ## @param metrics.readinessProbe.initialDelaySeconds Initial delay seconds for readinessProbe
+      ## @param metrics.readinessProbe.periodSeconds Period seconds for readinessProbe
+      ## @param metrics.readinessProbe.timeoutSeconds Timeout seconds for readinessProbe
+      ## @param metrics.readinessProbe.failureThreshold Failure threshold for readinessProbe
+      ## @param metrics.readinessProbe.successThreshold Success threshold for readinessProbe
+      ##
+      readinessProbe:
+        enabled: true
+        initialDelaySeconds: 5
+        periodSeconds: 10
+        timeoutSeconds: 3
+        failureThreshold: 3
+        successThreshold: 1
+      ## @param metrics.startupProbe.enabled Enable startupProbe on Prometheus exporter containers
+      ## @param metrics.startupProbe.initialDelaySeconds Initial delay seconds for startupProbe
+      ## @param metrics.startupProbe.periodSeconds Period seconds for startupProbe
+      ## @param metrics.startupProbe.timeoutSeconds Timeout seconds for startupProbe
+      ## @param metrics.startupProbe.failureThreshold Failure threshold for startupProbe
+      ## @param metrics.startupProbe.successThreshold Success threshold for startupProbe
+      ##
+      startupProbe:
+        enabled: false
+        initialDelaySeconds: 10
+        periodSeconds: 10
+        timeoutSeconds: 1
+        failureThreshold: 15
+        successThreshold: 1
+      ## @param metrics.customLivenessProbe Custom livenessProbe that overrides the default one
+      ##
+      customLivenessProbe: {}
+      ## @param metrics.customReadinessProbe Custom readinessProbe that overrides the default one
+      ##
+      customReadinessProbe: {}
+      ## @param metrics.customStartupProbe Custom startupProbe that overrides the default one
+      ##
+      customStartupProbe: {}
+      ## Prometheus exporter container's resource requests and limits
+      ## ref: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/
+      ## @param metrics.resourcesPreset Set container resources according to one common preset (allowed values: none, nano, small, medium, large, xlarge, 2xlarge). This is ignored if metrics.resources is set (metrics.resources is recommended for production).
+      ## More information: https://github.com/bitnami/charts/blob/main/bitnami/common/templates/_resources.tpl#L15
+      ##
+      resourcesPreset: "none"
+      ## @param metrics.resources Set container requests and limits for different resources like CPU or memory (essential for production workloads)
+      ## Example:
+      ## resources:
+      ##   requests:
+      ##     cpu: 2
+      ##     memory: 512Mi
+      ##   limits:
+      ##     cpu: 3
+      ##     memory: 1024Mi
+      ##
+      resources: {}
+      ## Configure Container Security Context
+      ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container
+      ## @param metrics.containerSecurityContext.enabled Enabled containers' Security Context
+      ## @param metrics.containerSecurityContext.seLinuxOptions [object,nullable] Set SELinux options in container
+      ## @param metrics.containerSecurityContext.runAsUser Set containers' Security Context runAsUser
+      ## @param metrics.containerSecurityContext.runAsNonRoot Set container's Security Context runAsNonRoot
+      ## @param metrics.containerSecurityContext.privileged Set container's Security Context privileged
+      ## @param metrics.containerSecurityContext.readOnlyRootFilesystem Set container's Security Context readOnlyRootFilesystem
+      ## @param metrics.containerSecurityContext.allowPrivilegeEscalation Set container's Security Context allowPrivilegeEscalation
+      ## @param metrics.containerSecurityContext.capabilities.drop List of capabilities to be dropped
+      ## @param metrics.containerSecurityContext.seccompProfile.type Set container's Security Context seccomp profile
+      ##
+      containerSecurityContext:
+        enabled: true
+        seLinuxOptions: null
+        runAsUser: 1001
+        runAsNonRoot: true
+        privileged: false
+        readOnlyRootFilesystem: false
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop: [ "ALL" ]
+        seccompProfile:
+          type: "RuntimeDefault"
+      ## Prometheus exporter service parameters
+      ##
+      service:
+        ## @param metrics.service.ports.metrics Prometheus metrics service port
+        ##
+        ports:
+          metrics: 9150
+        ## @param metrics.service.annotations [object] Additional custom annotations for Metrics service
+        ##
+        annotations:
+          prometheus.io/scrape: "true"
+          prometheus.io/port: "{{ .Values.metrics.containerPorts.metrics }}"
+      ## Prometheus Operator ServiceMonitor configuration
+      ##
+      serviceMonitor:
+        ## @param metrics.serviceMonitor.enabled Create ServiceMonitor Resource for scraping metrics using Prometheus Operator
+        ##
+        enabled: false
+        ## @param metrics.serviceMonitor.namespace Namespace for the ServiceMonitor Resource (defaults to the Release Namespace)
+        ##
+        namespace: ""
+        ## @param metrics.serviceMonitor.interval Interval at which metrics should be scraped.
+        ## ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#endpoint
+        ##
+        interval: ""
+        ## @param metrics.serviceMonitor.scrapeTimeout Timeout after which the scrape is ended
+        ## ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#endpoint
+        ##
+        scrapeTimeout: ""
+        ## @param metrics.serviceMonitor.labels Additional labels that can be used so ServiceMonitor will be discovered by Prometheus
+        ##
+        labels: {}
+        ## @param metrics.serviceMonitor.selector Prometheus instance selector labels
+        ## ref: https://github.com/bitnami/charts/tree/main/bitnami/prometheus-operator#prometheus-configuration
+        ##
+        selector: {}
+        ## @param metrics.serviceMonitor.relabelings RelabelConfigs to apply to samples before scraping
+        ##
+        relabelings: []
+        ## @param metrics.serviceMonitor.metricRelabelings MetricRelabelConfigs to apply to samples before ingestion
+        ##
+        metricRelabelings: []
+        ## @param metrics.serviceMonitor.honorLabels Specify honorLabels parameter to add the scrape endpoint
+        ##
+        honorLabels: false
+        ## @param metrics.serviceMonitor.jobLabel The name of the label on the target service to use as the job name in prometheus.
+        ##
+        jobLabel: ""
+    ## @section NetworkPolicy parameters
+    ##
+
+    ## Add networkpolicies
+    ##
+    networkPolicy:
+      ## @param networkPolicy.enabled Enable network policies
+      ## If ingress.enabled or metrics.enabled are true, configure networkPolicy.ingress and networkPolicy.metrics selectors respectively to allow communication
+      ##
+      enabled: false
+      ## @param networkPolicy.metrics.enabled Enable network policy for metrics (prometheus)
+      ## @param networkPolicy.metrics.namespaceSelector [object] Monitoring namespace selector labels. These labels will be used to identify the prometheus' namespace.
+      ## @param networkPolicy.metrics.podSelector [object] Monitoring pod selector labels. These labels will be used to identify the Prometheus pods.
+      ##
+      metrics:
+        enabled: false
+        ## e.g:
+        ## podSelector:
+        ##   label: monitoring
+        ##
+        podSelector: {}
+        ## e.g:
+        ## namespaceSelector:
+        ##   label: monitoring
+        ##
+        namespaceSelector: {}
+      ## @param networkPolicy.ingress.enabled Enable network policy for Ingress Proxies
+      ## @param networkPolicy.ingress.namespaceSelector [object] Ingress Proxy namespace selector labels. These labels will be used to identify the Ingress Proxy's namespace.
+      ## @param networkPolicy.ingress.podSelector [object] Ingress Proxy pods selector labels. These labels will be used to identify the Ingress Proxy pods.
+      ##
+      ingress:
+        enabled: false
+        ## e.g:
+        ## podSelector:
+        ##   label: ingress
+        ##
+        podSelector: {}
+        ## e.g:
+        ## namespaceSelector:
+        ##   label: ingress
+        ##
+        namespaceSelector: {}
+      ## @param networkPolicy.ingressRules.backendOnlyAccessibleByFrontend Enable ingress rule that makes the backend (mariadb) only accessible by testlink's pods.
+      ## @param networkPolicy.ingressRules.customBackendSelector [object] Backend selector labels. These labels will be used to identify the backend pods.
+      ## @param networkPolicy.ingressRules.accessOnlyFrom.enabled Enable ingress rule that makes testlink only accessible from a particular origin
+      ## @param networkPolicy.ingressRules.accessOnlyFrom.namespaceSelector [object] Namespace selector label that is allowed to access testlink. This label will be used to identified the allowed namespace(s).
+      ## @param networkPolicy.ingressRules.accessOnlyFrom.podSelector [object] Pods selector label that is allowed to access testlink. This label will be used to identified the allowed pod(s).
+      ## @param networkPolicy.ingressRules.customRules [object] Custom network policy ingress rule
+      ##
+      ingressRules:
+        ## mariadb backend only can be accessed from testlink
+        ##
+        backendOnlyAccessibleByFrontend: false
+        ## Additional custom backend selector
+        ## e.g:
+        ## customBackendSelector:
+        ##   - to:
+        ##       - namespaceSelector:
+        ##           matchLabels:
+        ##             label: example
+        ##
+        customBackendSelector: {}
+        ## Allow only from the indicated:
+        ##
+        accessOnlyFrom:
+          enabled: false
+          ## e.g:
+          ## podSelector:
+          ##   label: access
+          ##
+          podSelector: {}
+          ## e.g:
+          ## namespaceSelector:
+          ##   label: access
+          ##
+          namespaceSelector: {}
+        ## custom ingress rules
+        ## e.g:
+        ## customRules:
+        ##   - from:
+        ##       - namespaceSelector:
+        ##           matchLabels:
+        ##             label: example
+        ##
+        customRules: {}
+      ## @param networkPolicy.egressRules.denyConnectionsToExternal Enable egress rule that denies outgoing traffic outside the cluster, except for DNS (port 53).
+      ## @param networkPolicy.egressRules.customRules [object] Custom network policy rule
+      ##
+      egressRules:
+        # Deny connections to external. This is not compatible with an external database.
+        denyConnectionsToExternal: false
+        ## Additional custom egress rules
+        ## e.g:
+        ## customRules:
+        ##   - to:
+        ##       - namespaceSelector:
+        ##           matchLabels:
+        ##             label: example
+        ##
+        customRules: {}
+    ## @section Database Parameters
+    ##
+
+    ## MariaDB chart configuration
+    ## ref: https://github.com/bitnami/charts/blob/main/bitnami/mariadb/values.yaml
+    ##
+    mariadb:
+      ## @param mariadb.enabled Deploy a MariaDB server to satisfy the applications database requirements
+      ## To use an external database set this to false and configure the `externalDatabase.*` parameters
+      ##
+      enabled: true
+      ## @param mariadb.architecture MariaDB architecture. Allowed values: `standalone` or `replication`
+      ##
+      architecture: standalone
+      ## MariaDB Authentication parameters
+      ## @param mariadb.auth.rootPassword MariaDB root password
+      ## @param mariadb.auth.database MariaDB custom database
+      ## @param mariadb.auth.username MariaDB custom user name
+      ## @param mariadb.auth.password MariaDB custom user password
+      ## ref: https://github.com/bitnami/containers/tree/main/bitnami/mariadb#setting-the-root-password-on-first-run
+      ##      https://github.com/bitnami/containers/blob/main/bitnami/mariadb/README.md#creating-a-database-on-first-run
+      ##      https://github.com/bitnami/containers/blob/main/bitnami/mariadb/README.md#creating-a-database-user-on-first-run
+      ##
+      auth:
+        rootPassword: welcome123
+        # rootPassword: {{ .Values.wordpressPassword }}
+        database: wordpress
+        username: admin
+        # username: {{ .spectro.pack.wordpress-chart.charts.wordpress.wordpressUsername }}
+        password: welcome123
+        # password: {{ .spectro.pack.wordpress-chart.charts.wordpress.wordpressPassword }}
+
+        ## MariaDB Primary configuration
+        ##
+      primary:
+        ## MariaDB Primary Persistence parameters
+        ## ref: https://kubernetes.io/docs/concepts/storage/persistent-volumes/
+        ## @param mariadb.primary.persistence.enabled Enable persistence on MariaDB using PVC(s)
+        ## @param mariadb.primary.persistence.storageClass Persistent Volume storage class
+        ## @param mariadb.primary.persistence.accessModes [array] Persistent Volume access modes
+        ## @param mariadb.primary.persistence.size Persistent Volume size
+        ##
+        persistence:
+          enabled: true
+          storageClass: ""
+          accessModes:
+            - ReadWriteOnce
+          size: 8Gi
+    ## External Database Configuration
+    ## All of these values are only used if `mariadb.enabled=false`
+    ##
+    externalDatabase:
+      ## @param externalDatabase.host External Database server host
+      ##
+      host: localhost
+      ## @param externalDatabase.port External Database server port
+      ##
+      port: 3306
+      ## @param externalDatabase.user External Database username
+      ##
+      user: bn_wordpress
+      ## @param externalDatabase.password External Database user password
+      ##
+      password: ""
+      ## @param externalDatabase.database External Database database name
+      ##
+      database: bitnami_wordpress
+      ## @param externalDatabase.existingSecret The name of an existing secret with database credentials. Evaluated as a template
+      ## NOTE: Must contain key `mariadb-password`
+      ## NOTE: When it's set, the `externalDatabase.password` parameter is ignored
+      ##
+      existingSecret: ""
+    ## Memcached chart configuration
+    ## ref: https://github.com/bitnami/charts/blob/main/bitnami/memcached/values.yaml
+    ##
+    memcached:
+      ## @param memcached.enabled Deploy a Memcached server for caching database queries
+      ##
+      enabled: false
+      ## Authentication parameters
+      ## ref: https://github.com/bitnami/containers/tree/main/bitnami/memcached#creating-the-memcached-admin-user
+      ##
+      auth:
+        ## @param memcached.auth.enabled Enable Memcached authentication
+        ##
+        enabled: false
+        ## @param memcached.auth.username Memcached admin user
+        ##
+        username: ""
+        ## @param memcached.auth.password Memcached admin password
+        ##
+        password: ""
+        ## @param memcached.auth.existingPasswordSecret Existing secret with Memcached credentials (must contain a value for `memcached-password` key)
+        ##
+        existingPasswordSecret: ""
+      ## Service parameters
+      ##
+      service:
+        ## @param memcached.service.port Memcached service port
+        ##
+        port: 11211
+    ## External Memcached Configuration
+    ## All of these values are only used if `memcached.enabled=false`
+    ##
+    externalCache:
+      ## @param externalCache.host External cache server host
+      ##
+      host: localhost
+      ## @param externalCache.port External cache server port
+      ##
+      port: 11211

--- a/examples/tutorials/profile-variables/manifests/wordpress-variables.yaml
+++ b/examples/tutorials/profile-variables/manifests/wordpress-variables.yaml
@@ -1,0 +1,1198 @@
+# Copyright (c) Spectro Cloud
+# SPDX-License-Identifier: Apache-2.0
+
+pack:
+  #The namespace (on the target cluster) to install this chart
+  #When not found, a new namespace will be created
+  content:
+    images:
+      - image: docker.io/bitnami/mariadb:11.2.3-debian-12-r4
+      - image: docker.io/bitnami/memcached:1.6.24-debian-12-r0
+      - image: docker.io/bitnami/wordpress:6.4.3-debian-12-r16
+    charts:
+      - repo: https://charts.bitnami.com/wordpress
+        name: wordpress
+        version: 19.4.3
+  namespace: '{{ .spectro.var.wordpress_namespace }}'
+  spectrocloud.com/install-priority: 0
+
+charts:
+  wordpress:
+
+    image:
+      registry: docker.io
+      repository: bitnami/wordpress
+      tag: 6.4.3-debian-12-r16
+      digest: ""
+      ## Specify a imagePullPolicy
+      ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
+      ## ref: https://kubernetes.io/docs/concepts/containers/images/#pre-pulled-images
+      ##
+      pullPolicy: IfNotPresent
+      ## Optionally specify an array of imagePullSecrets.
+      ## Secrets must be manually created in the namespace.
+      ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+      ## e.g:
+      ## pullSecrets:
+      ##   - myRegistryKeySecretName
+      ##
+      pullSecrets: []
+      ## Enable debug mode
+      ##
+      debug: false
+    ## @section WordPress Configuration parameters
+    ## WordPress settings based on environment variables
+    ## ref: https://github.com/bitnami/containers/tree/main/bitnami/wordpress#environment-variables
+    ##
+
+    ## @param wordpressUsername WordPress username
+    ##
+    wordpressUsername: admin
+    ## @param wordpressPassword WordPress user password
+    ## Defaults to a random 10-character alphanumeric string if not set
+    ##
+    wordpressPassword: welcome123
+    ## @param existingSecret Name of existing secret containing WordPress credentials
+    ## NOTE: Must contain key `wordpress-password`
+    ## NOTE: When it's set, the `wordpressPassword` parameter is ignored
+    ##
+    existingSecret: ""
+    ## @param wordpressEmail WordPress user email
+    ##
+    wordpressEmail: admin@spectrocloud.com
+    ## @param wordpressFirstName WordPress user first name
+    ##
+    wordpressFirstName: Administrator
+    ## @param wordpressLastName WordPress user last name
+    ##
+    wordpressLastName: Spectro
+    ## @param wordpressBlogName Blog name
+    ##
+    wordpressBlogName: Hello World !
+    ## @param wordpressTablePrefix Prefix to use for WordPress database tables
+    ##
+    wordpressTablePrefix: wp_
+    ## @param wordpressScheme Scheme to use to generate WordPress URLs
+    ##
+    wordpressScheme: http
+    ## @param wordpressSkipInstall Skip wizard installation
+    ## NOTE: useful if you use an external database that already contains WordPress data
+    ## ref: https://github.com/bitnami/containers/tree/main/bitnami/wordpress#connect-wordpress-docker-container-to-an-existing-database
+    ##
+    wordpressSkipInstall: false
+    ## @param wordpressExtraConfigContent Add extra content to the default wp-config.php file
+    ## e.g:
+    ## wordpressExtraConfigContent: |
+    ##   @ini_set( 'post_max_size', '128M');
+    ##   @ini_set( 'memory_limit', '256M' );
+    ##
+    wordpressExtraConfigContent: ""
+    ## @param wordpressConfiguration The content for your custom wp-config.php file (advanced feature)
+    ## NOTE: This will override configuring WordPress based on environment variables (including those set by the chart)
+    ## NOTE: Currently only supported when `wordpressSkipInstall=true`
+    ##
+    wordpressConfiguration: ""
+    ## @param existingWordPressConfigurationSecret The name of an existing secret with your custom wp-config.php file (advanced feature)
+    ## NOTE: When it's set the `wordpressConfiguration` parameter is ignored
+    ##
+    existingWordPressConfigurationSecret: ""
+    ## @param wordpressConfigureCache Enable W3 Total Cache plugin and configure cache settings
+    ## NOTE: useful if you deploy Memcached for caching database queries or you use an external cache server
+    ##
+    wordpressConfigureCache: false
+    ## @param wordpressPlugins Array of plugins to install and activate. Can be specified as `all` or `none`.
+    ## NOTE: If set to all, only plugins that are already installed will be activated, and if set to none, no plugins will be activated
+    ##
+    wordpressPlugins: none
+    ## @param apacheConfiguration The content for your custom httpd.conf file (advanced feature)
+    ##
+    apacheConfiguration: ""
+    ## @param existingApacheConfigurationConfigMap The name of an existing secret with your custom httpd.conf file (advanced feature)
+    ## NOTE: When it's set the `apacheConfiguration` parameter is ignored
+    ##
+    existingApacheConfigurationConfigMap: ""
+    ## @param customPostInitScripts Custom post-init.d user scripts
+    ## ref: https://github.com/bitnami/containers/tree/main/bitnami/wordpress
+    ## NOTE: supported formats are `.sh`, `.sql` or `.php`
+    ## NOTE: scripts are exclusively executed during the 1st boot of the container
+    ## e.g:
+    ## customPostInitScripts:
+    ##   enable-multisite.sh: |
+    ##     #!/bin/bash
+    ##     chmod +w /bitnami/wordpress/wp-config.php
+    ##     wp core multisite-install --url=example.com --title="Welcome to the WordPress Multisite" --admin_user="doesntmatternotreallyused" --admin_password="doesntmatternotreallyused" --admin_email="user@example.com"
+    ##     cat /docker-entrypoint-init.d/.htaccess > /bitnami/wordpress/.htaccess
+    ##     chmod -w bitnami/wordpress/wp-config.php
+    ##   .htaccess: |
+    ##     RewriteEngine On
+    ##     RewriteBase /
+    ##     ...
+    ##
+    customPostInitScripts: {}
+    ## SMTP mail delivery configuration
+    ## ref: https://github.com/bitnami/containers/tree/main/bitnami/wordpress/#smtp-configuration
+    ## @param smtpHost SMTP server host
+    ## @param smtpPort SMTP server port
+    ## @param smtpUser SMTP username
+    ## @param smtpPassword SMTP user password
+    ## @param smtpProtocol SMTP protocol
+    ##
+    smtpHost: ""
+    smtpPort: ""
+    smtpUser: ""
+    smtpPassword: ""
+    smtpProtocol: ""
+    ## @param smtpExistingSecret The name of an existing secret with SMTP credentials
+    ## NOTE: Must contain key `smtp-password`
+    ## NOTE: When it's set, the `smtpPassword` parameter is ignored
+    ##
+    smtpExistingSecret: ""
+    ## @param allowEmptyPassword Allow the container to be started with blank passwords
+    ##
+    allowEmptyPassword: true
+    ## @param allowOverrideNone Configure Apache to prohibit overriding directives with htaccess files
+    ##
+    allowOverrideNone: false
+    ## @param overrideDatabaseSettings Allow overriding the database settings persisted in wp-config.php
+    ##
+    overrideDatabaseSettings: false
+    ## @param htaccessPersistenceEnabled Persist custom changes on htaccess files
+    ## If `allowOverrideNone` is `false`, it will persist `/opt/bitnami/wordpress/wordpress-htaccess.conf`
+    ## If `allowOverrideNone` is `true`, it will persist `/opt/bitnami/wordpress/.htaccess`
+    ##
+    htaccessPersistenceEnabled: false
+    ## @param customHTAccessCM The name of an existing ConfigMap with custom htaccess rules
+    ## NOTE: Must contain key `wordpress-htaccess.conf` with the file content
+    ## NOTE: Requires setting `allowOverrideNone=false`
+    ##
+    customHTAccessCM: ""
+    ## @param command Override default container command (useful when using custom images)
+    ##
+    command: []
+    ## @param args Override default container args (useful when using custom images)
+    ##
+    args: []
+    ## @param extraEnvVars Array with extra environment variables to add to the WordPress container
+    ## e.g:
+    ## extraEnvVars:
+    ##   - name: FOO
+    ##     value: "bar"
+    ##
+    extraEnvVars: []
+    ## @param extraEnvVarsCM Name of existing ConfigMap containing extra env vars
+    ##
+    extraEnvVarsCM: ""
+    ## @param extraEnvVarsSecret Name of existing Secret containing extra env vars
+    ##
+    extraEnvVarsSecret: ""
+    ## @section WordPress Multisite Configuration parameters
+    ## ref: https://github.com/bitnami/containers/tree/main/bitnami/wordpress#multisite-configuration
+    ##
+
+    ## @param multisite.enable Whether to enable WordPress Multisite configuration.
+    ## @param multisite.host WordPress Multisite hostname/address. This value is mandatory when enabling Multisite mode.
+    ## @param multisite.networkType WordPress Multisite network type to enable. Allowed values: `subfolder`, `subdirectory` or `subdomain`.
+    ## @param multisite.enableNipIoRedirect Whether to enable IP address redirection to nip.io wildcard DNS. Useful when running on an IP address with subdomain network type.
+    ##
+    multisite:
+      enable: false
+      host: ""
+      networkType: subdomain
+      enableNipIoRedirect: false
+    ## @section WordPress deployment parameters
+    ##
+
+    ## @param replicaCount Number of WordPress replicas to deploy
+    ## NOTE: ReadWriteMany PVC(s) are required if replicaCount > 1
+    ##
+    replicaCount: '{{ .spectro.var.wordpress_replica }}'
+    ## @param updateStrategy.type WordPress deployment strategy type
+    ## ref: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy
+    ## NOTE: Set it to `Recreate` if you use a PV that cannot be mounted on multiple pods
+    ## e.g:
+    ## updateStrategy:
+    ##  type: RollingUpdate
+    ##  rollingUpdate:
+    ##    maxSurge: 25%
+    ##    maxUnavailable: 25%
+    ##
+    updateStrategy:
+      type: RollingUpdate
+    ## @param schedulerName Alternate scheduler
+    ## ref: https://kubernetes.io/docs/tasks/administer-cluster/configure-multiple-schedulers/
+    ##
+    schedulerName: ""
+    ## @param terminationGracePeriodSeconds In seconds, time given to the WordPress pod to terminate gracefully
+    ## ref: https://kubernetes.io/docs/concepts/workloads/pods/pod/#termination-of-pods
+    ##
+    terminationGracePeriodSeconds: ""
+    ## @param topologySpreadConstraints Topology Spread Constraints for pod assignment spread across your cluster among failure-domains. Evaluated as a template
+    ## Ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/#spread-constraints-for-pods
+    ##
+    topologySpreadConstraints: []
+    ## @param priorityClassName Name of the existing priority class to be used by WordPress pods, priority class needs to be created beforehand
+    ## Ref: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/
+    ##
+    priorityClassName: ""
+    ## @param automountServiceAccountToken Mount Service Account token in pod
+    ##
+    automountServiceAccountToken: false
+    ## @param hostAliases [array] WordPress pod host aliases
+    ## https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/
+    ##
+    hostAliases:
+      ## Required for Apache exporter to work
+      ##
+      - ip: "127.0.0.1"
+        hostnames:
+          - "status.localhost"
+    ## @param extraVolumes Optionally specify extra list of additional volumes for WordPress pods
+    ##
+    extraVolumes: []
+    ## @param extraVolumeMounts Optionally specify extra list of additional volumeMounts for WordPress container(s)
+    ##
+    extraVolumeMounts: []
+    ## @param sidecars Add additional sidecar containers to the WordPress pod
+    ## e.g:
+    ## sidecars:
+    ##   - name: your-image-name
+    ##     image: your-image
+    ##     imagePullPolicy: Always
+    ##     ports:
+    ##       - name: portname
+    ##         containerPort: 1234
+    ##
+    sidecars: []
+    ## @param initContainers Add additional init containers to the WordPress pods
+    ## ref: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/
+    ## e.g:
+    ## initContainers:
+    ##  - name: your-image-name
+    ##    image: your-image
+    ##    imagePullPolicy: Always
+    ##    command: ['sh', '-c', 'copy themes and plugins from git and push to /bitnami/wordpress/wp-content. Should work with extraVolumeMounts and extraVolumes']
+    ##
+    initContainers: []
+    ## @param podLabels Extra labels for WordPress pods
+    ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
+    ##
+    podLabels: {}
+    ## @param podAnnotations Annotations for WordPress pods
+    ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
+    ##
+    podAnnotations: {}
+    ## @param podAffinityPreset Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`
+    ## ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity
+    ##
+    podAffinityPreset: ""
+    ## @param podAntiAffinityPreset Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`
+    ## Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity
+    ##
+    podAntiAffinityPreset: soft
+    ## Node affinity preset
+    ## Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#node-affinity
+    ##
+    nodeAffinityPreset:
+      ## @param nodeAffinityPreset.type Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`
+      ##
+      type: ""
+      ## @param nodeAffinityPreset.key Node label key to match. Ignored if `affinity` is set
+      ##
+      key: ""
+      ## @param nodeAffinityPreset.values Node label values to match. Ignored if `affinity` is set
+      ## E.g.
+      ## values:
+      ##   - e2e-az1
+      ##   - e2e-az2
+      ##
+      values: []
+    ## @param affinity Affinity for pod assignment
+    ## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+    ## NOTE: podAffinityPreset, podAntiAffinityPreset, and nodeAffinityPreset will be ignored when it's set
+    ##
+    affinity: {}
+    ## @param nodeSelector Node labels for pod assignment
+    ## ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/
+    ##
+    nodeSelector: {}
+    ## @param tolerations Tolerations for pod assignment
+    ## ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+    ##
+    tolerations: []
+    ## WordPress containers' resource requests and limits
+    ## ref: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/
+    ## @param resourcesPreset Set container resources according to one common preset (allowed values: none, nano, small, medium, large, xlarge, 2xlarge). This is ignored if resources is set (resources is recommended for production).
+    ## More information: https://github.com/bitnami/charts/blob/main/bitnami/common/templates/_resources.tpl#L15
+    ##
+    resourcesPreset: "none"
+    ## @param resources Set container requests and limits for different resources like CPU or memory (essential for production workloads)
+    ## Example:
+    ## resources:
+    ##   requests:
+    ##     cpu: 2
+    ##     memory: 512Mi
+    ##   limits:
+    ##     cpu: 3
+    ##     memory: 1024Mi
+    ##
+    resources: {}
+    ## Container ports
+    ## @param containerPorts.http WordPress HTTP container port
+    ## @param containerPorts.https WordPress HTTPS container port
+    ##
+    containerPorts:
+      http: 8080
+      https: 8443
+    ## @param extraContainerPorts Optionally specify extra list of additional ports for WordPress container(s)
+    ## e.g:
+    ## extraContainerPorts:
+    ##   - name: myservice
+    ##     containerPort: 9090
+    ##
+    extraContainerPorts: []
+    ## Configure Pods Security Context
+    ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
+    ## @param podSecurityContext.enabled Enabled WordPress pods' Security Context
+    ## @param podSecurityContext.fsGroupChangePolicy Set filesystem group change policy
+    ## @param podSecurityContext.sysctls Set kernel settings using the sysctl interface
+    ## @param podSecurityContext.supplementalGroups Set filesystem extra groups
+    ## @param podSecurityContext.fsGroup Set WordPress pod's Security Context fsGroup
+    ##
+    podSecurityContext:
+      enabled: true
+      fsGroupChangePolicy: Always
+      sysctls: []
+      supplementalGroups: []
+      fsGroup: 1001
+    ## Configure Container Security Context (only main container)
+    ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container
+    ## @param containerSecurityContext.enabled Enabled containers' Security Context
+    ## @param containerSecurityContext.seLinuxOptions [object,nullable] Set SELinux options in container
+    ## @param containerSecurityContext.runAsUser Set containers' Security Context runAsUser
+    ## @param containerSecurityContext.runAsNonRoot Set container's Security Context runAsNonRoot
+    ## @param containerSecurityContext.privileged Set container's Security Context privileged
+    ## @param containerSecurityContext.readOnlyRootFilesystem Set container's Security Context readOnlyRootFilesystem
+    ## @param containerSecurityContext.allowPrivilegeEscalation Set container's Security Context allowPrivilegeEscalation
+    ## @param containerSecurityContext.capabilities.drop List of capabilities to be dropped
+    ## @param containerSecurityContext.seccompProfile.type Set container's Security Context seccomp profile
+    ##
+    containerSecurityContext:
+      enabled: true
+      seLinuxOptions: null
+      runAsUser: 1001
+      runAsNonRoot: true
+      privileged: false
+      readOnlyRootFilesystem: false
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop: [ "ALL" ]
+      seccompProfile:
+        type: "RuntimeDefault"
+    ## Configure extra options for WordPress containers' liveness, readiness and startup probes
+    ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#configure-probes
+    ## @param livenessProbe.enabled Enable livenessProbe on WordPress containers
+    ## @skip livenessProbe.httpGet
+    ## @param livenessProbe.initialDelaySeconds Initial delay seconds for livenessProbe
+    ## @param livenessProbe.periodSeconds Period seconds for livenessProbe
+    ## @param livenessProbe.timeoutSeconds Timeout seconds for livenessProbe
+    ## @param livenessProbe.failureThreshold Failure threshold for livenessProbe
+    ## @param livenessProbe.successThreshold Success threshold for livenessProbe
+    ##
+    livenessProbe:
+      enabled: true
+      httpGet:
+        path: /wp-admin/install.php
+        port: '{{ .Values.wordpressScheme }}'
+        scheme: '{{ .Values.wordpressScheme | upper }}'
+        ## If using an HTTPS-terminating load-balancer, the probes may need to behave
+        ## like the balancer to prevent HTTP 302 responses. According to the Kubernetes
+        ## docs, 302 should be considered "successful", but this issue on GitHub
+        ## (https://github.com/kubernetes/kubernetes/issues/47893) shows that it isn't.
+        ## E.g.
+        ## httpHeaders:
+        ## - name: X-Forwarded-Proto
+        ##   value: https
+        ##
+        httpHeaders: []
+      initialDelaySeconds: 120
+      periodSeconds: 10
+      timeoutSeconds: 5
+      failureThreshold: 6
+      successThreshold: 1
+    ## @param readinessProbe.enabled Enable readinessProbe on WordPress containers
+    ## @skip readinessProbe.httpGet
+    ## @param readinessProbe.initialDelaySeconds Initial delay seconds for readinessProbe
+    ## @param readinessProbe.periodSeconds Period seconds for readinessProbe
+    ## @param readinessProbe.timeoutSeconds Timeout seconds for readinessProbe
+    ## @param readinessProbe.failureThreshold Failure threshold for readinessProbe
+    ## @param readinessProbe.successThreshold Success threshold for readinessProbe
+    ##
+    readinessProbe:
+      enabled: true
+      httpGet:
+        path: /wp-login.php
+        port: '{{ .Values.wordpressScheme }}'
+        scheme: '{{ .Values.wordpressScheme | upper }}'
+        ## If using an HTTPS-terminating load-balancer, the probes may need to behave
+        ## like the balancer to prevent HTTP 302 responses. According to the Kubernetes
+        ## docs, 302 should be considered "successful", but this issue on GitHub
+        ## (https://github.com/kubernetes/kubernetes/issues/47893) shows that it isn't.
+        ## E.g.
+        ## httpHeaders:
+        ## - name: X-Forwarded-Proto
+        ##   value: https
+        ##
+        httpHeaders: []
+      initialDelaySeconds: 30
+      periodSeconds: 10
+      timeoutSeconds: 5
+      failureThreshold: 6
+      successThreshold: 1
+    ## @param startupProbe.enabled Enable startupProbe on WordPress containers
+    ## @skip startupProbe.httpGet
+    ## @param startupProbe.initialDelaySeconds Initial delay seconds for startupProbe
+    ## @param startupProbe.periodSeconds Period seconds for startupProbe
+    ## @param startupProbe.timeoutSeconds Timeout seconds for startupProbe
+    ## @param startupProbe.failureThreshold Failure threshold for startupProbe
+    ## @param startupProbe.successThreshold Success threshold for startupProbe
+    ##
+    startupProbe:
+      enabled: false
+      httpGet:
+        path: /wp-login.php
+        port: '{{ .Values.wordpressScheme }}'
+        scheme: '{{ .Values.wordpressScheme | upper }}'
+        ## If using an HTTPS-terminating load-balancer, the probes may need to behave
+        ## like the balancer to prevent HTTP 302 responses. According to the Kubernetes
+        ## docs, 302 should be considered "successful", but this issue on GitHub
+        ## (https://github.com/kubernetes/kubernetes/issues/47893) shows that it isn't.
+        ## E.g.
+        ## httpHeaders:
+        ## - name: X-Forwarded-Proto
+        ##   value: https
+        ##
+        httpHeaders: []
+      initialDelaySeconds: 30
+      periodSeconds: 10
+      timeoutSeconds: 5
+      failureThreshold: 6
+      successThreshold: 1
+    ## @param customLivenessProbe Custom livenessProbe that overrides the default one
+    ##
+    customLivenessProbe: {}
+    ## @param customReadinessProbe Custom readinessProbe that overrides the default one
+    ##
+    customReadinessProbe: {}
+    ## @param customStartupProbe Custom startupProbe that overrides the default one
+    ##
+    customStartupProbe: {}
+    ## @param lifecycleHooks for the WordPress container(s) to automate configuration before or after startup
+    ##
+    lifecycleHooks: {}
+    ## @section Traffic Exposure Parameters
+    ##
+
+    ## WordPress service parameters
+    ##
+    service:
+      ## @param service.type WordPress service type
+      ##
+      type: LoadBalancer
+      ## @param service.ports.http WordPress service HTTP port
+      ## @param service.ports.https WordPress service HTTPS port
+      ##
+      ports:
+        http: '{{ .spectro.var.wordpress_port }}'
+        https: 443
+      ## @param service.httpsTargetPort Target port for HTTPS
+      ##
+      httpsTargetPort: https
+      ## Node ports to expose
+      ## @param service.nodePorts.http Node port for HTTP
+      ## @param service.nodePorts.https Node port for HTTPS
+      ## NOTE: choose port between <30000-32767>
+      ##
+      nodePorts:
+        http: ""
+        https: ""
+      ## @param service.sessionAffinity Control where client requests go, to the same pod or round-robin
+      ## Values: ClientIP or None
+      ## ref: https://kubernetes.io/docs/concepts/services-networking/service/
+      ##
+      sessionAffinity: None
+      ## @param service.sessionAffinityConfig Additional settings for the sessionAffinity
+      ## sessionAffinityConfig:
+      ##   clientIP:
+      ##     timeoutSeconds: 300
+      ##
+      sessionAffinityConfig: {}
+      ## @param service.clusterIP WordPress service Cluster IP
+      ## e.g.:
+      ## clusterIP: None
+      ##
+      clusterIP: ""
+      ## @param service.loadBalancerIP WordPress service Load Balancer IP
+      ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#type-loadbalancer
+      ##
+      loadBalancerIP: ""
+      ## @param service.loadBalancerSourceRanges WordPress service Load Balancer sources
+      ## ref: https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/#restrict-access-for-loadbalancer-service
+      ## e.g:
+      ## loadBalancerSourceRanges:
+      ##   - 10.10.10.0/24
+      ##
+      loadBalancerSourceRanges: []
+      ## @param service.externalTrafficPolicy WordPress service external traffic policy
+      ## ref https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#preserving-the-client-source-ip
+      ##
+      externalTrafficPolicy: Cluster
+      ## @param service.annotations Additional custom annotations for WordPress service
+      ##
+      annotations: {}
+      ## @param service.extraPorts Extra port to expose on WordPress service
+      ##
+      extraPorts: []
+    ## Configure the ingress resource that allows you to access the WordPress installation
+    ## ref: https://kubernetes.io/docs/concepts/services-networking/ingress/
+    ##
+    ingress:
+      ## @param ingress.enabled Enable ingress record generation for WordPress
+      ##
+      enabled: false
+      ## @param ingress.pathType Ingress path type
+      ##
+      pathType: ImplementationSpecific
+      ## @param ingress.apiVersion Force Ingress API version (automatically detected if not set)
+      ##
+      apiVersion: ""
+      ## @param ingress.ingressClassName IngressClass that will be be used to implement the Ingress (Kubernetes 1.18+)
+      ## This is supported in Kubernetes 1.18+ and required if you have more than one IngressClass marked as the default for your cluster .
+      ## ref: https://kubernetes.io/blog/2020/04/02/improvements-to-the-ingress-api-in-kubernetes-1.18/
+      ##
+      ingressClassName: ""
+      ## @param ingress.hostname Default host for the ingress record. The hostname is templated and thus can contain other variable references.
+      ##
+      hostname: wordpress.local
+      ## @param ingress.path Default path for the ingress record
+      ## NOTE: You may need to set this to '/*' in order to use this with ALB ingress controllers
+      ##
+      path: /
+      ## @param ingress.annotations Additional annotations for the Ingress resource. To enable certificate autogeneration, place here your cert-manager annotations.
+      ## For a full list of possible ingress annotations, please see
+      ## ref: https://github.com/kubernetes/ingress-nginx/blob/main/docs/user-guide/nginx-configuration/annotations.md
+      ## Use this parameter to set the required annotations for cert-manager, see
+      ## ref: https://cert-manager.io/docs/usage/ingress/#supported-annotations
+      ##
+      ## e.g:
+      ## annotations:
+      ##   kubernetes.io/ingress.class: nginx
+      ##   cert-manager.io/cluster-issuer: cluster-issuer-name
+      ##
+      annotations: {}
+      ## @param ingress.tls Enable TLS configuration for the host defined at `ingress.hostname` parameter
+      ## TLS certificates will be retrieved from a TLS secret with name: `{{- printf "%s-tls" .Values.ingress.hostname }}`
+      ## You can:
+      ##   - Use the `ingress.secrets` parameter to create this TLS secret
+      ##   - Rely on cert-manager to create it by setting the corresponding annotations
+      ##   - Rely on Helm to create self-signed certificates by setting `ingress.selfSigned=true`
+      ##
+      tls: false
+      ## @param ingress.tlsWwwPrefix Adds www subdomain to default cert
+      ## Creates tls host with ingress.hostname: {{ print "www.%s" .Values.ingress.hostname }}
+      ## Is enabled if "nginx.ingress.kubernetes.io/from-to-www-redirect" is "true"
+      tlsWwwPrefix: false
+      ## @param ingress.selfSigned Create a TLS secret for this ingress record using self-signed certificates generated by Helm
+      ##
+      selfSigned: false
+      ## @param ingress.extraHosts An array with additional hostname(s) to be covered with the ingress record. The host names are templated and thus can contain other variable references.
+      ## e.g:
+      ## extraHosts:
+      ##   - name: wordpress.local
+      ##     path: /
+      ##
+      extraHosts: []
+      ## @param ingress.extraPaths An array with additional arbitrary paths that may need to be added to the ingress under the main host
+      ## e.g:
+      ## extraPaths:
+      ## - path: /*
+      ##   backend:
+      ##     serviceName: ssl-redirect
+      ##     servicePort: use-annotation
+      ##
+      extraPaths: []
+      ## @param ingress.extraTls TLS configuration for additional hostname(s) to be covered with this ingress record
+      ## ref: https://kubernetes.io/docs/concepts/services-networking/ingress/#tls
+      ## e.g:
+      ## extraTls:
+      ## - hosts:
+      ##     - wordpress.local
+      ##   secretName: wordpress.local-tls
+      ##
+      extraTls: []
+      ## @param ingress.secrets Custom TLS certificates as secrets
+      ## NOTE: 'key' and 'certificate' are expected in PEM format
+      ## NOTE: 'name' should line up with a 'secretName' set further up
+      ## If it is not set and you're using cert-manager, this is unneeded, as it will create a secret for you with valid certificates
+      ## If it is not set and you're NOT using cert-manager either, self-signed certificates will be created valid for 365 days
+      ## It is also possible to create and manage the certificates outside of this helm chart
+      ## Please see README.md for more information
+      ## e.g:
+      ## secrets:
+      ##   - name: wordpress.local-tls
+      ##     key: |-
+      ##       -----BEGIN RSA PRIVATE KEY-----
+      ##       ...
+      ##       -----END RSA PRIVATE KEY-----
+      ##     certificate: |-
+      ##       -----BEGIN CERTIFICATE-----
+      ##       ...
+      ##       -----END CERTIFICATE-----
+      ##
+      secrets: []
+      ## @param ingress.extraRules Additional rules to be covered with this ingress record
+      ## ref: https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-rules
+      ## e.g:
+      ## extraRules:
+      ## - host: wordpress.local
+      ##     http:
+      ##       path: /
+      ##       backend:
+      ##         service:
+      ##           name: wordpress-svc
+      ##           port:
+      ##             name: http
+      ##
+      extraRules: []
+    ## @section Persistence Parameters
+    ##
+
+    ## Persistence Parameters
+    ## ref: https://kubernetes.io/docs/concepts/storage/persistent-volumes/
+    ##
+    persistence:
+      ## @param persistence.enabled Enable persistence using Persistent Volume Claims
+      ##
+      enabled: true
+      ## @param persistence.storageClass Persistent Volume storage class
+      ## If defined, storageClassName: <storageClass>
+      ## If set to "-", storageClassName: "", which disables dynamic provisioning
+      ## If undefined (the default) or set to null, no storageClassName spec is set, choosing the default provisioner
+      ##
+      storageClass: ""
+      ## @param persistence.accessModes [array] Persistent Volume access modes
+      ##
+      accessModes:
+        - ReadWriteOnce
+      ## @param persistence.accessMode Persistent Volume access mode (DEPRECATED: use `persistence.accessModes` instead)
+      ##
+      accessMode: ReadWriteOnce
+      ## @param persistence.size Persistent Volume size
+      ##
+      size: 10Gi
+      ## @param persistence.dataSource Custom PVC data source
+      ##
+      dataSource: {}
+      ## @param persistence.existingClaim The name of an existing PVC to use for persistence
+      ##
+      existingClaim: ""
+      ## @param persistence.selector Selector to match an existing Persistent Volume for WordPress data PVC
+      ## If set, the PVC can't have a PV dynamically provisioned for it
+      ## E.g.
+      ## selector:
+      ##   matchLabels:
+      ##     app: my-app
+      ##
+      selector: {}
+      ## @param persistence.annotations Persistent Volume Claim annotations
+      ##
+      annotations: {}
+    ## Init containers parameters:
+    ## volumePermissions: Change the owner and group of the persistent volume(s) mountpoint(s) to 'runAsUser:fsGroup' on each node
+    ##
+    volumePermissions:
+      ## @param volumePermissions.enabled Enable init container that changes the owner/group of the PV mount point to `runAsUser:fsGroup`
+      ##
+      enabled: false
+      ## OS Shell + Utility image
+      ## ref: https://hub.docker.com/r/bitnami/os-shell/tags/
+      ## @param volumePermissions.image.registry [default: REGISTRY_NAME] OS Shell + Utility image registry
+      ## @param volumePermissions.image.repository [default: REPOSITORY_NAME/os-shell] OS Shell + Utility image repository
+      ## @skip volumePermissions.image.tag OS Shell + Utility image tag (immutable tags are recommended)
+      ## @param volumePermissions.image.digest OS Shell + Utility image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
+      ## @param volumePermissions.image.pullPolicy OS Shell + Utility image pull policy
+      ## @param volumePermissions.image.pullSecrets OS Shell + Utility image pull secrets
+      ##
+      image:
+        registry: docker.io
+        repository: bitnami/os-shell
+        tag: 12-debian-12-r16
+        digest: ""
+        pullPolicy: IfNotPresent
+        ## Optionally specify an array of imagePullSecrets.
+        ## Secrets must be manually created in the namespace.
+        ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+        ## e.g:
+        ## pullSecrets:
+        ##   - myRegistryKeySecretName
+        ##
+        pullSecrets: []
+      ## Init container's resource requests and limits
+      ## ref: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/
+      ## @param volumePermissions.resourcesPreset Set container resources according to one common preset (allowed values: none, nano, small, medium, large, xlarge, 2xlarge). This is ignored if volumePermissions.resources is set (volumePermissions.resources is recommended for production).
+      ## More information: https://github.com/bitnami/charts/blob/main/bitnami/common/templates/_resources.tpl#L15
+      ##
+      resourcesPreset: "none"
+      ## @param volumePermissions.resources Set container requests and limits for different resources like CPU or memory (essential for production workloads)
+      ## Example:
+      ## resources:
+      ##   requests:
+      ##     cpu: 2
+      ##     memory: 512Mi
+      ##   limits:
+      ##     cpu: 3
+      ##     memory: 1024Mi
+      ##
+      resources: {}
+      ## Init container' Security Context
+      ## Note: the chown of the data folder is done to containerSecurityContext.runAsUser
+      ## and not the below volumePermissions.containerSecurityContext.runAsUser
+      ## @param volumePermissions.containerSecurityContext.seLinuxOptions [object,nullable] Set SELinux options in container
+      ## @param volumePermissions.containerSecurityContext.runAsUser User ID for the init container
+      ##
+      containerSecurityContext:
+        seLinuxOptions: null
+        runAsUser: 0
+    ## @section Other Parameters
+    ##
+
+    ## WordPress Service Account
+    ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
+    ##
+    serviceAccount:
+      ## @param serviceAccount.create Enable creation of ServiceAccount for WordPress pod
+      ##
+      create: true
+      ## @param serviceAccount.name The name of the ServiceAccount to use.
+      ## If not set and create is true, a name is generated using the common.names.fullname template
+      ##
+      name: ""
+      ## @param serviceAccount.automountServiceAccountToken Allows auto mount of ServiceAccountToken on the serviceAccount created
+      ## Can be set to false if pods using this serviceAccount do not need to use K8s API
+      ##
+      automountServiceAccountToken: false
+      ## @param serviceAccount.annotations Additional custom annotations for the ServiceAccount
+      ##
+      annotations: {}
+    ## WordPress Pod Disruption Budget configuration
+    ## ref: https://kubernetes.io/docs/tasks/run-application/configure-pdb/
+    ## @param pdb.create Enable a Pod Disruption Budget creation
+    ## @param pdb.minAvailable Minimum number/percentage of pods that should remain scheduled
+    ## @param pdb.maxUnavailable Maximum number/percentage of pods that may be made unavailable
+    ##
+    pdb:
+      create: false
+      minAvailable: 1
+      maxUnavailable: ""
+    ## WordPress Autoscaling configuration
+    ## ref: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/
+    ## @param autoscaling.enabled Enable Horizontal POD autoscaling for WordPress
+    ## @param autoscaling.minReplicas Minimum number of WordPress replicas
+    ## @param autoscaling.maxReplicas Maximum number of WordPress replicas
+    ## @param autoscaling.targetCPU Target CPU utilization percentage
+    ## @param autoscaling.targetMemory Target Memory utilization percentage
+    ##
+    autoscaling:
+      enabled: false
+      minReplicas: 1
+      maxReplicas: 11
+      targetCPU: 50
+      targetMemory: 50
+    ## @section Metrics Parameters
+    ##
+
+    ## Prometheus Exporter / Metrics configuration
+    ##
+    metrics:
+      ## @param metrics.enabled Start a sidecar prometheus exporter to expose metrics
+      ##
+      enabled: false
+      ## Bitnami Apache exporter image
+      ## ref: https://hub.docker.com/r/bitnami/apache-exporter/tags/
+      ## @param metrics.image.registry [default: REGISTRY_NAME] Apache exporter image registry
+      ## @param metrics.image.repository [default: REPOSITORY_NAME/apache-exporter] Apache exporter image repository
+      ## @skip metrics.image.tag Apache exporter image tag (immutable tags are recommended)
+      ## @param metrics.image.digest Apache exporter image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
+      ## @param metrics.image.pullPolicy Apache exporter image pull policy
+      ## @param metrics.image.pullSecrets Apache exporter image pull secrets
+      ##
+      image:
+        registry: docker.io
+        repository: bitnami/apache-exporter
+        tag: 1.0.6-debian-12-r7
+        digest: ""
+        pullPolicy: IfNotPresent
+        ## Optionally specify an array of imagePullSecrets.
+        ## Secrets must be manually created in the namespace.
+        ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+        ## e.g:
+        ## pullSecrets:
+        ##   - myRegistryKeySecretName
+        ##
+        pullSecrets: []
+      ## @param metrics.containerPorts.metrics Prometheus exporter container port
+      ##
+      containerPorts:
+        metrics: 9117
+      ## Configure extra options for Prometheus exporter containers' liveness, readiness and startup probes
+      ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#configure-probes
+      ## @param metrics.livenessProbe.enabled Enable livenessProbe on Prometheus exporter containers
+      ## @param metrics.livenessProbe.initialDelaySeconds Initial delay seconds for livenessProbe
+      ## @param metrics.livenessProbe.periodSeconds Period seconds for livenessProbe
+      ## @param metrics.livenessProbe.timeoutSeconds Timeout seconds for livenessProbe
+      ## @param metrics.livenessProbe.failureThreshold Failure threshold for livenessProbe
+      ## @param metrics.livenessProbe.successThreshold Success threshold for livenessProbe
+      ##
+      livenessProbe:
+        enabled: true
+        initialDelaySeconds: 15
+        periodSeconds: 10
+        timeoutSeconds: 5
+        failureThreshold: 3
+        successThreshold: 1
+      ## @param metrics.readinessProbe.enabled Enable readinessProbe on Prometheus exporter containers
+      ## @param metrics.readinessProbe.initialDelaySeconds Initial delay seconds for readinessProbe
+      ## @param metrics.readinessProbe.periodSeconds Period seconds for readinessProbe
+      ## @param metrics.readinessProbe.timeoutSeconds Timeout seconds for readinessProbe
+      ## @param metrics.readinessProbe.failureThreshold Failure threshold for readinessProbe
+      ## @param metrics.readinessProbe.successThreshold Success threshold for readinessProbe
+      ##
+      readinessProbe:
+        enabled: true
+        initialDelaySeconds: 5
+        periodSeconds: 10
+        timeoutSeconds: 3
+        failureThreshold: 3
+        successThreshold: 1
+      ## @param metrics.startupProbe.enabled Enable startupProbe on Prometheus exporter containers
+      ## @param metrics.startupProbe.initialDelaySeconds Initial delay seconds for startupProbe
+      ## @param metrics.startupProbe.periodSeconds Period seconds for startupProbe
+      ## @param metrics.startupProbe.timeoutSeconds Timeout seconds for startupProbe
+      ## @param metrics.startupProbe.failureThreshold Failure threshold for startupProbe
+      ## @param metrics.startupProbe.successThreshold Success threshold for startupProbe
+      ##
+      startupProbe:
+        enabled: false
+        initialDelaySeconds: 10
+        periodSeconds: 10
+        timeoutSeconds: 1
+        failureThreshold: 15
+        successThreshold: 1
+      ## @param metrics.customLivenessProbe Custom livenessProbe that overrides the default one
+      ##
+      customLivenessProbe: {}
+      ## @param metrics.customReadinessProbe Custom readinessProbe that overrides the default one
+      ##
+      customReadinessProbe: {}
+      ## @param metrics.customStartupProbe Custom startupProbe that overrides the default one
+      ##
+      customStartupProbe: {}
+      ## Prometheus exporter container's resource requests and limits
+      ## ref: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/
+      ## @param metrics.resourcesPreset Set container resources according to one common preset (allowed values: none, nano, small, medium, large, xlarge, 2xlarge). This is ignored if metrics.resources is set (metrics.resources is recommended for production).
+      ## More information: https://github.com/bitnami/charts/blob/main/bitnami/common/templates/_resources.tpl#L15
+      ##
+      resourcesPreset: "none"
+      ## @param metrics.resources Set container requests and limits for different resources like CPU or memory (essential for production workloads)
+      ## Example:
+      ## resources:
+      ##   requests:
+      ##     cpu: 2
+      ##     memory: 512Mi
+      ##   limits:
+      ##     cpu: 3
+      ##     memory: 1024Mi
+      ##
+      resources: {}
+      ## Configure Container Security Context
+      ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container
+      ## @param metrics.containerSecurityContext.enabled Enabled containers' Security Context
+      ## @param metrics.containerSecurityContext.seLinuxOptions [object,nullable] Set SELinux options in container
+      ## @param metrics.containerSecurityContext.runAsUser Set containers' Security Context runAsUser
+      ## @param metrics.containerSecurityContext.runAsNonRoot Set container's Security Context runAsNonRoot
+      ## @param metrics.containerSecurityContext.privileged Set container's Security Context privileged
+      ## @param metrics.containerSecurityContext.readOnlyRootFilesystem Set container's Security Context readOnlyRootFilesystem
+      ## @param metrics.containerSecurityContext.allowPrivilegeEscalation Set container's Security Context allowPrivilegeEscalation
+      ## @param metrics.containerSecurityContext.capabilities.drop List of capabilities to be dropped
+      ## @param metrics.containerSecurityContext.seccompProfile.type Set container's Security Context seccomp profile
+      ##
+      containerSecurityContext:
+        enabled: true
+        seLinuxOptions: null
+        runAsUser: 1001
+        runAsNonRoot: true
+        privileged: false
+        readOnlyRootFilesystem: false
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop: [ "ALL" ]
+        seccompProfile:
+          type: "RuntimeDefault"
+      ## Prometheus exporter service parameters
+      ##
+      service:
+        ## @param metrics.service.ports.metrics Prometheus metrics service port
+        ##
+        ports:
+          metrics: 9150
+        ## @param metrics.service.annotations [object] Additional custom annotations for Metrics service
+        ##
+        annotations:
+          prometheus.io/scrape: "true"
+          prometheus.io/port: "{{ .Values.metrics.containerPorts.metrics }}"
+      ## Prometheus Operator ServiceMonitor configuration
+      ##
+      serviceMonitor:
+        ## @param metrics.serviceMonitor.enabled Create ServiceMonitor Resource for scraping metrics using Prometheus Operator
+        ##
+        enabled: false
+        ## @param metrics.serviceMonitor.namespace Namespace for the ServiceMonitor Resource (defaults to the Release Namespace)
+        ##
+        namespace: ""
+        ## @param metrics.serviceMonitor.interval Interval at which metrics should be scraped.
+        ## ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#endpoint
+        ##
+        interval: ""
+        ## @param metrics.serviceMonitor.scrapeTimeout Timeout after which the scrape is ended
+        ## ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#endpoint
+        ##
+        scrapeTimeout: ""
+        ## @param metrics.serviceMonitor.labels Additional labels that can be used so ServiceMonitor will be discovered by Prometheus
+        ##
+        labels: {}
+        ## @param metrics.serviceMonitor.selector Prometheus instance selector labels
+        ## ref: https://github.com/bitnami/charts/tree/main/bitnami/prometheus-operator#prometheus-configuration
+        ##
+        selector: {}
+        ## @param metrics.serviceMonitor.relabelings RelabelConfigs to apply to samples before scraping
+        ##
+        relabelings: []
+        ## @param metrics.serviceMonitor.metricRelabelings MetricRelabelConfigs to apply to samples before ingestion
+        ##
+        metricRelabelings: []
+        ## @param metrics.serviceMonitor.honorLabels Specify honorLabels parameter to add the scrape endpoint
+        ##
+        honorLabels: false
+        ## @param metrics.serviceMonitor.jobLabel The name of the label on the target service to use as the job name in prometheus.
+        ##
+        jobLabel: ""
+    ## @section NetworkPolicy parameters
+    ##
+
+    ## Add networkpolicies
+    ##
+    networkPolicy:
+      ## @param networkPolicy.enabled Enable network policies
+      ## If ingress.enabled or metrics.enabled are true, configure networkPolicy.ingress and networkPolicy.metrics selectors respectively to allow communication
+      ##
+      enabled: false
+      ## @param networkPolicy.metrics.enabled Enable network policy for metrics (prometheus)
+      ## @param networkPolicy.metrics.namespaceSelector [object] Monitoring namespace selector labels. These labels will be used to identify the prometheus' namespace.
+      ## @param networkPolicy.metrics.podSelector [object] Monitoring pod selector labels. These labels will be used to identify the Prometheus pods.
+      ##
+      metrics:
+        enabled: false
+        ## e.g:
+        ## podSelector:
+        ##   label: monitoring
+        ##
+        podSelector: {}
+        ## e.g:
+        ## namespaceSelector:
+        ##   label: monitoring
+        ##
+        namespaceSelector: {}
+      ## @param networkPolicy.ingress.enabled Enable network policy for Ingress Proxies
+      ## @param networkPolicy.ingress.namespaceSelector [object] Ingress Proxy namespace selector labels. These labels will be used to identify the Ingress Proxy's namespace.
+      ## @param networkPolicy.ingress.podSelector [object] Ingress Proxy pods selector labels. These labels will be used to identify the Ingress Proxy pods.
+      ##
+      ingress:
+        enabled: false
+        ## e.g:
+        ## podSelector:
+        ##   label: ingress
+        ##
+        podSelector: {}
+        ## e.g:
+        ## namespaceSelector:
+        ##   label: ingress
+        ##
+        namespaceSelector: {}
+      ## @param networkPolicy.ingressRules.backendOnlyAccessibleByFrontend Enable ingress rule that makes the backend (mariadb) only accessible by testlink's pods.
+      ## @param networkPolicy.ingressRules.customBackendSelector [object] Backend selector labels. These labels will be used to identify the backend pods.
+      ## @param networkPolicy.ingressRules.accessOnlyFrom.enabled Enable ingress rule that makes testlink only accessible from a particular origin
+      ## @param networkPolicy.ingressRules.accessOnlyFrom.namespaceSelector [object] Namespace selector label that is allowed to access testlink. This label will be used to identified the allowed namespace(s).
+      ## @param networkPolicy.ingressRules.accessOnlyFrom.podSelector [object] Pods selector label that is allowed to access testlink. This label will be used to identified the allowed pod(s).
+      ## @param networkPolicy.ingressRules.customRules [object] Custom network policy ingress rule
+      ##
+      ingressRules:
+        ## mariadb backend only can be accessed from testlink
+        ##
+        backendOnlyAccessibleByFrontend: false
+        ## Additional custom backend selector
+        ## e.g:
+        ## customBackendSelector:
+        ##   - to:
+        ##       - namespaceSelector:
+        ##           matchLabels:
+        ##             label: example
+        ##
+        customBackendSelector: {}
+        ## Allow only from the indicated:
+        ##
+        accessOnlyFrom:
+          enabled: false
+          ## e.g:
+          ## podSelector:
+          ##   label: access
+          ##
+          podSelector: {}
+          ## e.g:
+          ## namespaceSelector:
+          ##   label: access
+          ##
+          namespaceSelector: {}
+        ## custom ingress rules
+        ## e.g:
+        ## customRules:
+        ##   - from:
+        ##       - namespaceSelector:
+        ##           matchLabels:
+        ##             label: example
+        ##
+        customRules: {}
+      ## @param networkPolicy.egressRules.denyConnectionsToExternal Enable egress rule that denies outgoing traffic outside the cluster, except for DNS (port 53).
+      ## @param networkPolicy.egressRules.customRules [object] Custom network policy rule
+      ##
+      egressRules:
+        # Deny connections to external. This is not compatible with an external database.
+        denyConnectionsToExternal: false
+        ## Additional custom egress rules
+        ## e.g:
+        ## customRules:
+        ##   - to:
+        ##       - namespaceSelector:
+        ##           matchLabels:
+        ##             label: example
+        ##
+        customRules: {}
+    ## @section Database Parameters
+    ##
+
+    ## MariaDB chart configuration
+    ## ref: https://github.com/bitnami/charts/blob/main/bitnami/mariadb/values.yaml
+    ##
+    mariadb:
+      ## @param mariadb.enabled Deploy a MariaDB server to satisfy the applications database requirements
+      ## To use an external database set this to false and configure the `externalDatabase.*` parameters
+      ##
+      enabled: true
+      ## @param mariadb.architecture MariaDB architecture. Allowed values: `standalone` or `replication`
+      ##
+      architecture: standalone
+      ## MariaDB Authentication parameters
+      ## @param mariadb.auth.rootPassword MariaDB root password
+      ## @param mariadb.auth.database MariaDB custom database
+      ## @param mariadb.auth.username MariaDB custom user name
+      ## @param mariadb.auth.password MariaDB custom user password
+      ## ref: https://github.com/bitnami/containers/tree/main/bitnami/mariadb#setting-the-root-password-on-first-run
+      ##      https://github.com/bitnami/containers/blob/main/bitnami/mariadb/README.md#creating-a-database-on-first-run
+      ##      https://github.com/bitnami/containers/blob/main/bitnami/mariadb/README.md#creating-a-database-user-on-first-run
+      ##
+      auth:
+        rootPassword: welcome123
+        # rootPassword: {{ .Values.wordpressPassword }}
+        database: wordpress
+        username: admin
+        # username: {{ .spectro.pack.wordpress-chart.charts.wordpress.wordpressUsername }}
+        password: welcome123
+        # password: {{ .spectro.pack.wordpress-chart.charts.wordpress.wordpressPassword }}
+
+        ## MariaDB Primary configuration
+        ##
+      primary:
+        ## MariaDB Primary Persistence parameters
+        ## ref: https://kubernetes.io/docs/concepts/storage/persistent-volumes/
+        ## @param mariadb.primary.persistence.enabled Enable persistence on MariaDB using PVC(s)
+        ## @param mariadb.primary.persistence.storageClass Persistent Volume storage class
+        ## @param mariadb.primary.persistence.accessModes [array] Persistent Volume access modes
+        ## @param mariadb.primary.persistence.size Persistent Volume size
+        ##
+        persistence:
+          enabled: true
+          storageClass: ""
+          accessModes:
+            - ReadWriteOnce
+          size: 8Gi
+    ## External Database Configuration
+    ## All of these values are only used if `mariadb.enabled=false`
+    ##
+    externalDatabase:
+      ## @param externalDatabase.host External Database server host
+      ##
+      host: localhost
+      ## @param externalDatabase.port External Database server port
+      ##
+      port: 3306
+      ## @param externalDatabase.user External Database username
+      ##
+      user: bn_wordpress
+      ## @param externalDatabase.password External Database user password
+      ##
+      password: ""
+      ## @param externalDatabase.database External Database database name
+      ##
+      database: bitnami_wordpress
+      ## @param externalDatabase.existingSecret The name of an existing secret with database credentials. Evaluated as a template
+      ## NOTE: Must contain key `mariadb-password`
+      ## NOTE: When it's set, the `externalDatabase.password` parameter is ignored
+      ##
+      existingSecret: ""
+    ## Memcached chart configuration
+    ## ref: https://github.com/bitnami/charts/blob/main/bitnami/memcached/values.yaml
+    ##
+    memcached:
+      ## @param memcached.enabled Deploy a Memcached server for caching database queries
+      ##
+      enabled: false
+      ## Authentication parameters
+      ## ref: https://github.com/bitnami/containers/tree/main/bitnami/memcached#creating-the-memcached-admin-user
+      ##
+      auth:
+        ## @param memcached.auth.enabled Enable Memcached authentication
+        ##
+        enabled: false
+        ## @param memcached.auth.username Memcached admin user
+        ##
+        username: ""
+        ## @param memcached.auth.password Memcached admin password
+        ##
+        password: ""
+        ## @param memcached.auth.existingPasswordSecret Existing secret with Memcached credentials (must contain a value for `memcached-password` key)
+        ##
+        existingPasswordSecret: ""
+      ## Service parameters
+      ##
+      service:
+        ## @param memcached.service.port Memcached service port
+        ##
+        port: 11211
+    ## External Memcached Configuration
+    ## All of these values are only used if `memcached.enabled=false`
+    ##
+    externalCache:
+      ## @param externalCache.host External cache server host
+      ##
+      host: localhost
+      ## @param externalCache.port External cache server port
+      ##
+      port: 11211

--- a/examples/tutorials/profile-variables/outputs.tf
+++ b/examples/tutorials/profile-variables/outputs.tf
@@ -1,0 +1,6 @@
+output "advisory" {
+  value = <<-EOT
+    It takes between one to three minutes for DNS to properly resolve the public load balancer URL.
+    We recommend waiting a few minutes before clicking on the service URL to prevent the browser from caching an unresolved DNS request.
+  EOT
+}

--- a/examples/tutorials/profile-variables/providers.tf
+++ b/examples/tutorials/profile-variables/providers.tf
@@ -1,0 +1,35 @@
+terraform {
+  required_providers {
+    spectrocloud = {
+      version = ">= 0.23.6"
+      source  = "spectrocloud/spectrocloud"
+    }
+
+    tls = {
+      source  = "hashicorp/tls"
+      version = "4.0.4"
+    }
+    local = {
+      source  = "hashicorp/local"
+      version = "2.4.1"
+    }
+  }
+
+  required_version = ">= 1.9"
+}
+
+variable "sc_host" {
+  description = "The Palette API endpoint to connect to."
+  default     = "api.spectrocloud.com"
+}
+
+variable "sc_api_key" {
+  description = "Your Palette API key. Can also be set via the SPECTROCLOUD_APIKEY environment variable instead of this variable."
+  default     = null
+}
+
+provider "spectrocloud" {
+  host         = var.sc_host
+  api_key      = var.sc_api_key
+  project_name = var.palette-project
+}

--- a/examples/tutorials/profile-variables/ssh-key.tf
+++ b/examples/tutorials/profile-variables/ssh-key.tf
@@ -1,0 +1,9 @@
+###############
+# Azure SSH Key
+###############
+
+resource "tls_private_key" "tutorial_ssh_key_azure" {
+  count     = var.deploy-azure ? 1 : 0
+  algorithm = "RSA"
+  rsa_bits  = "4096"
+}

--- a/examples/tutorials/profile-variables/terraform.template.tfvars
+++ b/examples/tutorials/profile-variables/terraform.template.tfvars
@@ -1,0 +1,94 @@
+#####################
+# Palette Settings
+#####################
+palette-project = "Default" # The name of your project in Palette.
+
+##############################
+# Application Configuration
+##############################
+wordpress_replica   = "REPLACE ME" # The number of pods to be created for Wordpress.
+wordpress_namespace = "REPLACE ME" # The namespace to be created for Wordpress.
+wordpress_port      = "REPLACE ME" # The port to be created for HTTP for Wordpress.
+
+############################
+# AWS Deployment Settings
+############################
+deploy-aws     = false # Set to true to deploy to AWS.
+deploy-aws-var = false # Set to true to deploy to AWS with cluster profile variables.
+
+aws-cloud-account-name = "REPLACE ME"
+aws-region             = "REPLACE ME"
+aws-key-pair-name      = "REPLACE ME"
+
+aws_control_plane_nodes = {
+  count              = "1"
+  control_plane      = true
+  instance_type      = "m4.2xlarge"
+  disk_size_gb       = "60"
+  availability_zones = ["REPLACE ME"] # If you want to deploy to multiple AZs, add them here. Example: ["us-east-1a", "us-east-1b"].
+}
+
+aws_worker_nodes = {
+  count              = "1"
+  control_plane      = false
+  instance_type      = "m4.2xlarge"
+  disk_size_gb       = "60"
+  availability_zones = ["REPLACE ME"] # If you want to deploy to multiple AZs, add them here. Example: ["us-east-1a", "us-east-1b"].
+}
+
+############################
+# Azure Deployment Settings
+############################
+deploy-azure     = false # Set to true to deploy to Azure.
+deploy-azure-var = false # Set to true to deploy to Azure with cluster profile variables
+azure-use-azs    = false # Set to false when you deploy to a region without AZs.
+
+azure-cloud-account-name = "REPLACE ME"
+azure-region             = "REPLACE ME"
+azure_subscription_id    = "REPLACE ME"
+azure_resource_group     = "REPLACE ME"
+
+
+azure_control_plane_nodes = {
+  count               = "1"
+  control_plane       = true
+  instance_type       = "Standard_D4s_v3"
+  disk_size_gb        = "60"
+  azs                 = ["1"] # If you want to deploy to multiple AZs, add them here.
+  is_system_node_pool = false
+}
+
+azure_worker_nodes = {
+  count               = "1"
+  control_plane       = false
+  instance_type       = "Standard_D4s_v3"
+  disk_size_gb        = "60"
+  azs                 = ["1"] # If you want to deploy to multiple AZs, add them here.
+  is_system_node_pool = false
+}
+
+############################
+# GCP Deployment Settings
+############################
+deploy-gcp     = false # Set to true to deploy to GCP.
+deploy-gcp-var = false # Set to true to deploy to GCP with cluster profile variables.
+
+gcp-cloud-account-name = "REPLACE ME"
+gcp-region             = "REPLACE ME"
+gcp_project_name       = "REPLACE ME"
+
+gcp_control_plane_nodes = {
+  count              = "1"
+  control_plane      = true
+  instance_type      = "n2-standard-4"
+  disk_size_gb       = "60"
+  availability_zones = ["REPLACE ME"] # If you want to deploy to multiple AZs, add them here. Example: ["us-central1-a", "us-central1-b"].
+}
+
+gcp_worker_nodes = {
+  count              = "1"
+  control_plane      = false
+  instance_type      = "n2-standard-4"
+  disk_size_gb       = "60"
+  availability_zones = ["REPLACE ME"] # If you want to deploy to multiple AZs, add them here. Example: ["us-central1-a", "us-central1-b"].
+}

--- a/examples/tutorials/profile-variables/variables.tf
+++ b/examples/tutorials/profile-variables/variables.tf
@@ -1,0 +1,337 @@
+#########
+# Palette
+#########
+variable "palette-project" {
+  type        = string
+  description = "The name of your project in Palette."
+
+  validation {
+    condition     = var.palette-project != ""
+    error_message = "Provide the correct Palette project."
+  }
+}
+
+########
+# AWS
+########
+variable "aws-cloud-account-name" {
+  type        = string
+  description = "The name of your AWS account as assigned in Palette."
+
+  validation {
+    condition     = var.deploy-aws ? var.aws-cloud-account-name != "REPLACE ME" && var.aws-cloud-account-name != "" : true
+    error_message = "Provide the correct AWS cloud account name."
+  }
+}
+
+variable "deploy-aws" {
+  type        = bool
+  description = "A flag for enabling a deployment on AWS."
+}
+
+variable "deploy-aws-var" {
+  type        = bool
+  description = "A flag for enabling a deployment on AWS with cluster profile variables."
+}
+
+variable "aws-region" {
+  type        = string
+  description = "AWS region"
+  default     = "us-east-1"
+
+  validation {
+    condition     = var.deploy-aws ? var.aws-region != "REPLACE ME" && var.aws-region != "" : true
+    error_message = "Provide the correct AWS region."
+  }
+}
+
+variable "aws-key-pair-name" {
+  type        = string
+  description = "The name of the AWS key pair to use for SSH access to the cluster."
+
+  validation {
+    condition     = var.deploy-aws ? var.aws-key-pair-name != "REPLACE ME" && var.aws-key-pair-name != "" : true
+    error_message = "Provide the correct AWS SSH key pair name."
+  }
+}
+
+variable "aws_control_plane_nodes" {
+  type = object({
+    count              = string
+    control_plane      = bool
+    instance_type      = string
+    disk_size_gb       = string
+    availability_zones = list(string)
+  })
+  default = {
+    count              = "1"
+    control_plane      = true
+    instance_type      = "m4.2xlarge"
+    disk_size_gb       = "60"
+    availability_zones = ["us-east-1a"]
+  }
+  description = "AWS control plane nodes configuration."
+
+  validation {
+    condition     = var.deploy-aws ? length(var.aws_control_plane_nodes.availability_zones) > 0 && !contains(var.aws_control_plane_nodes.availability_zones, "REPLACE ME") : true
+    error_message = "The availability_zones parameter must be set correctly"
+  }
+}
+
+variable "aws_worker_nodes" {
+  type = object({
+    count              = string
+    control_plane      = bool
+    instance_type      = string
+    disk_size_gb       = string
+    availability_zones = list(string)
+  })
+  default = {
+    count              = "1"
+    control_plane      = false
+    instance_type      = "m4.2xlarge"
+    disk_size_gb       = "60"
+    availability_zones = ["us-east-1a"]
+  }
+  description = "AWS worker nodes configuration."
+
+  validation {
+    condition     = var.deploy-aws ? length(var.aws_worker_nodes.availability_zones) > 0 && !contains(var.aws_worker_nodes.availability_zones, "REPLACE ME") : true
+    error_message = "The availability_zones parameter must be set correctly"
+  }
+}
+
+#######
+# Azure
+#######
+variable "azure-cloud-account-name" {
+  type        = string
+  description = "The name of your Azure account as assigned in Palette."
+  default     = ""
+
+  validation {
+    condition     = var.deploy-azure ? var.azure-cloud-account-name != "REPLACE ME" && var.azure-cloud-account-name != "" : true
+    error_message = "Provide the correct Azure cloud account name."
+  }
+}
+
+variable "deploy-azure" {
+  type        = bool
+  description = "A flag for enabling a deployment on Azure."
+}
+
+variable "deploy-azure-var" {
+  type        = bool
+  description = "A flag for enabling a deployment on Azure with cluster profile variables."
+}
+
+variable "azure_subscription_id" {
+  type        = string
+  description = "Azure subscription ID."
+  default     = ""
+
+  validation {
+    condition     = var.deploy-azure ? var.azure_subscription_id != "REPLACE ME" && var.azure_subscription_id != "" : true
+    error_message = "Provide the correct Azure subscription ID."
+  }
+}
+
+variable "azure_resource_group" {
+  type        = string
+  description = "Azure resource group."
+  default     = ""
+
+  validation {
+    condition     = var.deploy-azure ? var.azure_resource_group != "REPLACE ME" && var.azure_resource_group != "" : true
+    error_message = "Provide the correct Azure resource group name."
+  }
+}
+
+variable "azure-use-azs" {
+  type        = bool
+  description = "A flag for configuring whether to use Azure Availability Zones. Check if your Azure region supports availability zones by reviewing the [Azure Regions and Availability Zones](https://learn.microsoft.com/en-us/azure/reliability/availability-zones-service-support#azure-regions-with-availability-zone-support) resource."
+}
+
+variable "azure-region" {
+  type        = string
+  description = "Azure region."
+  default     = "eastus"
+
+  validation {
+    condition     = var.deploy-azure ? var.azure-region != "REPLACE ME" && var.azure-region != "" : true
+    error_message = "Provide the correct Azure region name."
+  }
+}
+
+variable "azure_control_plane_nodes" {
+  type = object({
+    count               = string
+    control_plane       = bool
+    instance_type       = string
+    disk_size_gb        = string
+    azs                 = list(string)
+    is_system_node_pool = bool
+  })
+  default = {
+    count               = "1"
+    control_plane       = true
+    instance_type       = "Standard_A8_v2"
+    disk_size_gb        = "60"
+    azs                 = ["1"]
+    is_system_node_pool = false
+  }
+  description = "Azure control plane nodes configuration."
+}
+
+variable "azure_worker_nodes" {
+  type = object({
+    count               = string
+    control_plane       = bool
+    instance_type       = string
+    disk_size_gb        = string
+    azs                 = list(string)
+    is_system_node_pool = bool
+  })
+  default = {
+    count               = "1"
+    control_plane       = false
+    instance_type       = "Standard_A8_v2"
+    disk_size_gb        = "60"
+    azs                 = ["1"]
+    is_system_node_pool = false
+  }
+  description = "Azure worker nodes configuration."
+}
+
+#######
+# GCP
+#######
+variable "gcp-cloud-account-name" {
+  type        = string
+  description = "The name of your GCP account as assigned in Palette."
+  default     = ""
+
+  validation {
+    condition     = var.deploy-gcp ? var.gcp-cloud-account-name != "REPLACE ME" && var.gcp-cloud-account-name != "" : true
+    error_message = "Provide the correct GCP cloud account name."
+  }
+}
+
+variable "gcp_project_name" {
+  type        = string
+  description = "The name of your GCP project."
+  default     = ""
+
+  validation {
+    condition     = var.deploy-gcp ? var.gcp_project_name != "REPLACE ME" && var.gcp_project_name != "" : true
+    error_message = "Provide the correct GCP project name."
+  }
+}
+
+variable "deploy-gcp" {
+  type        = bool
+  description = "A flag for enabling a deployment on GCP."
+}
+variable "deploy-gcp-var" {
+  type        = bool
+  description = "A flag for enabling a deployment on GCP with cluster profile variables."
+}
+
+variable "gcp-region" {
+  type        = string
+  description = "GCP region"
+  default     = "us-central1"
+
+  validation {
+    condition     = var.deploy-gcp ? var.gcp-region != "REPLACE ME" && var.gcp-region != "" : true
+    error_message = "Provide the correct GCP region."
+  }
+}
+
+variable "gcp_control_plane_nodes" {
+  type = object({
+    count              = string
+    control_plane      = bool
+    instance_type      = string
+    disk_size_gb       = string
+    availability_zones = list(string)
+  })
+  default = {
+    count              = "1"
+    control_plane      = true
+    instance_type      = "n1-standard-4"
+    disk_size_gb       = "60"
+    availability_zones = ["us-central1-a"]
+  }
+  description = "GCP control plane nodes configuration."
+
+  validation {
+    condition     = var.deploy-gcp ? length(var.gcp_control_plane_nodes.availability_zones) > 0 && !contains(var.gcp_control_plane_nodes.availability_zones, "REPLACE ME") : true
+    error_message = "The availability_zones parameter must be set correctly"
+  }
+}
+
+variable "gcp_worker_nodes" {
+  type = object({
+    count              = string
+    control_plane      = bool
+    instance_type      = string
+    disk_size_gb       = string
+    availability_zones = list(string)
+  })
+  default = {
+    count              = "1"
+    control_plane      = false
+    instance_type      = "n1-standard-4"
+    disk_size_gb       = "60"
+    availability_zones = ["us-central1-a"]
+  }
+  description = "GCP worker nodes configuration."
+
+  validation {
+    condition     = var.deploy-gcp ? length(var.gcp_worker_nodes.availability_zones) > 0 && !contains(var.gcp_worker_nodes.availability_zones, "REPLACE ME") : true
+    error_message = "The availability_zones parameter must be set correctly"
+  }
+}
+
+variable "tags" {
+  type        = list(string)
+  description = "The default tags to apply to Palette resources."
+  default = [
+    "spectro-cloud-education",
+    "app:wordpress",
+    "spectrocloud:tutorials",
+    "terraform_managed:true",
+    "tutorial:cluster-profile-variables"
+  ]
+}
+
+variable "wordpress_replica" {
+  type        = number
+  description = "The number of pods to be created for WordPress. Only used once deploy-<cloud>-var is enabled — the profile version without variables always deploys 1 replica."
+
+  validation {
+    condition     = var.deploy-aws || var.deploy-azure || var.deploy-gcp ? var.wordpress_replica != "REPLACE ME" && var.wordpress_replica >= 1 : true
+    error_message = "The number of WordPress replicas must be at least 1 or more."
+  }
+}
+
+variable "wordpress_namespace" {
+  type        = string
+  description = "The Kubernetes namespace to deploy WordPress into. Only used once deploy-<cloud>-var is enabled — the profile version without variables always deploys to the \"wordpress\" namespace."
+
+  validation {
+    condition     = var.deploy-aws || var.deploy-azure || var.deploy-gcp ? var.wordpress_namespace != "REPLACE ME" && var.wordpress_namespace != "" : true
+    error_message = "Provide the namespace for Wordpress."
+  }
+}
+
+variable "wordpress_port" {
+  type        = number
+  description = "The port WordPress listens on for HTTP traffic. Only used once deploy-<cloud>-var is enabled — the profile version without variables always uses port 80."
+
+  validation {
+    condition     = var.deploy-aws || var.deploy-azure || var.deploy-gcp ? var.wordpress_port != "REPLACE ME" && var.wordpress_port >= 1 : true
+    error_message = "Set the port number for WordPress"
+  }
+}


### PR DESCRIPTION
Ports cluster-profile-variables-tf from github.com/spectrocloud/tutorials into examples/tutorials/profile-variables/, reshaped to this repo's file-naming convention.

Demonstrates a cluster profile without variables (v1.0.0, fixed values baked into the manifest) versus one with profile_variables (v1.1.0, values supplied via wordpress_replica/wordpress_namespace/ wordpress_port), toggled per-cloud via deploy-<cloud>-var.

Fixes carried over from the source during porting:
- azure-profile, azure-profile-var, and gcp-profile-var each had a duplicate wordpress_chart pack block (two pack blocks with the same layer name); reduced to one each, matching the correct pattern already used by aws-profile/aws-profile-var/gcp-profile.
- wordpress_namespace was incorrectly marked sensitive = true; removed, since a namespace isn't sensitive data.
- Source README referenced variables/resources that don't exist in its own .tf files (stale terraform-docs output); replaced with an accurate README.

All attributes verified against the current provider schema - no drift found. terraform validate passes against the published provider.

Covers PLT-2382 (port), PLT-2383 (README), and PLT-2384 (validation).