### PR TITLE
PLT-2394: Port cluster-profile-update tutorial example

### DIFF
--- a/examples/tutorials/README.md
+++ b/examples/tutorials/README.md
@@ -18,6 +18,6 @@ following [PORTING_CHECKLIST.md](PORTING_CHECKLIST.md).
 | [`cluster-templates/`](cluster-templates) | [Standardize Clusters with Cluster Templates (Terraform)](https://docs.spectrocloud.com/tutorials/clusters/cluster-templates/standardize-clusters-with-cluster-templates-terraform/) | Done |
 | [`pcg-vmware-app/`](pcg-vmware-app) | [Deploy App Workloads with a PCG](https://docs.spectrocloud.com/tutorials/clusters/pcg/deploy-app-pcg/) | Planned |
 | [`pde-virtual-cluster-app/`](pde-virtual-cluster-app) | [Deploy an Application using Palette Dev Engine](https://docs.spectrocloud.com/tutorials/pde/deploy-app/) | Planned |
-| [`cluster-profile-update/`](cluster-profile-update) | [Deploy Cluster Profile Updates](https://docs.spectrocloud.com/tutorials/profiles/update-k8s-cluster/) | Planned |
+| [`cluster-profile-update/`](cluster-profile-update) | [Deploy Cluster Profile Updates](https://docs.spectrocloud.com/tutorials/profiles/update-k8s-cluster/) | Done |
 
 This table will be kept current as each example is ported and validated against the current provider build.

--- a/examples/tutorials/cluster-profile-update/README.md
+++ b/examples/tutorials/cluster-profile-update/README.md
@@ -1,0 +1,55 @@
+# Cluster profile update tutorial example
+
+End-to-end example accompanying the Spectro Cloud tutorial
+[Deploy Cluster Profile Updates](https://docs.spectrocloud.com/tutorials/profiles/update-k8s-cluster/).
+
+This is a day-2 operations example: it deploys a two-cluster application (a Hello Universe frontend and
+a separate hello-universe-api backend) per enabled cloud, then shows how to roll the frontend cluster
+forward to a new cluster profile version — via Terraform, in place — once the backend's address is known.
+It provisions, per enabled cloud (AWS, Azure, and/or GCP):
+- A frontend cluster profile (version `1.0.0`: OS, Kubernetes, CNI, CSI, plus the standalone Hello
+  Universe UI) and cluster
+- A backend cluster profile (OS, Kubernetes, CNI, CSI, plus the hello-universe-api + database manifests)
+  and cluster
+- A local kubeconfig file for the backend cluster, so you can query its load balancer address
+
+## The Day-2 workflow this demonstrates
+
+1. **Initial deploy:** with `update_profile_version = false` (default), `terraform apply` deploys both
+   the frontend cluster (profile v1.0.0, standalone UI) and the backend cluster for each enabled cloud.
+2. **Find the backend's address:** export the generated kubeconfig and query the backend's load balancer,
+   per the `<cloud>_hello_universe_api_ip` output shown after apply (for example
+   `export KUBECONFIG=$(pwd)/aws-cluster-api.kubeconfig && kubectl get service hello-universe-api-service --namespace hello-universe-api -o jsonpath='{.status.loadBalancer.ingress[0].hostname}'`).
+3. **Point the frontend at the backend:** set the matching `<cloud>-hello-universe-api-uri` variable to
+   that address.
+4. **Roll the frontend forward:** set `update_profile_version = true` and re-apply. This creates cluster
+   profile version `1.1.0` (the same packs, plus the Hello Universe manifest updated with an `API_URI`
+   environment variable) and updates the frontend cluster in place to use it — no cluster recreation.
+
+## Prerequisites
+
+You will need the following before getting started:
+1. A Palette API key, exported as the `SPECTROCLOUD_APIKEY` environment variable (or supplied via the
+   `sc_api_key` variable).
+2. A cloud account already registered in your Palette project settings for each cloud you enable.
+3. For AWS: an existing EC2 key pair in the region you deploy to.
+4. `kubectl` installed locally, to query the backend cluster's load balancer address.
+
+## Instructions
+
+Clone this repository to a local directory, and change directory to
+`examples/tutorials/cluster-profile-update`. Proceed with the following:
+1. From the current directory, copy the template variable file `terraform.template.tfvars` to a new
+   file `terraform.tfvars`.
+2. Set the `deploy-<cloud>` toggle(s) for the cloud(s) you want, and fill in the placeholder
+   (`REPLACE_ME`) values relevant to those clouds.
+3. Initialize and run terraform: `terraform init && terraform apply`.
+4. Walk through the Day-2 workflow above to point the frontend at the backend and roll it forward.
+
+## Clean up
+
+Run the destroy operation:
+
+```shell
+terraform destroy
+```

--- a/examples/tutorials/cluster-profile-update/cluster_profiles.tf
+++ b/examples/tutorials/cluster-profile-update/cluster_profiles.tf
@@ -1,0 +1,468 @@
+#########################
+# AWS Cluster Profile
+#########################
+resource "spectrocloud_cluster_profile" "aws-profile" {
+  count = var.deploy-aws ? 1 : 0
+
+  name        = "tf-aws-profile"
+  description = "A basic cluster profile for AWS"
+  tags        = concat(var.tags, ["env:aws"])
+  cloud       = "aws"
+  type        = "cluster"
+  version     = "1.0.0"
+
+  pack {
+    name   = data.spectrocloud_pack.aws_ubuntu.name
+    tag    = data.spectrocloud_pack.aws_ubuntu.version
+    uid    = data.spectrocloud_pack.aws_ubuntu.id
+    values = data.spectrocloud_pack.aws_ubuntu.values
+  }
+
+  pack {
+    name   = data.spectrocloud_pack.aws_k8s.name
+    tag    = data.spectrocloud_pack.aws_k8s.version
+    uid    = data.spectrocloud_pack.aws_k8s.id
+    values = data.spectrocloud_pack.aws_k8s.values
+  }
+
+  pack {
+    name   = data.spectrocloud_pack.aws_cni.name
+    tag    = data.spectrocloud_pack.aws_cni.version
+    uid    = data.spectrocloud_pack.aws_cni.id
+    values = data.spectrocloud_pack.aws_cni.values
+  }
+
+  pack {
+    name   = data.spectrocloud_pack.aws_csi.name
+    tag    = data.spectrocloud_pack.aws_csi.version
+    uid    = data.spectrocloud_pack.aws_csi.id
+    values = data.spectrocloud_pack.aws_csi.values
+  }
+
+  pack {
+    name   = "hello-universe"
+    type   = "manifest"
+    tag    = "1.0.0"
+    values = ""
+    manifest {
+      name    = "hello-universe"
+      content = file("manifests/hello-universe.yaml")
+    }
+  }
+}
+
+# Day-2 update: same profile, version 1.1.0, with the Hello Universe frontend calling out to the
+# hello-universe-api backend. Activated by setting update_profile_version = true (see clusters.tf).
+resource "spectrocloud_cluster_profile" "aws-profile-3tier" {
+  count = (var.deploy-aws && var.update_profile_version) ? 1 : 0
+
+  name        = "tf-aws-profile"
+  description = "A basic cluster profile for AWS"
+  tags        = concat(var.tags, ["env:aws"])
+  cloud       = "aws"
+  type        = "cluster"
+  version     = "1.1.0"
+
+  pack {
+    name   = data.spectrocloud_pack.aws_ubuntu.name
+    tag    = data.spectrocloud_pack.aws_ubuntu.version
+    uid    = data.spectrocloud_pack.aws_ubuntu.id
+    values = data.spectrocloud_pack.aws_ubuntu.values
+  }
+
+  pack {
+    name   = data.spectrocloud_pack.aws_k8s.name
+    tag    = data.spectrocloud_pack.aws_k8s.version
+    uid    = data.spectrocloud_pack.aws_k8s.id
+    values = data.spectrocloud_pack.aws_k8s.values
+  }
+
+  pack {
+    name   = data.spectrocloud_pack.aws_cni.name
+    tag    = data.spectrocloud_pack.aws_cni.version
+    uid    = data.spectrocloud_pack.aws_cni.id
+    values = data.spectrocloud_pack.aws_cni.values
+  }
+
+  pack {
+    name   = data.spectrocloud_pack.aws_csi.name
+    tag    = data.spectrocloud_pack.aws_csi.version
+    uid    = data.spectrocloud_pack.aws_csi.id
+    values = data.spectrocloud_pack.aws_csi.values
+  }
+
+  pack {
+    name   = "hello-universe"
+    type   = "manifest"
+    tag    = "1.0.0"
+    values = ""
+    manifest {
+      name = "hello-universe"
+      content = templatefile("manifests/hello-universe-3tier.yaml", {
+        api_uri = var.aws-hello-universe-api-uri
+      })
+    }
+  }
+}
+
+resource "spectrocloud_cluster_profile" "aws-profile-api" {
+  count = var.deploy-aws ? 1 : 0
+
+  name        = "tf-aws-profile-api"
+  description = "A basic cluster profile for AWS"
+  tags        = concat(var.tags, ["env:aws"])
+  cloud       = "aws"
+  type        = "cluster"
+
+  pack {
+    name   = data.spectrocloud_pack.aws_ubuntu.name
+    tag    = data.spectrocloud_pack.aws_ubuntu.version
+    uid    = data.spectrocloud_pack.aws_ubuntu.id
+    values = data.spectrocloud_pack.aws_ubuntu.values
+  }
+
+  pack {
+    name   = data.spectrocloud_pack.aws_k8s.name
+    tag    = data.spectrocloud_pack.aws_k8s.version
+    uid    = data.spectrocloud_pack.aws_k8s.id
+    values = data.spectrocloud_pack.aws_k8s.values
+  }
+
+  pack {
+    name   = data.spectrocloud_pack.aws_cni.name
+    tag    = data.spectrocloud_pack.aws_cni.version
+    uid    = data.spectrocloud_pack.aws_cni.id
+    values = data.spectrocloud_pack.aws_cni.values
+  }
+
+  pack {
+    name   = data.spectrocloud_pack.aws_csi.name
+    tag    = data.spectrocloud_pack.aws_csi.version
+    uid    = data.spectrocloud_pack.aws_csi.id
+    values = data.spectrocloud_pack.aws_csi.values
+  }
+
+  pack {
+    name   = "hello-universe-api"
+    type   = "manifest"
+    tag    = "1.0.0"
+    values = ""
+    manifest {
+      name    = "hello-universe-api"
+      content = file("manifests/hello-universe-api.yaml")
+    }
+  }
+}
+
+#########################
+# Azure Cluster Profile
+#########################
+resource "spectrocloud_cluster_profile" "azure-profile" {
+  count = var.deploy-azure ? 1 : 0
+
+  name        = "tf-azure-profile"
+  description = "A basic cluster profile for Azure"
+  tags        = concat(var.tags, ["env:azure"])
+  cloud       = "azure"
+  type        = "cluster"
+  version     = "1.0.0"
+
+  pack {
+    name   = data.spectrocloud_pack.azure_ubuntu.name
+    tag    = data.spectrocloud_pack.azure_ubuntu.version
+    uid    = data.spectrocloud_pack.azure_ubuntu.id
+    values = data.spectrocloud_pack.azure_ubuntu.values
+  }
+
+  pack {
+    name   = data.spectrocloud_pack.azure_k8s.name
+    tag    = data.spectrocloud_pack.azure_k8s.version
+    uid    = data.spectrocloud_pack.azure_k8s.id
+    values = data.spectrocloud_pack.azure_k8s.values
+  }
+
+  pack {
+    name   = data.spectrocloud_pack.azure_cni.name
+    tag    = data.spectrocloud_pack.azure_cni.version
+    uid    = data.spectrocloud_pack.azure_cni.id
+    values = data.spectrocloud_pack.azure_cni.values
+  }
+
+  pack {
+    name   = data.spectrocloud_pack.azure_csi.name
+    tag    = data.spectrocloud_pack.azure_csi.version
+    uid    = data.spectrocloud_pack.azure_csi.id
+    values = data.spectrocloud_pack.azure_csi.values
+  }
+
+  pack {
+    name   = "hello-universe"
+    type   = "manifest"
+    tag    = "1.0.0"
+    values = ""
+    manifest {
+      name    = "hello-universe"
+      content = file("manifests/hello-universe.yaml")
+    }
+  }
+}
+
+# Day-2 update: same profile, version 1.1.0, with the Hello Universe frontend calling out to the
+# hello-universe-api backend. Activated by setting update_profile_version = true (see clusters.tf).
+resource "spectrocloud_cluster_profile" "azure-profile-3tier" {
+  count = (var.deploy-azure && var.update_profile_version) ? 1 : 0
+
+  name        = "tf-azure-profile"
+  description = "A basic cluster profile for Azure"
+  tags        = concat(var.tags, ["env:azure"])
+  cloud       = "azure"
+  type        = "cluster"
+  version     = "1.1.0"
+
+  pack {
+    name   = data.spectrocloud_pack.azure_ubuntu.name
+    tag    = data.spectrocloud_pack.azure_ubuntu.version
+    uid    = data.spectrocloud_pack.azure_ubuntu.id
+    values = data.spectrocloud_pack.azure_ubuntu.values
+  }
+
+  pack {
+    name   = data.spectrocloud_pack.azure_k8s.name
+    tag    = data.spectrocloud_pack.azure_k8s.version
+    uid    = data.spectrocloud_pack.azure_k8s.id
+    values = data.spectrocloud_pack.azure_k8s.values
+  }
+
+  pack {
+    name   = data.spectrocloud_pack.azure_cni.name
+    tag    = data.spectrocloud_pack.azure_cni.version
+    uid    = data.spectrocloud_pack.azure_cni.id
+    values = data.spectrocloud_pack.azure_cni.values
+  }
+
+  pack {
+    name   = data.spectrocloud_pack.azure_csi.name
+    tag    = data.spectrocloud_pack.azure_csi.version
+    uid    = data.spectrocloud_pack.azure_csi.id
+    values = data.spectrocloud_pack.azure_csi.values
+  }
+
+  pack {
+    name   = "hello-universe"
+    type   = "manifest"
+    tag    = "1.0.0"
+    values = ""
+    manifest {
+      name = "hello-universe"
+      content = templatefile("manifests/hello-universe-3tier.yaml", {
+        api_uri = var.azure-hello-universe-api-uri
+      })
+    }
+  }
+}
+
+resource "spectrocloud_cluster_profile" "azure-profile-api" {
+  count = var.deploy-azure ? 1 : 0
+
+  name        = "tf-azure-profile-api"
+  description = "A basic cluster profile for Azure"
+  tags        = concat(var.tags, ["env:azure"])
+  cloud       = "azure"
+  type        = "cluster"
+
+  pack {
+    name   = data.spectrocloud_pack.azure_ubuntu.name
+    tag    = data.spectrocloud_pack.azure_ubuntu.version
+    uid    = data.spectrocloud_pack.azure_ubuntu.id
+    values = data.spectrocloud_pack.azure_ubuntu.values
+  }
+
+  pack {
+    name   = data.spectrocloud_pack.azure_k8s.name
+    tag    = data.spectrocloud_pack.azure_k8s.version
+    uid    = data.spectrocloud_pack.azure_k8s.id
+    values = data.spectrocloud_pack.azure_k8s.values
+  }
+
+  pack {
+    name   = data.spectrocloud_pack.azure_cni.name
+    tag    = data.spectrocloud_pack.azure_cni.version
+    uid    = data.spectrocloud_pack.azure_cni.id
+    values = data.spectrocloud_pack.azure_cni.values
+  }
+
+  pack {
+    name   = data.spectrocloud_pack.azure_csi.name
+    tag    = data.spectrocloud_pack.azure_csi.version
+    uid    = data.spectrocloud_pack.azure_csi.id
+    values = data.spectrocloud_pack.azure_csi.values
+  }
+
+  pack {
+    name   = "hello-universe-api"
+    type   = "manifest"
+    tag    = "1.0.0"
+    values = ""
+    manifest {
+      name    = "hello-universe-api"
+      content = file("manifests/hello-universe-api.yaml")
+    }
+  }
+}
+
+
+#########################
+# GCP Cluster Profile
+#########################
+resource "spectrocloud_cluster_profile" "gcp-profile" {
+  count = var.deploy-gcp ? 1 : 0
+
+  name        = "tf-gcp-profile"
+  description = "A basic cluster profile for GCP"
+  tags        = concat(var.tags, ["env:gcp"])
+  cloud       = "gcp"
+  type        = "cluster"
+  version     = "1.0.0"
+
+  pack {
+    name   = data.spectrocloud_pack.gcp_ubuntu.name
+    tag    = data.spectrocloud_pack.gcp_ubuntu.version
+    uid    = data.spectrocloud_pack.gcp_ubuntu.id
+    values = data.spectrocloud_pack.gcp_ubuntu.values
+  }
+
+  pack {
+    name   = data.spectrocloud_pack.gcp_k8s.name
+    tag    = data.spectrocloud_pack.gcp_k8s.version
+    uid    = data.spectrocloud_pack.gcp_k8s.id
+    values = data.spectrocloud_pack.gcp_k8s.values
+  }
+
+  pack {
+    name   = data.spectrocloud_pack.gcp_cni.name
+    tag    = data.spectrocloud_pack.gcp_cni.version
+    uid    = data.spectrocloud_pack.gcp_cni.id
+    values = data.spectrocloud_pack.gcp_cni.values
+  }
+
+  pack {
+    name   = data.spectrocloud_pack.gcp_csi.name
+    tag    = data.spectrocloud_pack.gcp_csi.version
+    uid    = data.spectrocloud_pack.gcp_csi.id
+    values = data.spectrocloud_pack.gcp_csi.values
+  }
+
+  pack {
+    name   = "hello-universe"
+    type   = "manifest"
+    tag    = "1.0.0"
+    values = ""
+    manifest {
+      name    = "hello-universe"
+      content = file("manifests/hello-universe.yaml")
+    }
+  }
+}
+
+# Day-2 update: same profile, version 1.1.0, with the Hello Universe frontend calling out to the
+# hello-universe-api backend. Activated by setting update_profile_version = true (see clusters.tf).
+resource "spectrocloud_cluster_profile" "gcp-profile-3tier" {
+  count = (var.deploy-gcp && var.update_profile_version) ? 1 : 0
+
+  name        = "tf-gcp-profile"
+  description = "A basic cluster profile for GCP"
+  tags        = concat(var.tags, ["env:gcp"])
+  cloud       = "gcp"
+  type        = "cluster"
+  version     = "1.1.0"
+
+  pack {
+    name   = data.spectrocloud_pack.gcp_ubuntu.name
+    tag    = data.spectrocloud_pack.gcp_ubuntu.version
+    uid    = data.spectrocloud_pack.gcp_ubuntu.id
+    values = data.spectrocloud_pack.gcp_ubuntu.values
+  }
+
+  pack {
+    name   = data.spectrocloud_pack.gcp_k8s.name
+    tag    = data.spectrocloud_pack.gcp_k8s.version
+    uid    = data.spectrocloud_pack.gcp_k8s.id
+    values = data.spectrocloud_pack.gcp_k8s.values
+  }
+
+  pack {
+    name   = data.spectrocloud_pack.gcp_cni.name
+    tag    = data.spectrocloud_pack.gcp_cni.version
+    uid    = data.spectrocloud_pack.gcp_cni.id
+    values = data.spectrocloud_pack.gcp_cni.values
+  }
+
+  pack {
+    name   = data.spectrocloud_pack.gcp_csi.name
+    tag    = data.spectrocloud_pack.gcp_csi.version
+    uid    = data.spectrocloud_pack.gcp_csi.id
+    values = data.spectrocloud_pack.gcp_csi.values
+  }
+
+  pack {
+    name   = "hello-universe"
+    type   = "manifest"
+    tag    = "1.0.0"
+    values = ""
+    manifest {
+      name = "hello-universe"
+      content = templatefile("manifests/hello-universe-3tier.yaml", {
+        api_uri = var.gcp-hello-universe-api-uri
+      })
+    }
+  }
+}
+
+resource "spectrocloud_cluster_profile" "gcp-profile-api" {
+  count = var.deploy-gcp ? 1 : 0
+
+  name        = "tf-gcp-profile-api"
+  description = "A basic cluster profile for GCP"
+  tags        = concat(var.tags, ["env:gcp"])
+  cloud       = "gcp"
+  type        = "cluster"
+
+  pack {
+    name   = data.spectrocloud_pack.gcp_ubuntu.name
+    tag    = data.spectrocloud_pack.gcp_ubuntu.version
+    uid    = data.spectrocloud_pack.gcp_ubuntu.id
+    values = data.spectrocloud_pack.gcp_ubuntu.values
+  }
+
+  pack {
+    name   = data.spectrocloud_pack.gcp_k8s.name
+    tag    = data.spectrocloud_pack.gcp_k8s.version
+    uid    = data.spectrocloud_pack.gcp_k8s.id
+    values = data.spectrocloud_pack.gcp_k8s.values
+  }
+
+  pack {
+    name   = data.spectrocloud_pack.gcp_cni.name
+    tag    = data.spectrocloud_pack.gcp_cni.version
+    uid    = data.spectrocloud_pack.gcp_cni.id
+    values = data.spectrocloud_pack.gcp_cni.values
+  }
+
+  pack {
+    name   = data.spectrocloud_pack.gcp_csi.name
+    tag    = data.spectrocloud_pack.gcp_csi.version
+    uid    = data.spectrocloud_pack.gcp_csi.id
+    values = data.spectrocloud_pack.gcp_csi.values
+  }
+
+  pack {
+    name   = "hello-universe-api"
+    type   = "manifest"
+    tag    = "1.0.0"
+    values = ""
+    manifest {
+      name    = "hello-universe-api"
+      content = file("manifests/hello-universe-api.yaml")
+    }
+  }
+}

--- a/examples/tutorials/cluster-profile-update/clusters.tf
+++ b/examples/tutorials/cluster-profile-update/clusters.tf
@@ -1,0 +1,287 @@
+#########################
+# AWS Cluster Profile
+########################
+resource "spectrocloud_cluster_aws" "aws-cluster" {
+  count = var.deploy-aws ? 1 : 0
+
+  name             = "aws-cluster"
+  tags             = concat(var.tags, ["env:aws", "service:hello-universe-frontend"])
+  cloud_account_id = data.spectrocloud_cloudaccount_aws.account[0].id
+
+  cloud_config {
+    region       = var.aws-region
+    ssh_key_name = var.aws-key-pair-name
+  }
+
+  cluster_profile {
+    id = var.update_profile_version ? spectrocloud_cluster_profile.aws-profile-3tier[0].id : spectrocloud_cluster_profile.aws-profile[0].id
+  }
+
+  machine_pool {
+    control_plane           = true
+    control_plane_as_worker = true
+    name                    = "control-pane-pool"
+    count                   = var.aws_control_plane_nodes.count
+    instance_type           = var.aws_control_plane_nodes.instance_type
+    disk_size_gb            = var.aws_control_plane_nodes.disk_size_gb
+    azs                     = var.aws_control_plane_nodes.availability_zones
+  }
+
+  machine_pool {
+    name          = "worker-pool"
+    count         = var.aws_worker_nodes.count
+    instance_type = var.aws_worker_nodes.instance_type
+    disk_size_gb  = var.aws_worker_nodes.disk_size_gb
+    azs           = var.aws_worker_nodes.availability_zones
+  }
+
+  timeouts {
+    create = "30m"
+    delete = "15m"
+  }
+}
+
+resource "spectrocloud_cluster_aws" "aws-cluster-api" {
+  count = var.deploy-aws ? 1 : 0
+
+  name             = "aws-cluster-api"
+  tags             = concat(var.tags, ["env:aws", "service:hello-universe-backend"])
+  cloud_account_id = data.spectrocloud_cloudaccount_aws.account[0].id
+
+  cloud_config {
+    region       = var.aws-region
+    ssh_key_name = var.aws-key-pair-name
+  }
+
+  cluster_profile {
+    id = spectrocloud_cluster_profile.aws-profile-api[0].id
+  }
+
+  machine_pool {
+    control_plane           = true
+    control_plane_as_worker = true
+    name                    = "control-pane-pool"
+    count                   = var.aws_control_plane_nodes.count
+    instance_type           = var.aws_control_plane_nodes.instance_type
+    disk_size_gb            = var.aws_control_plane_nodes.disk_size_gb
+    azs                     = var.aws_control_plane_nodes.availability_zones
+  }
+
+  machine_pool {
+    name          = "worker-pool"
+    count         = var.aws_worker_nodes.count
+    instance_type = var.aws_worker_nodes.instance_type
+    disk_size_gb  = var.aws_worker_nodes.disk_size_gb
+    azs           = var.aws_worker_nodes.availability_zones
+  }
+
+  timeouts {
+    create = "30m"
+    delete = "15m"
+  }
+}
+
+resource "local_file" "aws-kubeconfig" {
+  count = var.deploy-aws ? 1 : 0
+
+  content              = data.spectrocloud_cluster.aws_cluster_api[0].kube_config
+  filename             = "aws-cluster-api.kubeconfig"
+  file_permission      = "0644"
+  directory_permission = "0755"
+}
+
+#########################
+# Azure Cluster Profile
+#########################
+resource "spectrocloud_cluster_azure" "azure-cluster" {
+  count = var.deploy-azure ? 1 : 0
+
+  name             = "azure-cluster"
+  tags             = concat(var.tags, ["env:azure", "service:hello-universe-frontend"])
+  cloud_account_id = data.spectrocloud_cloudaccount_azure.account[0].id
+
+  cloud_config {
+    subscription_id = var.azure_subscription_id
+    resource_group  = var.azure_resource_group
+    region          = var.azure-region
+    ssh_key         = tls_private_key.tutorial_ssh_key[0].public_key_openssh
+  }
+
+  cluster_profile {
+    id = var.update_profile_version ? spectrocloud_cluster_profile.azure-profile-3tier[0].id : spectrocloud_cluster_profile.azure-profile[0].id
+  }
+
+  machine_pool {
+    control_plane           = true
+    control_plane_as_worker = true
+    name                    = "control-pane-pool"
+    count                   = var.azure_control_plane_nodes.count
+    instance_type           = var.azure_control_plane_nodes.instance_type
+    azs                     = var.azure-use-azs ? var.azure_control_plane_nodes.azs : [""]
+    is_system_node_pool     = var.azure_control_plane_nodes.is_system_node_pool
+    disk {
+      size_gb = var.azure_control_plane_nodes.disk_size_gb
+      type    = "Standard_LRS"
+    }
+  }
+
+  machine_pool {
+    name                = "worker-basic"
+    count               = var.azure_worker_nodes.count
+    instance_type       = var.azure_worker_nodes.instance_type
+    azs                 = var.azure-use-azs ? var.azure_worker_nodes.azs : [""]
+    is_system_node_pool = var.azure_worker_nodes.is_system_node_pool
+  }
+
+  timeouts {
+    create = "30m"
+    delete = "15m"
+  }
+}
+
+resource "spectrocloud_cluster_azure" "azure-cluster-api" {
+  count = var.deploy-azure ? 1 : 0
+
+  name             = "azure-cluster-api"
+  tags             = concat(var.tags, ["env:azure", "service:hello-universe-backend"])
+  cloud_account_id = data.spectrocloud_cloudaccount_azure.account[0].id
+
+  cloud_config {
+    subscription_id = var.azure_subscription_id
+    resource_group  = var.azure_resource_group
+    region          = var.azure-region
+    ssh_key         = tls_private_key.tutorial_ssh_key[0].public_key_openssh
+  }
+
+  cluster_profile {
+    id = spectrocloud_cluster_profile.azure-profile-api[0].id
+  }
+
+  machine_pool {
+    control_plane           = true
+    control_plane_as_worker = true
+    name                    = "control-pane-pool"
+    count                   = var.azure_control_plane_nodes.count
+    instance_type           = var.azure_control_plane_nodes.instance_type
+    azs                     = var.azure-use-azs ? var.azure_control_plane_nodes.azs : [""]
+    is_system_node_pool     = var.azure_control_plane_nodes.is_system_node_pool
+    disk {
+      size_gb = var.azure_control_plane_nodes.disk_size_gb
+      type    = "Standard_LRS"
+    }
+  }
+
+  machine_pool {
+    name                = "worker-basic"
+    count               = var.azure_worker_nodes.count
+    instance_type       = var.azure_worker_nodes.instance_type
+    azs                 = var.azure-use-azs ? var.azure_worker_nodes.azs : [""]
+    is_system_node_pool = var.azure_worker_nodes.is_system_node_pool
+  }
+
+  timeouts {
+    create = "30m"
+    delete = "15m"
+  }
+}
+
+resource "local_file" "azure-kubeconfig" {
+  count = var.deploy-azure ? 1 : 0
+
+  content              = data.spectrocloud_cluster.azure_cluster_api[0].kube_config
+  filename             = "azure-cluster-api.kubeconfig"
+  file_permission      = "0644"
+  directory_permission = "0755"
+}
+
+#########################
+# GCP Cluster Profile
+#########################
+resource "spectrocloud_cluster_gcp" "gcp-cluster" {
+  count = var.deploy-gcp ? 1 : 0
+
+  name             = "gcp-cluster"
+  tags             = concat(var.tags, ["env:gcp", "service:hello-universe-frontend"])
+  cloud_account_id = data.spectrocloud_cloudaccount_gcp.account[0].id
+
+  cloud_config {
+    project = var.gcp_project_name
+    region  = var.gcp-region
+  }
+
+  cluster_profile {
+    id = var.update_profile_version ? spectrocloud_cluster_profile.gcp-profile-3tier[0].id : spectrocloud_cluster_profile.gcp-profile[0].id
+  }
+
+  machine_pool {
+    control_plane           = true
+    control_plane_as_worker = true
+    name                    = "control-pane-pool"
+    count                   = var.gcp_control_plane_nodes.count
+    instance_type           = var.gcp_control_plane_nodes.instance_type
+    disk_size_gb            = var.gcp_control_plane_nodes.disk_size_gb
+    azs                     = var.gcp_control_plane_nodes.availability_zones
+  }
+
+  machine_pool {
+    name          = "worker-pool"
+    count         = var.gcp_worker_nodes.count
+    instance_type = var.gcp_worker_nodes.instance_type
+    disk_size_gb  = var.gcp_worker_nodes.disk_size_gb
+    azs           = var.gcp_worker_nodes.availability_zones
+  }
+
+  timeouts {
+    create = "30m"
+    delete = "15m"
+  }
+}
+
+resource "spectrocloud_cluster_gcp" "gcp-cluster-api" {
+  count = var.deploy-gcp ? 1 : 0
+
+  name             = "gcp-cluster-api"
+  tags             = concat(var.tags, ["env:gcp", "service:hello-universe-backend"])
+  cloud_account_id = data.spectrocloud_cloudaccount_gcp.account[0].id
+
+  cloud_config {
+    project = var.gcp_project_name
+    region  = var.gcp-region
+  }
+
+  cluster_profile {
+    id = spectrocloud_cluster_profile.gcp-profile-api[0].id
+  }
+
+  machine_pool {
+    control_plane           = true
+    control_plane_as_worker = true
+    name                    = "control-plane-pool"
+    count                   = var.gcp_control_plane_nodes.count
+    instance_type           = var.gcp_control_plane_nodes.instance_type
+    disk_size_gb            = var.gcp_control_plane_nodes.disk_size_gb
+    azs                     = var.gcp_control_plane_nodes.availability_zones
+  }
+
+  machine_pool {
+    name          = "worker-pool"
+    count         = var.gcp_worker_nodes.count
+    instance_type = var.gcp_worker_nodes.instance_type
+    disk_size_gb  = var.gcp_worker_nodes.disk_size_gb
+    azs           = var.gcp_worker_nodes.availability_zones
+  }
+
+  timeouts {
+    create = "30m"
+    delete = "15m"
+  }
+}
+
+resource "local_file" "gcp-kubeconfig" {
+  count = var.deploy-gcp ? 1 : 0
+
+  content              = data.spectrocloud_cluster.gcp_cluster_api[0].kube_config
+  filename             = "gcp-cluster-api.kubeconfig"
+  file_permission      = "0644"
+  directory_permission = "0755"
+}

--- a/examples/tutorials/cluster-profile-update/data.tf
+++ b/examples/tutorials/cluster-profile-update/data.tf
@@ -1,0 +1,129 @@
+####################################
+# Data resources for the profile
+####################################
+data "spectrocloud_registry" "public_registry" {
+  name = "Public Repo"
+}
+
+#############
+# AWS
+#############
+data "spectrocloud_cloudaccount_aws" "account" {
+  count = var.deploy-aws ? 1 : 0
+  name  = var.aws-cloud-account-name
+}
+
+data "spectrocloud_pack" "aws_csi" {
+  name         = "csi-aws-ebs"
+  version      = "1.41.0"
+  registry_uid = data.spectrocloud_registry.public_registry.id
+}
+
+data "spectrocloud_pack" "aws_cni" {
+  name         = "cni-calico"
+  version      = "3.29.3"
+  registry_uid = data.spectrocloud_registry.public_registry.id
+}
+
+data "spectrocloud_pack" "aws_k8s" {
+  name         = "kubernetes"
+  version      = "1.32.3"
+  registry_uid = data.spectrocloud_registry.public_registry.id
+}
+
+data "spectrocloud_pack" "aws_ubuntu" {
+  name         = "ubuntu-aws"
+  version      = "22.04"
+  registry_uid = data.spectrocloud_registry.public_registry.id
+}
+
+data "spectrocloud_cluster" "aws_cluster_api" {
+  count = var.deploy-aws ? 1 : 0
+
+  name    = "aws-cluster-api"
+  context = "project"
+
+  depends_on = [spectrocloud_cluster_aws.aws-cluster-api]
+}
+
+#############
+# Azure
+#############
+data "spectrocloud_cloudaccount_azure" "account" {
+  count = var.deploy-azure ? 1 : 0
+  name  = var.azure-cloud-account-name
+}
+
+data "spectrocloud_pack" "azure_csi" {
+  name         = "csi-azure"
+  version      = "1.32.0"
+  registry_uid = data.spectrocloud_registry.public_registry.id
+}
+
+data "spectrocloud_pack" "azure_cni" {
+  name         = "cni-calico-azure"
+  version      = "3.29.3"
+  registry_uid = data.spectrocloud_registry.public_registry.id
+}
+
+data "spectrocloud_pack" "azure_k8s" {
+  name         = "kubernetes"
+  version      = "1.32.3"
+  registry_uid = data.spectrocloud_registry.public_registry.id
+}
+
+data "spectrocloud_pack" "azure_ubuntu" {
+  name         = "ubuntu-azure"
+  version      = "22.04"
+  registry_uid = data.spectrocloud_registry.public_registry.id
+}
+
+data "spectrocloud_cluster" "azure_cluster_api" {
+  count = var.deploy-azure ? 1 : 0
+
+  name    = "azure-cluster-api"
+  context = "project"
+
+  depends_on = [spectrocloud_cluster_azure.azure-cluster-api]
+}
+
+#############
+# GCP
+#############
+data "spectrocloud_cloudaccount_gcp" "account" {
+  count = var.deploy-gcp ? 1 : 0
+  name  = var.gcp-cloud-account-name
+}
+
+data "spectrocloud_pack" "gcp_csi" {
+  name         = "csi-gcp-driver"
+  version      = "1.15.4"
+  registry_uid = data.spectrocloud_registry.public_registry.id
+}
+
+data "spectrocloud_pack" "gcp_cni" {
+  name         = "cni-calico"
+  version      = "3.29.3"
+  registry_uid = data.spectrocloud_registry.public_registry.id
+}
+
+data "spectrocloud_pack" "gcp_k8s" {
+  name         = "kubernetes"
+  version      = "1.32.3"
+  registry_uid = data.spectrocloud_registry.public_registry.id
+}
+
+data "spectrocloud_pack" "gcp_ubuntu" {
+  name         = "ubuntu-gcp"
+  version      = "22.04"
+  registry_uid = data.spectrocloud_registry.public_registry.id
+}
+
+data "spectrocloud_cluster" "gcp_cluster_api" {
+  count = var.deploy-gcp ? 1 : 0
+
+  name    = "gcp-cluster-api"
+  context = "project"
+
+  depends_on = [spectrocloud_cluster_gcp.gcp-cluster-api]
+}

--- a/examples/tutorials/cluster-profile-update/manifests/hello-universe-3tier.yaml
+++ b/examples/tutorials/cluster-profile-update/manifests/hello-universe-3tier.yaml
@@ -1,0 +1,46 @@
+# Copyright (c) Spectro Cloud
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: hello-universe
+--- 
+apiVersion: v1
+kind: Service
+metadata:
+  name: hello-universe-service
+  namespace: hello-universe
+spec:
+  type: LoadBalancer
+  ports:
+  - protocol: TCP
+    port: 8080
+    targetPort: 8080
+  selector:
+    app: hello-universe
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: hello-universe-deployment
+  namespace: hello-universe
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: hello-universe
+  template:
+    metadata:
+      labels:
+        app: hello-universe
+    spec:
+      containers:
+      - name: hello-universe
+        image: ghcr.io/spectrocloud/hello-universe:1.1.0
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 8080
+        env:
+          - name: API_URI
+            value: ${api_uri}

--- a/examples/tutorials/cluster-profile-update/manifests/hello-universe-api.yaml
+++ b/examples/tutorials/cluster-profile-update/manifests/hello-universe-api.yaml
@@ -1,0 +1,82 @@
+# Copyright (c) Spectro Cloud
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: hello-universe-api
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: hello-universe-api-service
+  namespace: hello-universe-api
+spec:
+  type: LoadBalancer
+  ports:
+  - protocol: TCP
+    port: 3000
+    targetPort: 3000
+  selector:
+    app: hello-universe-api
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: hello-universe-db-service
+  namespace: hello-universe-api
+spec:
+  type: ClusterIP
+  ports:
+  - protocol: TCP
+    port: 5432
+    targetPort: 5432
+  selector:
+    app: hello-universe-db
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: hello-universe-api-deployment
+  namespace: hello-universe-api
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: hello-universe-api
+  template:
+    metadata:
+      labels:
+        app: hello-universe-api
+    spec:
+      containers:
+      - name: hello-universe-api
+        image: ghcr.io/spectrocloud/hello-universe-api:1.0.9
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 3000
+        env:
+          - name: DB_HOST
+            value: "hello-universe-db-service.hello-universe-api.svc.cluster.local"
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: hello-universe-db-deployment
+  namespace: hello-universe-api
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: hello-universe-db
+  template:
+    metadata:
+      labels:
+        app: hello-universe-db
+    spec:
+      containers:
+      - name: hello-universe-db
+        image: ghcr.io/spectrocloud/hello-universe-db:1.0.0
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 5432

--- a/examples/tutorials/cluster-profile-update/manifests/hello-universe.yaml
+++ b/examples/tutorials/cluster-profile-update/manifests/hello-universe.yaml
@@ -1,0 +1,43 @@
+# Copyright (c) Spectro Cloud
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: hello-universe
+--- 
+apiVersion: v1
+kind: Service
+metadata:
+  name: hello-universe-service
+  namespace: hello-universe
+spec:
+  type: LoadBalancer
+  ports:
+  - protocol: TCP
+    port: 8080
+    targetPort: 8080
+  selector:
+    app: hello-universe
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: hello-universe-deployment
+  namespace: hello-universe
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: hello-universe
+  template:
+    metadata:
+      labels:
+        app: hello-universe
+    spec:
+      containers:
+      - name: hello-universe
+        image: ghcr.io/spectrocloud/hello-universe:1.1.0
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 8080

--- a/examples/tutorials/cluster-profile-update/outputs.tf
+++ b/examples/tutorials/cluster-profile-update/outputs.tf
@@ -1,0 +1,21 @@
+output "advisory" {
+  value = <<-EOT
+    It takes between one to three minutes for DNS to properly resolve the public load balancer URL.
+    We recommend waiting a few moments before clicking on the service URL to prevent the browser from caching an unresolved DNS request.
+  EOT
+}
+
+output "aws_hello_universe_api_ip" {
+  description = "Instructions to retrieve the IP address of the hello-universe-api service deployed to AWS."
+  value       = var.deploy-aws ? "Use the following command to get the IP address of hello-universe-api service:\n\nexport KUBECONFIG=$(pwd)/aws-cluster-api.kubeconfig && \\\nkubectl get service hello-universe-api-service --namespace hello-universe-api --output jsonpath='{.status.loadBalancer.ingress[0].hostname}'" : null
+}
+
+output "azure_hello_universe_api_ip" {
+  description = "Instructions to retrieve the IP address of the hello-universe-api service deployed to Azure."
+  value       = var.deploy-azure ? "Use the following command to get the IP address of hello-universe-api service:\n\nexport KUBECONFIG=$(pwd)/azure-cluster-api.kubeconfig && \\\nkubectl get service hello-universe-api-service --namespace hello-universe-api --output jsonpath='{.status.loadBalancer.ingress[0].ip}'" : null
+}
+
+output "gcp_hello_universe_api_ip" {
+  description = "Instructions to retrieve the IP address of the hello-universe-api service deployed to GCP."
+  value       = var.deploy-gcp ? "Use the following command to get the IP address of hello-universe-api service:\n\nexport KUBECONFIG=$(pwd)/gcp-cluster-api.kubeconfig && \\\nkubectl get service hello-universe-api-service --namespace hello-universe-api --output jsonpath='{.status.loadBalancer.ingress[0].ip}'" : null
+}

--- a/examples/tutorials/cluster-profile-update/providers.tf
+++ b/examples/tutorials/cluster-profile-update/providers.tf
@@ -1,0 +1,40 @@
+terraform {
+  required_providers {
+    spectrocloud = {
+      version = ">= 0.17.2"
+      source  = "spectrocloud/spectrocloud"
+    }
+    tls = {
+      source  = "hashicorp/tls"
+      version = "4.0.4"
+    }
+
+    local = {
+      source  = "hashicorp/local"
+      version = ">= 2.4.0"
+    }
+  }
+
+  required_version = ">= 1.5"
+}
+
+variable "sc_host" {
+  description = "The Palette API endpoint to connect to."
+  default     = "api.spectrocloud.com"
+}
+
+variable "sc_api_key" {
+  description = "Your Palette API key. Can also be set via the SPECTROCLOUD_APIKEY environment variable instead of this variable."
+  default     = null
+}
+
+variable "sc_project_name" {
+  description = "The Palette project to deploy resources into (e.g. Default)."
+  default     = "Default"
+}
+
+provider "spectrocloud" {
+  host         = var.sc_host
+  api_key      = var.sc_api_key
+  project_name = var.sc_project_name
+}

--- a/examples/tutorials/cluster-profile-update/ssh-key.tf
+++ b/examples/tutorials/cluster-profile-update/ssh-key.tf
@@ -1,0 +1,5 @@
+resource "tls_private_key" "tutorial_ssh_key" {
+  count     = var.deploy-azure ? 1 : 0
+  algorithm = "RSA"
+  rsa_bits  = "4096"
+}

--- a/examples/tutorials/cluster-profile-update/terraform.template.tfvars
+++ b/examples/tutorials/cluster-profile-update/terraform.template.tfvars
@@ -1,0 +1,89 @@
+###########################
+# AWS Deployment Settings
+############################
+deploy-aws = false # Set to true to deploy to AWS
+
+aws-cloud-account-name = "REPLACE_ME"
+aws-region             = "REPLACE_ME"
+aws-key-pair-name      = "REPLACE_ME"
+
+aws-hello-universe-api-uri = "http://REPLACE_ME:3000" # Set IP address of hello-universe API once deployed
+
+aws_control_plane_nodes = {
+  count              = "1"
+  control_plane      = true
+  instance_type      = "m4.2xlarge"
+  disk_size_gb       = "60"
+  availability_zones = ["REPLACE_ME"] # If you want to deploy to multiple AZs, add them here. Example: ["us-east-1a", "us-east-1b"]
+}
+
+aws_worker_nodes = {
+  count              = "1"
+  control_plane      = false
+  instance_type      = "m4.2xlarge"
+  disk_size_gb       = "60"
+  availability_zones = ["REPLACE_ME"] # If you want to deploy to multiple AZs, add them here. Example: ["us-east-1a", "us-east-1b"]
+}
+
+###########################
+# Azure Deployment Settings
+############################
+deploy-azure  = false # Set to true to deploy to Azure
+azure-use-azs = true  # Set to false when you deploy to a region without AZs
+
+azure-cloud-account-name = "REPLACE_ME"
+azure-region             = "REPLACE_ME"
+azure_subscription_id    = "REPLACE_ME"
+azure_resource_group     = "REPLACE_ME"
+
+azure-hello-universe-api-uri = "http://REPLACE_ME:3000" # Set IP address of hello-universe API once deployed
+
+azure_control_plane_nodes = {
+  count               = "1"
+  control_plane       = true
+  instance_type       = "Standard_D4s_v3"
+  disk_size_gb        = "60"
+  azs                 = ["1"] # If you want to deploy to multiple AZs, add them here.
+  is_system_node_pool = false
+}
+
+azure_worker_nodes = {
+  count               = "1"
+  control_plane       = false
+  instance_type       = "Standard_D4s_v3"
+  disk_size_gb        = "60"
+  azs                 = ["1"] # If you want to deploy to multiple AZs, add them here.
+  is_system_node_pool = false
+}
+
+###########################
+# GCP Deployment Settings
+############################
+deploy-gcp = false # Set to true to deploy to GCP
+
+gcp-cloud-account-name = "REPLACE_ME"
+gcp-region             = "REPLACE_ME"
+gcp_project_name       = "REPLACE_ME"
+
+gcp-hello-universe-api-uri = "http://REPLACE_ME:3000" # Set IP address of hello-universe API once deployed
+
+gcp_control_plane_nodes = {
+  count              = "1"
+  control_plane      = true
+  instance_type      = "n2-standard-4"
+  disk_size_gb       = "60"
+  availability_zones = ["REPLACE_ME"] # If you want to deploy to multiple AZs, add them here. Example: ["us-central1-a", "us-central1-b"]
+}
+
+gcp_worker_nodes = {
+  count              = "1"
+  control_plane      = false
+  instance_type      = "n2-standard-4"
+  disk_size_gb       = "60"
+  availability_zones = ["REPLACE_ME"] # If you want to deploy to multiple AZs, add them here. Example: ["us-central1-a", "us-central1-b"]
+}
+
+###########################
+# Day-2 Profile Update
+###########################
+update_profile_version = false # Set to true after retrieving the API IP(s) above to switch the frontend cluster(s) to the 3-tier profile.

--- a/examples/tutorials/cluster-profile-update/variables.tf
+++ b/examples/tutorials/cluster-profile-update/variables.tf
@@ -1,0 +1,225 @@
+variable "aws-cloud-account-name" {
+  type        = string
+  description = "The name of your AWS account as assigned in Palette"
+  default     = ""
+}
+variable "gcp-cloud-account-name" {
+  type        = string
+  description = "The name of your GCP account as assigned in Palette"
+  default     = ""
+}
+
+variable "azure-cloud-account-name" {
+  type        = string
+  description = "The name of your Azure account as assigned in Palette"
+  default     = ""
+}
+
+variable "gcp_project_name" {
+  type        = string
+  description = "The name of your GCP project"
+  default     = ""
+}
+
+variable "deploy-aws" {
+  type        = bool
+  description = "A flag for enabling a deployment on AWS"
+}
+
+variable "deploy-gcp" {
+  type        = bool
+  description = "A flag for enabling a deployment on GCP"
+}
+
+variable "deploy-azure" {
+  type        = bool
+  description = "A flag for enabling a deployment on Azure"
+}
+
+variable "update_profile_version" {
+  type        = bool
+  description = "Switch each enabled cloud's frontend cluster from the base Hello Universe profile (version 1.0.0) to the 3-tier profile (version 1.1.0) that calls the hello-universe-api backend. Set the matching <cloud>-hello-universe-api-uri variable to the backend's load balancer address first (see the <cloud>_hello_universe_api_ip outputs after the first apply), then set this to true and re-apply."
+  default     = false
+}
+
+variable "azure_subscription_id" {
+  type        = string
+  description = "Azure subscription ID"
+  default     = ""
+}
+
+variable "azure_resource_group" {
+  type        = string
+  description = "Azure resource group"
+  default     = ""
+}
+
+variable "azure-use-azs" {
+  type        = bool
+  description = "A flag for configuring whether to use Azure Availability Zones. Check if your Azure region supports availability zones by reviewing the [Azure Regions and Availability Zones](https://learn.microsoft.com/en-us/azure/reliability/availability-zones-service-support#azure-regions-with-availability-zone-support) resource"
+}
+
+variable "aws-region" {
+  type        = string
+  description = "AWS region"
+  default     = "us-east-1"
+}
+
+variable "gcp-region" {
+  type        = string
+  description = "GCP region"
+  default     = "us-central1"
+}
+
+variable "azure-region" {
+  type        = string
+  description = "Azure region"
+  default     = "eastus"
+}
+
+variable "aws-hello-universe-api-uri" {
+  type        = string
+  description = "The URI of the hello-universe-api service deployed to AWS. Only used once update_profile_version is true — find this value from the aws_hello_universe_api_ip output after deploying the API cluster."
+  default     = "http://REPLACE_ME:3000"
+}
+
+variable "azure-hello-universe-api-uri" {
+  type        = string
+  description = "The URI of the hello-universe-api service deployed to Azure. Only used once update_profile_version is true — find this value from the azure_hello_universe_api_ip output after deploying the API cluster."
+  default     = "http://REPLACE_ME:3000"
+}
+
+variable "gcp-hello-universe-api-uri" {
+  type        = string
+  description = "The URI of the hello-universe-api service deployed to GCP. Only used once update_profile_version is true — find this value from the gcp_hello_universe_api_ip output after deploying the API cluster."
+  default     = "http://REPLACE_ME:3000"
+}
+
+variable "aws-key-pair-name" {
+  type        = string
+  description = "The name of the AWS key pair to use for SSH access to the cluster. Refer to [EC2 Key Pairs](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-key-pairs.html) to learn more."
+  default     = ""
+}
+
+variable "aws_control_plane_nodes" {
+  type = object({
+    count              = string
+    control_plane      = bool
+    instance_type      = string
+    disk_size_gb       = string
+    availability_zones = list(string)
+  })
+  default = {
+    count              = "1"
+    control_plane      = true
+    instance_type      = "m4.2xlarge"
+    disk_size_gb       = "60"
+    availability_zones = ["us-east-1a"]
+  }
+  description = "AWS control nodes configuration."
+}
+variable "aws_worker_nodes" {
+  type = object({
+    count              = string
+    control_plane      = bool
+    instance_type      = string
+    disk_size_gb       = string
+    availability_zones = list(string)
+  })
+  default = {
+    count              = "1"
+    control_plane      = false
+    instance_type      = "m4.2xlarge"
+    disk_size_gb       = "60"
+    availability_zones = ["us-east-1a"]
+  }
+  description = "AWS worker nodes configuration."
+}
+
+variable "azure_control_plane_nodes" {
+  type = object({
+    count               = string
+    control_plane       = bool
+    instance_type       = string
+    disk_size_gb        = string
+    azs                 = list(string)
+    is_system_node_pool = bool
+  })
+  default = {
+    count               = "1"
+    control_plane       = true
+    instance_type       = "Standard_A8_v2"
+    disk_size_gb        = "60"
+    azs                 = ["1"]
+    is_system_node_pool = false
+  }
+  description = "Azure control plane nodes configuration."
+}
+
+variable "azure_worker_nodes" {
+  type = object({
+    count               = string
+    control_plane       = bool
+    instance_type       = string
+    disk_size_gb        = string
+    azs                 = list(string)
+    is_system_node_pool = bool
+  })
+  default = {
+    count               = "1"
+    control_plane       = false
+    instance_type       = "Standard_A8_v2"
+    disk_size_gb        = "60"
+    azs                 = ["1"]
+    is_system_node_pool = false
+  }
+  description = "Azure worker nodes configuration."
+}
+
+variable "gcp_control_plane_nodes" {
+  type = object({
+    count              = string
+    control_plane      = bool
+    instance_type      = string
+    disk_size_gb       = string
+    availability_zones = list(string)
+  })
+  default = {
+    count              = "1"
+    control_plane      = true
+    instance_type      = "n1-standard-4"
+    disk_size_gb       = "60"
+    availability_zones = ["us-central1-a"]
+  }
+  description = "GCP control plane nodes configuration."
+}
+
+variable "gcp_worker_nodes" {
+  type = object({
+    count              = string
+    control_plane      = bool
+    instance_type      = string
+    disk_size_gb       = string
+    availability_zones = list(string)
+  })
+  default = {
+    count              = "1"
+    control_plane      = false
+    instance_type      = "n1-standard-4"
+    disk_size_gb       = "60"
+    availability_zones = ["us-central1-a"]
+  }
+  description = "GCP worker nodes configuration."
+}
+
+variable "tags" {
+  type        = list(string)
+  description = "The default tags to apply to Palette resources"
+  default = [
+    "spectro-cloud-education",
+    "app:hello-universe",
+    "repository:spectrocloud:tutorials",
+    "terraform_managed:true",
+    "tutorial:cluster-profile-update"
+  ]
+}


### PR DESCRIPTION
Ports iaas-cluster-update-tf from github.com/spectrocloud/tutorials into examples/tutorials/cluster-profile-update/, reshaped to this repo's file-naming convention.

Demonstrates a day-2 profile update: deploy a Hello Universe frontend
+ hello-universe-api backend per cloud, discover the backend's load balancer address, then roll the frontend cluster forward in place to a new profile version (1.1.0) that points at it.

Adaptations made during porting:
- Converted the source's commented-out '3-tier' profile upgrade blocks into an update_profile_version variable toggle, consistent with the create_new_profile_version pattern from cluster-templates - the Day-2 flow now works via terraform apply alone, no hand-editing .tf files required.
- Fixed a tagging bug: the GCP cluster profile and its API variant were tagged "env:azure" instead of "env:gcp".
- Updated the README's tutorial link (source had a "TODO: change once tutorial is written up" comment; that tutorial now exists) and added an explicit Day-2 workflow section.

All attributes verified against the current provider schema, including the spectrocloud_cluster data source used to read back the backend cluster's kubeconfig - no drift found. terraform validate passes against the published provider.

Covers PLT-2394 (port), PLT-2395 (README), and PLT-2396 (validation). This completes Milestone 4 (Story PLT-2370).