### PR TITLE
PLT-2388: Port pcg-vmware-app tutorial example

### DIFF
--- a/examples/tutorials/README.md
+++ b/examples/tutorials/README.md
@@ -16,7 +16,7 @@ following [PORTING_CHECKLIST.md](PORTING_CHECKLIST.md).
 | [`getting-started-multicloud/`](getting-started-multicloud) | [Cluster Management with Terraform (Getting Started)](https://docs.spectrocloud.com/tutorials/getting-started/palette/aws/deploy-manage-k8s-cluster-tf/) | Done |
 | [`profile-variables/`](profile-variables) | [Deploy Cluster with Profile Variables](https://docs.spectrocloud.com/tutorials/profiles/cluster-profile-variables/) | Done |
 | [`cluster-templates/`](cluster-templates) | [Standardize Clusters with Cluster Templates (Terraform)](https://docs.spectrocloud.com/tutorials/clusters/cluster-templates/standardize-clusters-with-cluster-templates-terraform/) | Done |
-| [`pcg-vmware-app/`](pcg-vmware-app) | [Deploy App Workloads with a PCG](https://docs.spectrocloud.com/tutorials/clusters/pcg/deploy-app-pcg/) | Planned |
+| [`pcg-vmware-app/`](pcg-vmware-app) | [Deploy App Workloads with a PCG](https://docs.spectrocloud.com/tutorials/clusters/pcg/deploy-app-pcg/) | Done |
 | [`pde-virtual-cluster-app/`](pde-virtual-cluster-app) | [Deploy an Application using Palette Dev Engine](https://docs.spectrocloud.com/tutorials/pde/deploy-app/) | Planned |
 | [`cluster-profile-update/`](cluster-profile-update) | [Deploy Cluster Profile Updates](https://docs.spectrocloud.com/tutorials/profiles/update-k8s-cluster/) | Done |
 

--- a/examples/tutorials/pcg-vmware-app/README.md
+++ b/examples/tutorials/pcg-vmware-app/README.md
@@ -1,0 +1,50 @@
+# PCG VMware app deployment tutorial example
+
+End-to-end example accompanying the Spectro Cloud tutorial
+[Deploy App Workloads with a PCG](https://docs.spectrocloud.com/tutorials/clusters/pcg/deploy-app-pcg/).
+
+This terraform configuration provisions a VMware vSphere Kubernetes cluster, reachable through an
+existing Private Cloud Gateway (PCG), with a cluster profile that includes MetalLB (for load-balanced
+services on-prem) and the "Hello Universe" sample application. It will provision the following resources
+on Spectro Cloud:
+- Cluster Profile (Ubuntu, Kubernetes, Calico CNI, vSphere CSI, MetalLB, plus Hello Universe)
+- VMware vSphere Kubernetes Cluster, deployed through the PCG
+
+## Prerequisite: install the Private Cloud Gateway first
+
+**Terraform cannot install the PCG itself** — this is a manual, one-time step you must complete before
+running this example. Install a VMware PCG by following
+[Spectro Cloud VMware Cluster](https://docs.spectrocloud.com/getting-started/?getting_started=vmware#yourfirstvmwarecluster).
+
+Once the PCG is running, note the name of the vSphere cloud account it registered — this is a required
+Terraform variable (`pcg_name`). Find it in the Palette UI: switch to the Admin view (bottom left of the
+main menu) → Settings → Cloud Accounts.
+
+## Other prerequisites
+
+You will need the following before getting started:
+1. A Palette API key, exported as the `SPECTROCLOUD_APIKEY` environment variable (or supplied via the
+   `sc_api_key` variable).
+2. The VMware PCG installed as described above, and its vSphere cloud account name.
+3. A public SSH key to access the cluster nodes. If not provided, a new key pair is generated for you.
+
+## Instructions
+
+Clone this repository to a local directory, and change directory to
+`examples/tutorials/pcg-vmware-app`. Proceed with the following:
+1. From the current directory, copy the template variable file `terraform.template.tfvars` to a new
+   file `terraform.tfvars`.
+2. Specify and update all the placeholder (`REPLACE ME`) values in the `terraform.tfvars` file.
+3. Initialize and run terraform: `terraform init && terraform apply`.
+4. Wait for the cluster creation to finish.
+
+If you didn't supply your own SSH key, see the `ssh_key_location` / `ssh_connection_command` outputs
+for how to access the cluster nodes with the key Terraform generated for you.
+
+## Clean up
+
+Run the destroy operation:
+
+```shell
+terraform destroy
+```

--- a/examples/tutorials/pcg-vmware-app/cluster.tf
+++ b/examples/tutorials/pcg-vmware-app/cluster.tf
@@ -1,0 +1,81 @@
+resource "spectrocloud_cluster_vsphere" "cluster" {
+  name             = var.cluster_name
+  tags             = var.tags
+  cloud_account_id = data.spectrocloud_cloudaccount_vsphere.account.id
+  depends_on       = [spectrocloud_cluster_profile.profile]
+
+  cloud_config {
+    ssh_keys              = [local.ssh_public_key]
+    datacenter            = var.datacenter_name
+    folder                = var.folder_name
+    static_ip             = false # If true, the cluster will use static IP placement. If false, the cluster will use DDNS.
+    network_search_domain = var.search_domain
+  }
+
+  cluster_profile {
+    id = spectrocloud_cluster_profile.profile.id
+  }
+
+  scan_policy {
+    configuration_scan_schedule = "0 0 * * SUN"
+    penetration_scan_schedule   = "0 0 * * SUN"
+    conformance_scan_schedule   = "0 0 1 * *"
+  }
+
+  ##############################
+  # control-plane-pool
+  ##############################
+  machine_pool {
+    name                    = "control-plane-pool"
+    count                   = 1
+    control_plane           = true
+    control_plane_as_worker = true
+
+    instance_type {
+      cpu          = 4
+      disk_size_gb = 60
+      memory_mb    = 8000
+    }
+
+    placement {
+      cluster       = var.vsphere_cluster
+      datastore     = var.datastore_name
+      network       = var.network_name
+      resource_pool = var.resource_pool_name
+    }
+
+    additional_labels = {
+      "owner"   = "docs"
+      "purpose" = "tutorial"
+      "type"    = "control-plane-node"
+    }
+  }
+
+  ##############################
+  # worker-pool
+  ##############################
+  machine_pool {
+    name          = "worker-pool"
+    count         = 1
+    control_plane = false
+
+    instance_type {
+      cpu          = 4
+      disk_size_gb = 60
+      memory_mb    = 8000
+    }
+
+    placement {
+      cluster       = var.vsphere_cluster
+      datastore     = var.datastore_name
+      network       = var.network_name
+      resource_pool = var.resource_pool_name
+    }
+
+    additional_labels = {
+      "owner"   = "docs"
+      "purpose" = "tutorial"
+      "type"    = "worker-node"
+    }
+  }
+}

--- a/examples/tutorials/pcg-vmware-app/data.tf
+++ b/examples/tutorials/pcg-vmware-app/data.tf
@@ -1,0 +1,61 @@
+####################################
+# Data resources for the profile
+####################################
+data "spectrocloud_registry" "public_registry" {
+  name = "Public Repo"
+}
+
+data "spectrocloud_registry" "community_registry" {
+  name = "Palette Registry"
+}
+
+####################################
+# Core Infrastructure Layers
+# The following core infrastructure layers are configured for deployment to vSphere.
+####################################
+data "spectrocloud_pack" "ubuntu" {
+  name         = "ubuntu-vsphere"
+  version      = "22.04"
+  registry_uid = data.spectrocloud_registry.public_registry.id
+}
+
+data "spectrocloud_pack" "k8s" {
+  name         = "kubernetes"
+  version      = "1.32.3"
+  registry_uid = data.spectrocloud_registry.public_registry.id
+}
+
+data "spectrocloud_pack" "cni" {
+  name         = "cni-calico"
+  version      = "3.29.3"
+  registry_uid = data.spectrocloud_registry.public_registry.id
+}
+
+data "spectrocloud_pack" "csi" {
+  name         = "csi-vsphere-csi"
+  version      = "3.3.1"
+  registry_uid = data.spectrocloud_registry.public_registry.id
+}
+
+data "spectrocloud_pack" "metallb" {
+  name         = "lb-metallb-helm"
+  version      = "0.14.9"
+  registry_uid = data.spectrocloud_registry.public_registry.id
+}
+
+####################################
+# Add-On Layers
+####################################
+
+data "spectrocloud_pack" "hellouniverse" {
+  name         = "hello-universe"
+  version      = "1.2.0"
+  registry_uid = data.spectrocloud_registry.community_registry.id
+}
+
+####################################
+# Data resources for the cluster
+####################################
+data "spectrocloud_cloudaccount_vsphere" "account" {
+  name = var.pcg_name
+}

--- a/examples/tutorials/pcg-vmware-app/outputs.tf
+++ b/examples/tutorials/pcg-vmware-app/outputs.tf
@@ -1,0 +1,25 @@
+output "advisory" {
+  value = <<-EOT
+    We recommend waiting a few minutes before clicking on the service URL to prevent the browser from caching an unresolved DNS request.
+  EOT
+}
+
+output "ssh_key_location" {
+  description = "Location of the generated private SSH key file"
+  value       = length(tls_private_key.tutorial_ssh_key) > 0 ? "This is the location of the generated private SSH key file: ${local_sensitive_file.private_key_file[0].filename}." : null
+}
+
+output "ssh_public_key_location" {
+  description = "Location of the generated public SSH key file"
+  value       = length(tls_private_key.tutorial_ssh_key) > 0 ? "This is the location of the generated public SSH key file: ${local_file.public_key_file[0].filename}." : null
+}
+
+output "ssh_connection_command" {
+  description = "Command to use the generated private SSH key to access the nodes."
+  value       = length(tls_private_key.tutorial_ssh_key) > 0 ? "To access your nodes, use the following command, replacing <username> with the username and <hostname> with the IP address of your node:  ssh -i ${local_sensitive_file.private_key_file[0].filename} <username>@<hostname>" : null
+}
+
+output "ssh_connection_command_user" {
+  description = "Command to use the user's private SSH key to access the nodes."
+  value       = var.ssh_key != "" ? "To access your nodes, use the following command, replacing <username> with the username and <hostname> with the IP address of your node:  ssh -i ${var.ssh_key_private} <username>@<hostname>" : null
+}

--- a/examples/tutorials/pcg-vmware-app/profile.tf
+++ b/examples/tutorials/pcg-vmware-app/profile.tf
@@ -1,0 +1,57 @@
+resource "spectrocloud_cluster_profile" "profile" {
+  name        = var.cluster_profile_name
+  description = var.cluster_profile_description
+  tags        = var.tags
+  cloud       = "vsphere"
+  type        = "cluster"
+
+  ############################
+  # Core layers
+  ############################
+  pack {
+    name   = data.spectrocloud_pack.ubuntu.name
+    tag    = data.spectrocloud_pack.ubuntu.version
+    uid    = data.spectrocloud_pack.ubuntu.id
+    values = data.spectrocloud_pack.ubuntu.values
+  }
+
+  pack {
+    name   = data.spectrocloud_pack.k8s.name
+    tag    = data.spectrocloud_pack.k8s.version
+    uid    = data.spectrocloud_pack.k8s.id
+    values = data.spectrocloud_pack.k8s.values
+  }
+
+  pack {
+    name   = data.spectrocloud_pack.cni.name
+    tag    = data.spectrocloud_pack.cni.version
+    uid    = data.spectrocloud_pack.cni.id
+    values = data.spectrocloud_pack.cni.values
+  }
+
+  pack {
+    name   = data.spectrocloud_pack.csi.name
+    tag    = data.spectrocloud_pack.csi.version
+    uid    = data.spectrocloud_pack.csi.id
+    values = data.spectrocloud_pack.csi.values
+  }
+
+  pack {
+    name   = data.spectrocloud_pack.metallb.name
+    tag    = data.spectrocloud_pack.metallb.version
+    uid    = data.spectrocloud_pack.metallb.id
+    values = replace(data.spectrocloud_pack.metallb.values, "192.168.10.0/24", var.metallb_ip)
+  }
+
+  ############################
+  # Add-on layer
+  ############################
+
+  pack {
+    name   = data.spectrocloud_pack.hellouniverse.name
+    tag    = data.spectrocloud_pack.hellouniverse.version
+    uid    = data.spectrocloud_pack.hellouniverse.id
+    values = data.spectrocloud_pack.hellouniverse.values
+    type   = "oci"
+  }
+}

--- a/examples/tutorials/pcg-vmware-app/providers.tf
+++ b/examples/tutorials/pcg-vmware-app/providers.tf
@@ -1,0 +1,44 @@
+terraform {
+  required_providers {
+    spectrocloud = {
+      version = ">= 0.19.0"
+      source  = "spectrocloud/spectrocloud"
+    }
+
+    vsphere = {
+      source  = "hashicorp/vsphere"
+      version = ">= 2.6.1"
+    }
+
+    tls = {
+      source  = "hashicorp/tls"
+      version = "4.0.4"
+    }
+
+    local = {
+      source  = "hashicorp/local"
+      version = "2.4.1"
+    }
+  }
+}
+
+variable "sc_host" {
+  description = "The Palette API endpoint to connect to."
+  default     = "api.spectrocloud.com"
+}
+
+variable "sc_api_key" {
+  description = "Your Palette API key. Can also be set via the SPECTROCLOUD_APIKEY environment variable instead of this variable."
+  default     = null
+}
+
+variable "sc_project_name" {
+  description = "The Palette project to deploy resources into (e.g. Default)."
+  default     = "Default"
+}
+
+provider "spectrocloud" {
+  host         = var.sc_host
+  api_key      = var.sc_api_key
+  project_name = var.sc_project_name
+}

--- a/examples/tutorials/pcg-vmware-app/ssh-key.tf
+++ b/examples/tutorials/pcg-vmware-app/ssh-key.tf
@@ -1,0 +1,22 @@
+resource "tls_private_key" "tutorial_ssh_key" {
+  count     = var.ssh_key == "" && var.ssh_key_private == "" ? 1 : 0
+  algorithm = "RSA"
+  rsa_bits  = "4096"
+}
+
+locals {
+  ssh_public_key = var.ssh_key != "" ? var.ssh_key : tls_private_key.tutorial_ssh_key[0].public_key_openssh
+}
+
+resource "local_sensitive_file" "private_key_file" {
+  count           = length(tls_private_key.tutorial_ssh_key) > 0 ? 1 : 0
+  content         = tls_private_key.tutorial_ssh_key[0].private_key_openssh
+  filename        = "${path.module}/tutorial_ssh_key"
+  file_permission = "0600"
+}
+
+resource "local_file" "public_key_file" {
+  count    = length(tls_private_key.tutorial_ssh_key) > 0 ? 1 : 0
+  content  = tls_private_key.tutorial_ssh_key[0].public_key_openssh
+  filename = "${path.module}/tutorial_ssh_key.pub"
+}

--- a/examples/tutorials/pcg-vmware-app/terraform.template.tfvars
+++ b/examples/tutorials/pcg-vmware-app/terraform.template.tfvars
@@ -1,0 +1,14 @@
+# Cluster Profile Variables
+metallb_ip = "REPLACE ME" # Provide a range of IP addresses for your Metallb Load Balancer. This range must be included in the PCG's static IP pool range if using static IP placement.
+
+# Cluster Variables
+pcg_name           = "REPLACE ME" # Provide the name of the PCG that will be used to deploy the Palette cluster.
+datacenter_name    = "REPLACE ME" # Provide the name of the datacenter in vSphere.
+folder_name        = "REPLACE ME" # Provide the name of the folder in vSphere.
+search_domain      = "REPLACE ME" # Provide the name of the network search domain.
+vsphere_cluster    = "REPLACE ME" # Provide the cluster name for the machine pool as it appears in vSphere.
+datastore_name     = "REPLACE ME" # Provide the datastore name for the machine pool as it appears in vSphere.
+network_name       = "REPLACE ME" # Provide the network name for the machine pool as it appears in vSphere.
+resource_pool_name = "REPLACE ME" # Provide the resource pool name for the machine pool as it appears in vSphere.
+ssh_key            = ""           # Provide the path to your public SSH key. If not provided, a new key pair will be created.
+ssh_key_private    = ""           # Provide the path to your private SSH key. If not provided, a new key pair will be created.

--- a/examples/tutorials/pcg-vmware-app/variables.tf
+++ b/examples/tutorials/pcg-vmware-app/variables.tf
@@ -1,0 +1,104 @@
+####################################
+# Input resources for the profile
+####################################
+
+variable "cluster_profile_name" {
+  type        = string
+  description = "The name of the cluster profile."
+  default     = "pcg-tutorial-profile"
+}
+
+variable "cluster_profile_description" {
+  type        = string
+  description = "Provide a description of the cluster profile."
+  default     = "My cluster profile as part of the PCG tutorial."
+}
+
+variable "metallb_ip" {
+  type        = string
+  description = "The IP address range for your MetalLB Load Balancer. This range must be included in the PCG's static IP pool range if using static IP placement."
+}
+
+####################################
+# Input resources for the cluster
+####################################
+
+variable "cluster_name" {
+  type        = string
+  description = "The name of the cluster."
+  default     = "pcg-tutorial-cluster"
+}
+
+variable "tags" {
+  type        = list(string)
+  description = "The default tags to apply to Palette resources. Each tag must be 63 characters or fewer, start and end with an alphanumeric character, and contain only alphanumeric characters, dots, dashes, or underscores (no slashes)."
+  default     = ["spectro-cloud-education", "app:hello-universe", "terraform_managed:true", "repository:spectrocloud:tutorials", "tutorial:DEPLOY_APP_WORKLOADS_WITH_A_PCG"]
+}
+
+#################################################
+# Input resources for the cluster - Cloud config
+#################################################
+
+variable "ssh_key" {
+  type        = string
+  description = "The path to the public key that will be added to the cluster nodes. If not provided, a new key pair will be generated."
+
+  validation {
+    condition     = var.ssh_key == "" ? true : fileexists(var.ssh_key)
+    error_message = "The provided SSH key file does not exist. Please, provide a valid path."
+  }
+}
+
+variable "ssh_key_private" {
+  type        = string
+  description = "The path to the private key that will be used to access the cluster nodes. If not provided, a new key pair will be generated."
+
+  validation {
+    condition     = var.ssh_key_private == "" ? true : fileexists(var.ssh_key_private)
+    error_message = "The provided SSH key file does not exist. Please, provide a valid path."
+  }
+}
+
+variable "datacenter_name" {
+  type        = string
+  description = "The name of the datacenter in vSphere."
+}
+
+variable "folder_name" {
+  type        = string
+  description = "The name of the folder in vSphere."
+}
+
+variable "search_domain" {
+  type        = string
+  description = "The name of the network search domain."
+}
+
+#################################################
+# Input resources for the cluster - Placement
+#################################################
+
+variable "vsphere_cluster" {
+  type        = string
+  description = "The name of your vSphere cluster."
+}
+
+variable "datastore_name" {
+  type        = string
+  description = "The name of the vSphere datastore."
+}
+
+variable "network_name" {
+  type        = string
+  description = "The name of the vSphere network."
+}
+
+variable "resource_pool_name" {
+  type        = string
+  description = "The name of the vSphere resource pool."
+}
+
+variable "pcg_name" {
+  type        = string
+  description = "The name of the Private Cloud Gateway (PCG) that will be used to deploy the cluster. The PCG itself must already be installed — see the README prerequisites."
+}


### PR DESCRIPTION
Ports vmware-cluster-deployment-tf from github.com/spectrocloud/tutorials into examples/tutorials/pcg-vmware-app/, reshaped to this repo's file-naming convention.

Deploys a VMware vSphere cluster through an existing Private Cloud Gateway, with a cluster profile including MetalLB and the Hello Universe sample app.

Fixes made during porting:
- Pack blocks hardcoded stale tag values that didn't match the actual queried pack versions (e.g. tag = "1.28.x" while querying version 1.32.3); changed to reference data.spectrocloud_pack.X.version directly, matching every other ported example.
- The Hello Universe pack (community registry) was missing type = "oci", defaulting to "spectro" instead.
- cloud_config.ssh_key (singular) is deprecated in favor of ssh_keys (plural); switched to the current form.
- Dropped entirely commented-out, non-functional scaffolding for static IP placement (a stray ippool.tf with zero live code, a commented PCG data source, commented static-IP variables) rather than carrying forward dead code for an unimplemented feature.

README states the PCG install as a manual prerequisite outside Terraform's scope, per the story requirement, linked to the PCG install docs.

All attributes verified against the current provider schema. terraform validate passes against the published provider.

Covers PLT-2388 (port), PLT-2389 (README), and PLT-2390 (validation).