### PR TITLE
PLT-2385: Port cluster-templates tutorial example

### DIFF
--- a/examples/tutorials/README.md
+++ b/examples/tutorials/README.md
@@ -15,7 +15,7 @@ following [PORTING_CHECKLIST.md](PORTING_CHECKLIST.md).
 | [`custom-pack/`](custom-pack) | [Deploy a Custom Pack](https://docs.spectrocloud.com/tutorials/packs-registries/deploy-pack/) | Done |
 | [`getting-started-multicloud/`](getting-started-multicloud) | [Cluster Management with Terraform (Getting Started)](https://docs.spectrocloud.com/tutorials/getting-started/palette/aws/deploy-manage-k8s-cluster-tf/) | Done |
 | [`profile-variables/`](profile-variables) | [Deploy Cluster with Profile Variables](https://docs.spectrocloud.com/tutorials/profiles/cluster-profile-variables/) | Done |
-| [`cluster-templates/`](cluster-templates) | [Standardize Clusters with Cluster Templates (Terraform)](https://docs.spectrocloud.com/tutorials/clusters/cluster-templates/standardize-clusters-with-cluster-templates-terraform/) | Planned |
+| [`cluster-templates/`](cluster-templates) | [Standardize Clusters with Cluster Templates (Terraform)](https://docs.spectrocloud.com/tutorials/clusters/cluster-templates/standardize-clusters-with-cluster-templates-terraform/) | Done |
 | [`pcg-vmware-app/`](pcg-vmware-app) | [Deploy App Workloads with a PCG](https://docs.spectrocloud.com/tutorials/clusters/pcg/deploy-app-pcg/) | Planned |
 | [`pde-virtual-cluster-app/`](pde-virtual-cluster-app) | [Deploy an Application using Palette Dev Engine](https://docs.spectrocloud.com/tutorials/pde/deploy-app/) | Planned |
 | [`cluster-profile-update/`](cluster-profile-update) | [Deploy Cluster Profile Updates](https://docs.spectrocloud.com/tutorials/profiles/update-k8s-cluster/) | Planned |

--- a/examples/tutorials/cluster-templates/README.md
+++ b/examples/tutorials/cluster-templates/README.md
@@ -1,0 +1,62 @@
+# Cluster templates tutorial example
+
+End-to-end example accompanying the Spectro Cloud tutorial
+[Standardize Clusters with Cluster Templates using Terraform](https://docs.spectrocloud.com/tutorials/clusters/cluster-templates/standardize-clusters-with-cluster-templates-terraform/).
+
+This example shows how to standardize and later roll out an upgrade across a fleet of clusters using a
+`spectrocloud_cluster_config_template`, rather than managing each cluster's profile version individually.
+It provisions, per enabled cloud (AWS and/or Azure):
+- A maintenance policy (`spectrocloud_cluster_config_policy`) defining a weekly upgrade window
+- A cluster profile (v1.0.0: OS, Kubernetes, CNI, CSI, plus the Hello Universe sample app)
+- A cluster template (`spectrocloud_cluster_config_template`) that pins a cluster profile version and
+  attaches the maintenance policy
+- Two clusters — `dev` and `prod` — both built from the same template, but each overriding the
+  `app_replicas` profile variable to a different value (1 vs. 2)
+
+## The Day-2 workflow this demonstrates
+
+1. **Initial deploy:** with `create_new_profile_version` and `update_template_profile_version` both
+   `false`, `terraform apply` creates the template pointing at profile v1.0.0, and both the `dev` and
+   `prod` clusters.
+2. **Add a new profile version:** set `create_new_profile_version = true` and re-apply. This creates
+   profile v1.1.0, which adds the Kubecost add-on — the template still points at v1.0.0, so existing
+   clusters are unaffected.
+3. **Roll the template forward:** set `update_template_profile_version = true` and re-apply. The template
+   now points at v1.1.0. This alone does not change already-running clusters — it changes what new
+   clusters deployed from the template will use, and prepares the template for an explicit rollout.
+4. **Trigger the upgrade:** set `upgrade_now_timestamp` to the current RFC3339 timestamp (for example
+   `2026-05-12T14:30:00Z`) and re-apply. This immediately triggers an upgrade of every cluster launched
+   from the template — both `dev` and `prod` — to the template's current profile version. Change this
+   timestamp to any new value to re-trigger a later upgrade.
+
+The maintenance policy's weekly schedule governs *routine* upgrade windows; `upgrade_now` is an explicit
+override that upgrades immediately regardless of that schedule.
+
+## Prerequisites
+
+You will need the following before getting started:
+1. A Palette API key, exported as the `SPECTROCLOUD_APIKEY` environment variable (or supplied via the
+   `sc_api_key` variable).
+2. A cloud account already registered in your Palette project settings for each cloud you enable.
+3. For AWS: an existing EC2 key pair in the region you deploy to.
+4. Terraform 1.9 or later.
+
+## Instructions
+
+Clone this repository to a local directory, and change directory to
+`examples/tutorials/cluster-templates`. Proceed with the following:
+1. From the current directory, copy the template variable file `terraform.template.tfvars` to a new
+   file `terraform.tfvars`.
+2. Set the `deploy-aws` and/or `deploy-azure` toggle(s), and fill in the placeholder (`REPLACE ME`)
+   values relevant to those clouds.
+3. Initialize and run terraform: `terraform init && terraform apply`. This deploys the maintenance
+   policy, template, and both `dev`/`prod` clusters at profile v1.0.0.
+4. Walk through the Day-2 workflow above by editing `terraform.tfvars` and re-applying at each step.
+
+## Clean up
+
+Run the destroy operation:
+
+```shell
+terraform destroy
+```

--- a/examples/tutorials/cluster-templates/cluster_profiles.tf
+++ b/examples/tutorials/cluster-templates/cluster_profiles.tf
@@ -1,0 +1,265 @@
+resource "spectrocloud_cluster_profile" "aws_profile" {
+  count = var.deploy-aws ? 1 : 0
+
+  name        = "tf-cluster-template-profile-aws"
+  description = "Cluster profile for the cluster templates tutorial"
+  cloud       = "aws"
+  type        = "cluster"
+  version     = "1.0.0"
+
+  pack {
+    name   = data.spectrocloud_pack.aws_ubuntu.name
+    tag    = data.spectrocloud_pack.aws_ubuntu.version
+    uid    = data.spectrocloud_pack.aws_ubuntu.id
+    values = data.spectrocloud_pack.aws_ubuntu.values
+    type   = "spectro"
+  }
+
+  pack {
+    name   = data.spectrocloud_pack.aws_k8s.name
+    tag    = data.spectrocloud_pack.aws_k8s.version
+    uid    = data.spectrocloud_pack.aws_k8s.id
+    values = data.spectrocloud_pack.aws_k8s.values
+    type   = "spectro"
+  }
+
+  pack {
+    name   = data.spectrocloud_pack.aws_cni.name
+    tag    = data.spectrocloud_pack.aws_cni.version
+    uid    = data.spectrocloud_pack.aws_cni.id
+    values = data.spectrocloud_pack.aws_cni.values
+    type   = "spectro"
+  }
+
+  pack {
+    name   = data.spectrocloud_pack.aws_csi.name
+    tag    = data.spectrocloud_pack.aws_csi.version
+    uid    = data.spectrocloud_pack.aws_csi.id
+    values = data.spectrocloud_pack.aws_csi.values
+    type   = "spectro"
+  }
+
+  pack {
+    name = data.spectrocloud_pack.hellouniverse.name
+    tag  = data.spectrocloud_pack.hellouniverse.version
+    uid  = data.spectrocloud_pack.hellouniverse.id
+    values = templatefile("manifests/values-hello-universe.yaml", {
+      port = var.app_port
+    })
+    type = "oci"
+  }
+
+  profile_variables {
+    variable {
+      name          = "app_replicas"
+      display_name  = "Hello Universe Replicas"
+      format        = "number"
+      description   = "Number of replicas for the hello-universe workload"
+      default_value = "1"
+      required      = true
+    }
+  }
+}
+
+resource "spectrocloud_cluster_profile" "azure_profile" {
+  count = var.deploy-azure ? 1 : 0
+
+  name        = "tf-cluster-template-profile-azure"
+  description = "Cluster profile for the cluster templates tutorial"
+  cloud       = "azure"
+  type        = "cluster"
+  version     = "1.0.0"
+
+  pack {
+    name   = data.spectrocloud_pack.azure_ubuntu.name
+    tag    = data.spectrocloud_pack.azure_ubuntu.version
+    uid    = data.spectrocloud_pack.azure_ubuntu.id
+    values = data.spectrocloud_pack.azure_ubuntu.values
+    type   = "spectro"
+  }
+
+  pack {
+    name   = data.spectrocloud_pack.azure_k8s.name
+    tag    = data.spectrocloud_pack.azure_k8s.version
+    uid    = data.spectrocloud_pack.azure_k8s.id
+    values = data.spectrocloud_pack.azure_k8s.values
+    type   = "spectro"
+  }
+
+  pack {
+    name   = data.spectrocloud_pack.azure_cni.name
+    tag    = data.spectrocloud_pack.azure_cni.version
+    uid    = data.spectrocloud_pack.azure_cni.id
+    values = data.spectrocloud_pack.azure_cni.values
+    type   = "spectro"
+  }
+
+  pack {
+    name   = data.spectrocloud_pack.azure_csi.name
+    tag    = data.spectrocloud_pack.azure_csi.version
+    uid    = data.spectrocloud_pack.azure_csi.id
+    values = data.spectrocloud_pack.azure_csi.values
+    type   = "spectro"
+  }
+
+  pack {
+    name = data.spectrocloud_pack.hellouniverse.name
+    tag  = data.spectrocloud_pack.hellouniverse.version
+    uid  = data.spectrocloud_pack.hellouniverse.id
+    values = templatefile("manifests/values-hello-universe.yaml", {
+      port = var.app_port
+    })
+    type = "oci"
+  }
+
+  profile_variables {
+    variable {
+      name          = "app_replicas"
+      display_name  = "Hello Universe Replicas"
+      format        = "number"
+      description   = "Number of replicas for the hello-universe workload"
+      default_value = "1"
+      required      = true
+    }
+  }
+}
+
+resource "spectrocloud_cluster_profile" "aws_profile_v110" {
+  count = (var.deploy-aws && var.create_new_profile_version) ? 1 : 0
+
+  name        = "tf-cluster-template-profile-aws"
+  description = "Cluster profile for the cluster templates tutorial"
+  cloud       = "aws"
+  type        = "cluster"
+  version     = "1.1.0"
+
+  pack {
+    name   = data.spectrocloud_pack.aws_ubuntu.name
+    tag    = data.spectrocloud_pack.aws_ubuntu.version
+    uid    = data.spectrocloud_pack.aws_ubuntu.id
+    values = data.spectrocloud_pack.aws_ubuntu.values
+    type   = "spectro"
+  }
+
+  pack {
+    name   = data.spectrocloud_pack.aws_k8s.name
+    tag    = data.spectrocloud_pack.aws_k8s.version
+    uid    = data.spectrocloud_pack.aws_k8s.id
+    values = data.spectrocloud_pack.aws_k8s.values
+    type   = "spectro"
+  }
+
+  pack {
+    name   = data.spectrocloud_pack.aws_cni.name
+    tag    = data.spectrocloud_pack.aws_cni.version
+    uid    = data.spectrocloud_pack.aws_cni.id
+    values = data.spectrocloud_pack.aws_cni.values
+    type   = "spectro"
+  }
+
+  pack {
+    name   = data.spectrocloud_pack.aws_csi.name
+    tag    = data.spectrocloud_pack.aws_csi.version
+    uid    = data.spectrocloud_pack.aws_csi.id
+    values = data.spectrocloud_pack.aws_csi.values
+    type   = "spectro"
+  }
+
+  pack {
+    name = data.spectrocloud_pack.hellouniverse.name
+    tag  = data.spectrocloud_pack.hellouniverse.version
+    uid  = data.spectrocloud_pack.hellouniverse.id
+    values = templatefile("manifests/values-hello-universe.yaml", {
+      port = var.app_port
+    })
+    type = "oci"
+  }
+
+  pack {
+    name = data.spectrocloud_pack.kubecost[0].name
+    tag  = data.spectrocloud_pack.kubecost[0].version
+    uid  = data.spectrocloud_pack.kubecost[0].id
+    type = "oci"
+  }
+
+  profile_variables {
+    variable {
+      name          = "app_replicas"
+      display_name  = "Hello Universe Replicas"
+      format        = "number"
+      description   = "Number of replicas for the hello-universe workload"
+      default_value = "1"
+      required      = true
+    }
+  }
+}
+
+resource "spectrocloud_cluster_profile" "azure_profile_v110" {
+  count = (var.deploy-azure && var.create_new_profile_version) ? 1 : 0
+
+  name        = "tf-cluster-template-profile-azure"
+  description = "Cluster profile for the cluster templates tutorial"
+  cloud       = "azure"
+  type        = "cluster"
+  version     = "1.1.0"
+
+  pack {
+    name   = data.spectrocloud_pack.azure_ubuntu.name
+    tag    = data.spectrocloud_pack.azure_ubuntu.version
+    uid    = data.spectrocloud_pack.azure_ubuntu.id
+    values = data.spectrocloud_pack.azure_ubuntu.values
+    type   = "spectro"
+  }
+
+  pack {
+    name   = data.spectrocloud_pack.azure_k8s.name
+    tag    = data.spectrocloud_pack.azure_k8s.version
+    uid    = data.spectrocloud_pack.azure_k8s.id
+    values = data.spectrocloud_pack.azure_k8s.values
+    type   = "spectro"
+  }
+
+  pack {
+    name   = data.spectrocloud_pack.azure_cni.name
+    tag    = data.spectrocloud_pack.azure_cni.version
+    uid    = data.spectrocloud_pack.azure_cni.id
+    values = data.spectrocloud_pack.azure_cni.values
+    type   = "spectro"
+  }
+
+  pack {
+    name   = data.spectrocloud_pack.azure_csi.name
+    tag    = data.spectrocloud_pack.azure_csi.version
+    uid    = data.spectrocloud_pack.azure_csi.id
+    values = data.spectrocloud_pack.azure_csi.values
+    type   = "spectro"
+  }
+
+  pack {
+    name = data.spectrocloud_pack.hellouniverse.name
+    tag  = data.spectrocloud_pack.hellouniverse.version
+    uid  = data.spectrocloud_pack.hellouniverse.id
+    values = templatefile("manifests/values-hello-universe.yaml", {
+      port = var.app_port
+    })
+    type = "oci"
+  }
+
+  pack {
+    name = data.spectrocloud_pack.kubecost[0].name
+    tag  = data.spectrocloud_pack.kubecost[0].version
+    uid  = data.spectrocloud_pack.kubecost[0].id
+    type = "oci"
+  }
+
+  profile_variables {
+    variable {
+      name          = "app_replicas"
+      display_name  = "Hello Universe Replicas"
+      format        = "number"
+      description   = "Number of replicas for the hello-universe workload"
+      default_value = "1"
+      required      = true
+    }
+  }
+}

--- a/examples/tutorials/cluster-templates/cluster_templates.tf
+++ b/examples/tutorials/cluster-templates/cluster_templates.tf
@@ -1,0 +1,37 @@
+resource "spectrocloud_cluster_config_template" "aws_template" {
+  count = var.deploy-aws ? 1 : 0
+
+  name       = "tf-cluster-template-aws"
+  cloud_type = "aws"
+  context    = "project"
+
+  cluster_profile {
+    id = (var.create_new_profile_version && var.update_template_profile_version) ? spectrocloud_cluster_profile.aws_profile_v110[0].id : spectrocloud_cluster_profile.aws_profile[0].id
+  }
+
+  policy {
+    id   = spectrocloud_cluster_config_policy.maintenance.id
+    kind = "maintenance"
+  }
+
+  upgrade_now = var.upgrade_now_timestamp != "" ? var.upgrade_now_timestamp : null
+}
+
+resource "spectrocloud_cluster_config_template" "azure_template" {
+  count = var.deploy-azure ? 1 : 0
+
+  name       = "tf-cluster-template-azure"
+  cloud_type = "azure"
+  context    = "project"
+
+  cluster_profile {
+    id = (var.create_new_profile_version && var.update_template_profile_version) ? spectrocloud_cluster_profile.azure_profile_v110[0].id : spectrocloud_cluster_profile.azure_profile[0].id
+  }
+
+  policy {
+    id   = spectrocloud_cluster_config_policy.maintenance.id
+    kind = "maintenance"
+  }
+
+  upgrade_now = var.upgrade_now_timestamp != "" ? var.upgrade_now_timestamp : null
+}

--- a/examples/tutorials/cluster-templates/clusters.tf
+++ b/examples/tutorials/cluster-templates/clusters.tf
@@ -1,0 +1,215 @@
+#############
+# AWS Cluster
+#############
+
+resource "spectrocloud_cluster_aws" "dev_cluster" {
+  count = var.deploy-aws ? 1 : 0
+
+  name             = "tf-dev-cluster"
+  cluster_timezone = "UTC"
+  cloud_account_id = data.spectrocloud_cloudaccount_aws.account[0].id
+
+  cloud_config {
+    region       = var.aws-region
+    ssh_key_name = var.aws-key-pair-name
+  }
+
+  cluster_template {
+    id = spectrocloud_cluster_config_template.aws_template[0].id
+
+    cluster_profile {
+      id = spectrocloud_cluster_profile.aws_profile[0].id
+      variables = {
+        "app_replicas" = "1"
+      }
+    }
+  }
+
+  machine_pool {
+    control_plane           = true
+    control_plane_as_worker = true
+    name                    = "control-plane-pool"
+    count                   = var.aws_control_plane_nodes.count
+    instance_type           = var.aws_control_plane_nodes.instance_type
+    disk_size_gb            = var.aws_control_plane_nodes.disk_size_gb
+    azs                     = var.aws_control_plane_nodes.availability_zones
+  }
+
+  machine_pool {
+    name          = "worker-pool"
+    count         = var.aws_worker_nodes.count
+    instance_type = var.aws_worker_nodes.instance_type
+    disk_size_gb  = var.aws_worker_nodes.disk_size_gb
+    azs           = var.aws_worker_nodes.availability_zones
+  }
+
+  timeouts {
+    create = "60m"
+    delete = "60m"
+  }
+}
+
+##################
+# AWS Prod Cluster
+##################
+
+resource "spectrocloud_cluster_aws" "prod_cluster" {
+  count = var.deploy-aws ? 1 : 0
+
+  name             = "tf-prod-cluster"
+  cluster_timezone = "UTC"
+  cloud_account_id = data.spectrocloud_cloudaccount_aws.account[0].id
+
+  cloud_config {
+    region       = var.aws-region
+    ssh_key_name = var.aws-key-pair-name
+  }
+
+  cluster_template {
+    id = spectrocloud_cluster_config_template.aws_template[0].id
+
+    cluster_profile {
+      id = spectrocloud_cluster_profile.aws_profile[0].id
+      variables = {
+        "app_replicas" = "2"
+      }
+    }
+  }
+
+  machine_pool {
+    control_plane           = true
+    control_plane_as_worker = true
+    name                    = "control-plane-pool"
+    count                   = var.aws_control_plane_nodes.count
+    instance_type           = var.aws_control_plane_nodes.instance_type
+    disk_size_gb            = var.aws_control_plane_nodes.disk_size_gb
+    azs                     = var.aws_control_plane_nodes.availability_zones
+  }
+
+  machine_pool {
+    name          = "worker-pool"
+    count         = var.aws_worker_nodes.count
+    instance_type = var.aws_worker_nodes.instance_type
+    disk_size_gb  = var.aws_worker_nodes.disk_size_gb
+    azs           = var.aws_worker_nodes.availability_zones
+  }
+
+  timeouts {
+    create = "60m"
+    delete = "60m"
+  }
+}
+
+###############
+# Azure Cluster
+###############
+
+resource "spectrocloud_cluster_azure" "dev_cluster" {
+  count = var.deploy-azure ? 1 : 0
+
+  name             = "tf-dev-cluster-azure"
+  cluster_timezone = "UTC"
+  cloud_account_id = data.spectrocloud_cloudaccount_azure.account[0].id
+
+  cloud_config {
+    subscription_id = var.azure_subscription_id
+    resource_group  = var.azure_resource_group
+    region          = var.azure-region
+    ssh_key         = tls_private_key.tutorial_ssh_key_azure[0].public_key_openssh
+  }
+
+  cluster_template {
+    id = spectrocloud_cluster_config_template.azure_template[0].id
+
+    cluster_profile {
+      id = spectrocloud_cluster_profile.azure_profile[0].id
+      variables = {
+        "app_replicas" = "1"
+      }
+    }
+  }
+
+  machine_pool {
+    control_plane           = true
+    control_plane_as_worker = true
+    name                    = "control-plane-pool"
+    count                   = var.azure_control_plane_nodes.count
+    instance_type           = var.azure_control_plane_nodes.instance_type
+    azs                     = var.azure-use-azs ? var.azure_control_plane_nodes.azs : [""]
+    is_system_node_pool     = var.azure_control_plane_nodes.is_system_node_pool
+    disk {
+      size_gb = var.azure_control_plane_nodes.disk_size_gb
+      type    = "Standard_LRS"
+    }
+  }
+
+  machine_pool {
+    name                = "worker-pool"
+    count               = var.azure_worker_nodes.count
+    instance_type       = var.azure_worker_nodes.instance_type
+    azs                 = var.azure-use-azs ? var.azure_worker_nodes.azs : [""]
+    is_system_node_pool = var.azure_worker_nodes.is_system_node_pool
+  }
+
+  timeouts {
+    create = "60m"
+    delete = "60m"
+  }
+}
+
+####################
+# Azure Prod Cluster
+####################
+
+resource "spectrocloud_cluster_azure" "prod_cluster" {
+  count = var.deploy-azure ? 1 : 0
+
+  name             = "tf-prod-cluster-azure"
+  cluster_timezone = "UTC"
+  cloud_account_id = data.spectrocloud_cloudaccount_azure.account[0].id
+
+  cloud_config {
+    subscription_id = var.azure_subscription_id
+    resource_group  = var.azure_resource_group
+    region          = var.azure-region
+    ssh_key         = tls_private_key.tutorial_ssh_key_azure[0].public_key_openssh
+  }
+
+  cluster_template {
+    id = spectrocloud_cluster_config_template.azure_template[0].id
+
+    cluster_profile {
+      id = spectrocloud_cluster_profile.azure_profile[0].id
+      variables = {
+        "app_replicas" = "2"
+      }
+    }
+  }
+
+  machine_pool {
+    control_plane           = true
+    control_plane_as_worker = true
+    name                    = "control-plane-pool"
+    count                   = var.azure_control_plane_nodes.count
+    instance_type           = var.azure_control_plane_nodes.instance_type
+    azs                     = var.azure-use-azs ? var.azure_control_plane_nodes.azs : [""]
+    is_system_node_pool     = var.azure_control_plane_nodes.is_system_node_pool
+    disk {
+      size_gb = var.azure_control_plane_nodes.disk_size_gb
+      type    = "Standard_LRS"
+    }
+  }
+
+  machine_pool {
+    name                = "worker-pool"
+    count               = var.azure_worker_nodes.count
+    instance_type       = var.azure_worker_nodes.instance_type
+    azs                 = var.azure-use-azs ? var.azure_worker_nodes.azs : [""]
+    is_system_node_pool = var.azure_worker_nodes.is_system_node_pool
+  }
+
+  timeouts {
+    create = "60m"
+    delete = "60m"
+  }
+}

--- a/examples/tutorials/cluster-templates/data.tf
+++ b/examples/tutorials/cluster-templates/data.tf
@@ -1,0 +1,98 @@
+########################################
+# Data resources for the cluster profile
+########################################
+
+data "spectrocloud_registry" "public_registry" {
+  name = "Public Repo"
+}
+
+data "spectrocloud_registry" "community_registry" {
+  name = "Palette Community Registry"
+}
+
+#############
+# AWS
+#############
+
+data "spectrocloud_cloudaccount_aws" "account" {
+  count = var.deploy-aws ? 1 : 0
+  name  = var.aws-cloud-account-name
+}
+
+data "spectrocloud_pack" "aws_ubuntu" {
+  name         = "ubuntu-aws"
+  version      = "22.04"
+  registry_uid = data.spectrocloud_registry.public_registry.id
+}
+
+data "spectrocloud_pack" "aws_k8s" {
+  name         = "kubernetes"
+  version      = "1.35.2"
+  registry_uid = data.spectrocloud_registry.public_registry.id
+}
+
+data "spectrocloud_pack" "aws_cni" {
+  name         = "cni-calico"
+  version      = "3.31.4"
+  registry_uid = data.spectrocloud_registry.public_registry.id
+}
+
+data "spectrocloud_pack" "aws_csi" {
+  name         = "csi-aws-ebs"
+  version      = "1.59.0"
+  registry_uid = data.spectrocloud_registry.public_registry.id
+}
+
+#############
+# Azure
+#############
+
+data "spectrocloud_cloudaccount_azure" "account" {
+  count = var.deploy-azure ? 1 : 0
+  name  = var.azure-cloud-account-name
+}
+
+data "spectrocloud_pack" "azure_ubuntu" {
+  name         = "ubuntu-azure"
+  version      = "22.04"
+  registry_uid = data.spectrocloud_registry.public_registry.id
+}
+
+data "spectrocloud_pack" "azure_k8s" {
+  name         = "kubernetes"
+  version      = "1.35.2"
+  registry_uid = data.spectrocloud_registry.public_registry.id
+}
+
+data "spectrocloud_pack" "azure_cni" {
+  name         = "cni-calico-azure"
+  version      = "3.31.4"
+  registry_uid = data.spectrocloud_registry.public_registry.id
+}
+
+data "spectrocloud_pack" "azure_csi" {
+  name         = "csi-azure"
+  version      = "1.34.2"
+  registry_uid = data.spectrocloud_registry.public_registry.id
+}
+
+#####################
+# Hello Universe Pack
+#####################
+
+data "spectrocloud_pack" "hellouniverse" {
+  name         = "hello-universe"
+  version      = "1.3.0"
+  registry_uid = data.spectrocloud_registry.community_registry.id
+}
+
+###########
+# Kubecost
+###########
+
+data "spectrocloud_pack" "kubecost" {
+  count        = var.create_new_profile_version ? 1 : 0
+  name         = "cost-analyzer"
+  version      = "1.103.3"
+  registry_uid = data.spectrocloud_registry.community_registry.id
+}

--- a/examples/tutorials/cluster-templates/maintenance_policy.tf
+++ b/examples/tutorials/cluster-templates/maintenance_policy.tf
@@ -1,0 +1,10 @@
+resource "spectrocloud_cluster_config_policy" "maintenance" {
+  name    = "tf-maintenance-policy"
+  context = "project"
+
+  schedules {
+    name         = "weekly-sunday"
+    start_cron   = "0 0 * * SUN"
+    duration_hrs = 4
+  }
+}

--- a/examples/tutorials/cluster-templates/manifests/values-hello-universe.yaml
+++ b/examples/tutorials/cluster-templates/manifests/values-hello-universe.yaml
@@ -1,0 +1,13 @@
+pack:
+  content:
+    images:
+      - image: ghcr.io/spectrocloud/hello-universe:1.3.0
+
+manifests:
+  hello-universe:
+    images:
+      hellouniverse: ghcr.io/spectrocloud/hello-universe:1.3.0
+    apiEnabled: false
+    namespace: hello-universe
+    port: ${port}
+    replicas: "{{.spectro.var.app_replicas}}"

--- a/examples/tutorials/cluster-templates/providers.tf
+++ b/examples/tutorials/cluster-templates/providers.tf
@@ -1,0 +1,31 @@
+terraform {
+  required_providers {
+    spectrocloud = {
+      version = ">= 0.29.1"
+      source  = "spectrocloud/spectrocloud"
+    }
+
+    tls = {
+      source  = "hashicorp/tls"
+      version = "4.0.4"
+    }
+  }
+
+  required_version = ">= 1.9"
+}
+
+variable "sc_host" {
+  description = "The Palette API endpoint to connect to."
+  default     = "api.spectrocloud.com"
+}
+
+variable "sc_api_key" {
+  description = "Your Palette API key. Can also be set via the SPECTROCLOUD_APIKEY environment variable instead of this variable."
+  default     = null
+}
+
+provider "spectrocloud" {
+  host         = var.sc_host
+  api_key      = var.sc_api_key
+  project_name = var.palette-project
+}

--- a/examples/tutorials/cluster-templates/ssh-key.tf
+++ b/examples/tutorials/cluster-templates/ssh-key.tf
@@ -1,0 +1,9 @@
+###############
+# Azure SSH Key
+###############
+
+resource "tls_private_key" "tutorial_ssh_key_azure" {
+  count     = var.deploy-azure ? 1 : 0
+  algorithm = "RSA"
+  rsa_bits  = "4096"
+}

--- a/examples/tutorials/cluster-templates/terraform.template.tfvars
+++ b/examples/tutorials/cluster-templates/terraform.template.tfvars
@@ -1,0 +1,69 @@
+#####################
+# Palette Settings
+#####################
+palette-project = "Default" # The name of your project in Palette.
+
+##############################
+# Hello Universe Configuration
+##############################
+app_port = 8080 # The cluster port number on which the service will listen for incoming traffic.
+
+create_new_profile_version = false # Set to true to create cluster profile version 1.1.0 with Kubecost.
+
+update_template_profile_version = false # Set to true after profile v1.1.0 is created to update the cluster template.
+
+upgrade_now_timestamp = "" # Set to the current RFC3339 timestamp (for example, "2026-05-12T14:30:00Z") to trigger an immediate upgrade of all clusters launched from the template. Change the value each time you want to re-trigger an upgrade.
+
+###########################
+# AWS Deployment Settings
+############################
+deploy-aws = false # Set to true to deploy to AWS.
+
+aws-cloud-account-name = "REPLACE ME"
+aws-region             = "REPLACE ME"
+aws-key-pair-name      = "REPLACE ME"
+
+aws_control_plane_nodes = {
+  count              = "1"
+  control_plane      = true
+  instance_type      = "m4.2xlarge"
+  disk_size_gb       = "60"
+  availability_zones = ["REPLACE ME"]
+}
+
+aws_worker_nodes = {
+  count              = "1"
+  control_plane      = false
+  instance_type      = "m4.2xlarge"
+  disk_size_gb       = "60"
+  availability_zones = ["REPLACE ME"]
+}
+
+###########################
+# Azure Deployment Settings
+############################
+deploy-azure = false # Set to true to deploy to Azure.
+
+azure-cloud-account-name = "REPLACE ME"
+azure_subscription_id    = "REPLACE ME"
+azure_resource_group     = "REPLACE ME"
+azure-use-azs            = false
+azure-region             = "REPLACE ME"
+
+azure_control_plane_nodes = {
+  count               = "1"
+  control_plane       = true
+  instance_type       = "Standard_D4s_v5"
+  disk_size_gb        = "60"
+  azs                 = ["REPLACE ME"]
+  is_system_node_pool = false
+}
+
+azure_worker_nodes = {
+  count               = "1"
+  control_plane       = false
+  instance_type       = "Standard_D4s_v5"
+  disk_size_gb        = "60"
+  azs                 = ["REPLACE ME"]
+  is_system_node_pool = false
+}

--- a/examples/tutorials/cluster-templates/variables.tf
+++ b/examples/tutorials/cluster-templates/variables.tf
@@ -1,0 +1,224 @@
+#########
+# Palette
+#########
+
+variable "palette-project" {
+  description = "Palette project name"
+  type        = string
+
+  validation {
+    condition     = var.palette-project != ""
+    error_message = "Provide the correct Palette project."
+  }
+}
+
+#####################
+# Hello Universe
+#####################
+
+variable "app_port" {
+  type        = number
+  description = "The cluster port number on which the service will listen for incoming traffic."
+}
+
+variable "create_new_profile_version" {
+  type        = bool
+  description = "Create cluster profile version 1.1.0 with Kubecost added. Set to true after the initial clusters are deployed."
+  default     = false
+}
+
+variable "update_template_profile_version" {
+  type        = bool
+  description = "Update the cluster template to reference cluster profile version 1.1.0. Requires create_new_profile_version to be true and already applied."
+  default     = false
+}
+
+variable "upgrade_now_timestamp" {
+  type        = string
+  description = "RFC3339 timestamp that triggers an immediate upgrade on all template clusters when changed. Set a new timestamp to re-trigger the upgrade. Leave empty to skip."
+  default     = ""
+}
+
+#######
+# AWS
+#######
+
+variable "aws-cloud-account-name" {
+  type        = string
+  description = "The name of your AWS account as assigned in Palette."
+
+  validation {
+    condition     = var.deploy-aws ? var.aws-cloud-account-name != "REPLACE ME" && var.aws-cloud-account-name != "" : true
+    error_message = "Provide the correct AWS cloud account name."
+  }
+}
+
+variable "deploy-aws" {
+  type        = bool
+  description = "A flag for enabling a deployment on AWS."
+}
+
+variable "aws-region" {
+  type        = string
+  description = "AWS region."
+  default     = "us-east-1"
+
+  validation {
+    condition     = var.deploy-aws ? var.aws-region != "REPLACE ME" && var.aws-region != "" : true
+    error_message = "Provide the correct AWS region."
+  }
+}
+
+variable "aws-key-pair-name" {
+  type        = string
+  description = "The name of the AWS key pair to use for SSH access to the cluster."
+
+  validation {
+    condition     = var.deploy-aws ? var.aws-key-pair-name != "REPLACE ME" && var.aws-key-pair-name != "" : true
+    error_message = "Provide the correct AWS SSH key pair name."
+  }
+}
+
+variable "aws_control_plane_nodes" {
+  type = object({
+    count              = string
+    control_plane      = bool
+    instance_type      = string
+    disk_size_gb       = string
+    availability_zones = list(string)
+  })
+  default = {
+    count              = "1"
+    control_plane      = true
+    instance_type      = "m4.2xlarge"
+    disk_size_gb       = "60"
+    availability_zones = ["us-east-1a"]
+  }
+  description = "AWS control plane nodes configuration."
+
+  validation {
+    condition     = var.deploy-aws ? length(var.aws_control_plane_nodes.availability_zones) > 0 && !contains(var.aws_control_plane_nodes.availability_zones, "REPLACE ME") : true
+    error_message = "The availability_zones parameter must be set correctly"
+  }
+}
+
+variable "aws_worker_nodes" {
+  type = object({
+    count              = string
+    control_plane      = bool
+    instance_type      = string
+    disk_size_gb       = string
+    availability_zones = list(string)
+  })
+  default = {
+    count              = "1"
+    control_plane      = false
+    instance_type      = "m4.2xlarge"
+    disk_size_gb       = "60"
+    availability_zones = ["us-east-1a"]
+  }
+  description = "AWS worker nodes configuration."
+
+  validation {
+    condition     = var.deploy-aws ? length(var.aws_worker_nodes.availability_zones) > 0 && !contains(var.aws_worker_nodes.availability_zones, "REPLACE ME") : true
+    error_message = "The availability_zones parameter must be set correctly"
+  }
+}
+
+#########
+# Azure
+#########
+
+variable "azure-cloud-account-name" {
+  type        = string
+  description = "The name of your Azure account as assigned in Palette."
+  default     = ""
+
+  validation {
+    condition     = var.deploy-azure ? var.azure-cloud-account-name != "REPLACE ME" && var.azure-cloud-account-name != "" : true
+    error_message = "Provide the correct Azure cloud account name."
+  }
+}
+
+variable "deploy-azure" {
+  type        = bool
+  description = "A flag for enabling a deployment on Azure."
+}
+
+variable "azure_subscription_id" {
+  type        = string
+  description = "Azure subscription ID."
+  default     = ""
+
+  validation {
+    condition     = var.deploy-azure ? var.azure_subscription_id != "REPLACE ME" && var.azure_subscription_id != "" : true
+    error_message = "Provide the correct Azure subscription ID."
+  }
+}
+
+variable "azure_resource_group" {
+  type        = string
+  description = "Azure resource group."
+  default     = ""
+
+  validation {
+    condition     = var.deploy-azure ? var.azure_resource_group != "REPLACE ME" && var.azure_resource_group != "" : true
+    error_message = "Provide the correct Azure resource group name."
+  }
+}
+
+variable "azure-use-azs" {
+  type        = bool
+  description = "A flag for configuring whether to use Azure Availability Zones. Check if your Azure region supports availability zones by reviewing the [Azure Regions and Availability Zones](https://learn.microsoft.com/en-us/azure/reliability/availability-zones-service-support#azure-regions-with-availability-zone-support) resource."
+}
+
+variable "azure-region" {
+  type        = string
+  description = "Azure region."
+  default     = "eastus"
+
+  validation {
+    condition     = var.deploy-azure ? var.azure-region != "REPLACE ME" && var.azure-region != "" : true
+    error_message = "Provide the correct Azure region name."
+  }
+}
+
+variable "azure_control_plane_nodes" {
+  type = object({
+    count               = string
+    control_plane       = bool
+    instance_type       = string
+    disk_size_gb        = string
+    azs                 = list(string)
+    is_system_node_pool = bool
+  })
+  default = {
+    count               = "1"
+    control_plane       = true
+    instance_type       = "Standard_D4s_v5"
+    disk_size_gb        = "60"
+    azs                 = ["1"]
+    is_system_node_pool = false
+  }
+  description = "Azure control plane nodes configuration."
+}
+
+variable "azure_worker_nodes" {
+  type = object({
+    count               = string
+    control_plane       = bool
+    instance_type       = string
+    disk_size_gb        = string
+    azs                 = list(string)
+    is_system_node_pool = bool
+  })
+  default = {
+    count               = "1"
+    control_plane       = false
+    instance_type       = "Standard_D4s_v5"
+    disk_size_gb        = "60"
+    azs                 = ["1"]
+    is_system_node_pool = false
+  }
+  description = "Azure worker nodes configuration."
+}


### PR DESCRIPTION
Ports cluster-templates-tf from github.com/spectrocloud/tutorials into examples/tutorials/cluster-templates/, reshaped to this repo's file-naming convention.

Demonstrates spectrocloud_cluster_config_template and spectrocloud_cluster_config_policy to standardize dev/prod clusters on a shared, versioned cluster profile, then roll out an upgrade via upgrade_now once the template is pointed at a new profile version.

All attributes verified against the current provider schema, with extra scrutiny on cluster_config_template/cluster_config_policy since they are newer/less common resources - no drift found. terraform validate passes against the published provider.

Adaptations made during porting:
- No README existed in the source for this example; wrote one documenting the actual 4-step Day-2 workflow.
- Dropped an unused data.spectrocloud_project.current data source that was declared but never referenced anywhere in the source.

Covers PLT-2385 (port), PLT-2386 (README), and PLT-2387 (validation).