### PR TITLE
PLT-2391: Port pde-virtual-cluster-app tutorial example

### DIFF
--- a/examples/tutorials/README.md
+++ b/examples/tutorials/README.md
@@ -17,7 +17,7 @@ following [PORTING_CHECKLIST.md](PORTING_CHECKLIST.md).
 | [`profile-variables/`](profile-variables) | [Deploy Cluster with Profile Variables](https://docs.spectrocloud.com/tutorials/profiles/cluster-profile-variables/) | Done |
 | [`cluster-templates/`](cluster-templates) | [Standardize Clusters with Cluster Templates (Terraform)](https://docs.spectrocloud.com/tutorials/clusters/cluster-templates/standardize-clusters-with-cluster-templates-terraform/) | Done |
 | [`pcg-vmware-app/`](pcg-vmware-app) | [Deploy App Workloads with a PCG](https://docs.spectrocloud.com/tutorials/clusters/pcg/deploy-app-pcg/) | Done |
-| [`pde-virtual-cluster-app/`](pde-virtual-cluster-app) | [Deploy an Application using Palette Dev Engine](https://docs.spectrocloud.com/tutorials/pde/deploy-app/) | Planned |
+| [`pde-virtual-cluster-app/`](pde-virtual-cluster-app) | [Deploy an Application using Palette Dev Engine](https://docs.spectrocloud.com/tutorials/pde/deploy-app/) | Done |
 | [`cluster-profile-update/`](cluster-profile-update) | [Deploy Cluster Profile Updates](https://docs.spectrocloud.com/tutorials/profiles/update-k8s-cluster/) | Done |
 
 This table will be kept current as each example is ported and validated against the current provider build.

--- a/examples/tutorials/pde-virtual-cluster-app/README.md
+++ b/examples/tutorials/pde-virtual-cluster-app/README.md
@@ -1,0 +1,49 @@
+# Palette Dev Engine virtual cluster app tutorial example
+
+End-to-end example accompanying the Spectro Cloud tutorial
+[Deploy an Application using Palette Dev Engine](https://docs.spectrocloud.com/tutorials/pde/deploy-app/).
+
+Palette Dev Engine (App Mode) lets you deploy applications onto lightweight virtual clusters carved out
+of a shared cluster group, without provisioning or managing full Kubernetes clusters yourself. This
+example deploys the Hello Universe sample application in two forms:
+- **Scenario 1 (always deployed):** a virtual cluster running Hello Universe as a single, standalone
+  UI container.
+- **Scenario 2 (optional, via `enable-second-scenario`):** a second virtual cluster running the
+  three-tier version of Hello Universe — UI, API, and a Postgres database, wired together through
+  application-profile pack outputs.
+
+It provisions, per scenario: a virtual cluster (`spectrocloud_virtual_cluster`), an application profile
+describing the container/database packs (`spectrocloud_application_profile`), and the deployed application
+itself (`spectrocloud_application`).
+
+## Prerequisite: an existing cluster group
+
+This example does not create a cluster group — it deploys virtual clusters into one that must already
+exist. Create a cluster group first (via the Palette UI, under App Mode) before running this example, and
+set `cluster-group-name` to its name.
+
+## Other prerequisites
+
+You will need the following before getting started:
+1. A Palette API key, exported as the `SPECTROCLOUD_APIKEY` environment variable (or supplied via the
+   `sc_api_key` variable).
+2. An existing cluster group, as described above.
+
+## Instructions
+
+Clone this repository to a local directory, and change directory to
+`examples/tutorials/pde-virtual-cluster-app`. Proceed with the following:
+1. From the current directory, copy the template variable file `terraform.template.tfvars` to a new
+   file `terraform.tfvars`.
+2. Set `cluster-group-name` to your existing cluster group's name.
+3. Initialize and run terraform: `terraform init && terraform apply`. This deploys scenario 1 (the
+   standalone UI app).
+4. To also deploy scenario 2 (the three-tier app), set `enable-second-scenario = true` and re-apply.
+
+## Clean up
+
+Run the destroy operation:
+
+```shell
+terraform destroy
+```

--- a/examples/tutorials/pde-virtual-cluster-app/application-profiles.tf
+++ b/examples/tutorials/pde-virtual-cluster-app/application-profiles.tf
@@ -1,0 +1,271 @@
+##########################################
+# Scenario 1: Single Application
+##########################################
+resource "spectrocloud_application_profile" "hello-universe-ui" {
+  name        = "hello-universe-ui"
+  description = "Hello Universe as a single UI instance"
+  version     = "1.0.0"
+
+  pack {
+    name            = "ui"
+    type            = data.spectrocloud_pack_simple.container_pack.type
+    registry_uid    = data.spectrocloud_registry.public_registry.id
+    source_app_tier = data.spectrocloud_pack_simple.container_pack.id
+    values          = <<-EOT
+        pack:
+          namespace: "{{.spectro.system.appdeployment.tiername}}-ns"
+          releaseNameOverride: "{{.spectro.system.appdeployment.tiername}}"
+        postReadinessHooks:
+          outputParameters:
+            - name: CONTAINER_NAMESPACE
+              type: lookupSecret
+              spec:
+                namespace: "{{.spectro.system.appdeployment.tiername}}-ns"
+                secretName: "{{.spectro.system.appdeployment.tiername}}-custom-secret"
+                ownerReference:
+                  apiVersion: v1
+                  kind: Service
+                  name: "{{.spectro.system.appdeployment.tiername}}-svc"
+                keyToCheck: metadata.namespace
+            - name: CONTAINER_SVC
+              type: lookupSecret
+              spec:
+                namespace: "{{.spectro.system.appdeployment.tiername}}-ns"
+                secretName: "{{.spectro.system.appdeployment.tiername}}-custom-secret"
+                ownerReference:
+                  apiVersion: v1
+                  kind: Service
+                  name: "{{.spectro.system.appdeployment.tiername}}-svc"
+                keyToCheck: metadata.annotations["spectrocloud.com/service-fqdn"]
+            - name: CONTAINER_SVC_EXTERNALHOSTNAME
+              type: lookupSecret
+              spec:
+                namespace: "{{.spectro.system.appdeployment.tiername}}-ns"
+                secretName: "{{.spectro.system.appdeployment.tiername}}-custom-secret"
+                ownerReference:
+                  apiVersion: v1
+                  kind: Service
+                  name: "{{.spectro.system.appdeployment.tiername}}-svc"
+                keyToCheck: status.loadBalancer.ingress[0].hostname
+                conditional: true
+            - name: CONTAINER_SVC_EXTERNALIP
+              type: lookupSecret
+              spec:
+                namespace: "{{.spectro.system.appdeployment.tiername}}-ns"
+                secretName: "{{.spectro.system.appdeployment.tiername}}-custom-secret"
+                ownerReference:
+                  apiVersion: v1
+                  kind: Service
+                  name: "{{.spectro.system.appdeployment.tiername}}-svc"
+                keyToCheck: status.loadBalancer.ingress[0].ip
+                conditional: true
+            - name: CONTAINER_SVC_PORT
+              type: lookupSecret
+              spec:
+                namespace: "{{.spectro.system.appdeployment.tiername}}-ns"
+                secretName: "{{.spectro.system.appdeployment.tiername}}-custom-secret"
+                ownerReference:
+                  apiVersion: v1
+                  kind: Service
+                  name: "{{.spectro.system.appdeployment.tiername}}-svc"
+                keyToCheck: spec.ports[0].port
+        containerService:
+            serviceName: "{{.spectro.system.appdeployment.tiername}}-svc"
+            registryUrl: ""
+            image: ${var.single-container-image}
+            access: public
+            ports:
+              - "8080"
+            serviceType: LoadBalancer
+    EOT
+  }
+  tags = concat(var.tags, ["scenario-1"])
+}
+##########################################
+# Scenario 2: Multiple Applications
+##########################################
+
+resource "spectrocloud_application_profile" "hello-universe-complete" {
+  count       = var.enable-second-scenario == true ? 1 : 0
+  name        = "hello-universe-complete"
+  description = "Hello Universe as a three-tier application"
+  version     = "1.0.0"
+  pack {
+    name            = "postgres-db"
+    type            = data.spectrocloud_pack_simple.postgres_service.type
+    source_app_tier = data.spectrocloud_pack_simple.postgres_service.id
+    properties = {
+      "dbUserName"         = var.database-user
+      "databaseName"       = var.database-name
+      "databaseVolumeSize" = "8"
+      "version"            = var.database-version
+    }
+  }
+  pack {
+    name            = "api"
+    type            = data.spectrocloud_pack_simple.container_pack.type
+    registry_uid    = data.spectrocloud_registry.public_registry.id
+    source_app_tier = data.spectrocloud_pack_simple.container_pack.id
+    values          = <<-EOT
+pack:
+  namespace: "{{.spectro.system.appdeployment.tiername}}-ns"
+  releaseNameOverride: "{{.spectro.system.appdeployment.tiername}}"
+postReadinessHooks:
+  outputParameters:
+  - name: CONTAINER_NAMESPACE
+    type: lookupSecret
+    spec:
+      namespace: "{{.spectro.system.appdeployment.tiername}}-ns"
+      secretName: "{{.spectro.system.appdeployment.tiername}}-custom-secret"
+      ownerReference:
+        apiVersion: v1
+        kind: Service
+        name: "{{.spectro.system.appdeployment.tiername}}-svc"
+      keyToCheck: metadata.namespace
+  - name: CONTAINER_SVC
+    type: lookupSecret
+    spec:
+      namespace: "{{.spectro.system.appdeployment.tiername}}-ns"
+      secretName: "{{.spectro.system.appdeployment.tiername}}-custom-secret"
+      ownerReference:
+        apiVersion: v1
+        kind: Service
+        name: "{{.spectro.system.appdeployment.tiername}}-svc"
+      keyToCheck: metadata.annotations["spectrocloud.com/service-fqdn"]
+  - name: CONTAINER_SVC_EXTERNALHOSTNAME
+    type: lookupSecret
+    spec:
+      namespace: "{{.spectro.system.appdeployment.tiername}}-ns"
+      secretName: "{{.spectro.system.appdeployment.tiername}}-custom-secret"
+      ownerReference:
+        apiVersion: v1
+        kind: Service
+        name: "{{.spectro.system.appdeployment.tiername}}-svc"
+      keyToCheck: status.loadBalancer.ingress[0].hostname
+      conditional: true
+  - name: CONTAINER_SVC_EXTERNALIP
+    type: lookupSecret
+    spec:
+      namespace: "{{.spectro.system.appdeployment.tiername}}-ns"
+      secretName: "{{.spectro.system.appdeployment.tiername}}-custom-secret"
+      ownerReference:
+        apiVersion: v1
+        kind: Service
+        name: "{{.spectro.system.appdeployment.tiername}}-svc"
+      keyToCheck: status.loadBalancer.ingress[0].ip
+      conditional: true
+  - name: CONTAINER_SVC_PORT
+    type: lookupSecret
+    spec:
+      namespace: "{{.spectro.system.appdeployment.tiername}}-ns"
+      secretName: "{{.spectro.system.appdeployment.tiername}}-custom-secret"
+      ownerReference:
+        apiVersion: v1
+        kind: Service
+        name: "{{.spectro.system.appdeployment.tiername}}-svc"
+      keyToCheck: spec.ports[0].port
+containerService:
+  serviceName: "{{.spectro.system.appdeployment.tiername}}-svc"
+  registryUrl: ""
+  image: ${var.multiple_container_images["api"]}
+  access: public
+  ports:
+    - "3000"
+  serviceType: LoadBalancer
+  env:
+    - name: DB_HOST
+      value: "{{.spectro.app.$appDeploymentName.postgres-db.POSTGRESMSTR_SVC}}"
+    - name: DB_USER
+      value: "{{.spectro.app.$appDeploymentName.postgres-db.USERNAME}}"
+    - name: DB_PASSWORD
+      value: "{{.spectro.app.$appDeploymentName.postgres-db.PASSWORD}}"
+    - name: DB_NAME
+      value: counter
+    - name: DB_INIT
+      value: "true"
+    - name: DB_ENCRYPTION
+      value: "${var.database-ssl-mode}"
+    - name: AUTHORIZATION
+      value: "true"
+    EOT
+  }
+  pack {
+    name            = "ui"
+    type            = data.spectrocloud_pack_simple.container_pack.type
+    registry_uid    = data.spectrocloud_registry.public_registry.id
+    source_app_tier = data.spectrocloud_pack_simple.container_pack.id
+    values          = <<-EOT
+        pack:
+          namespace: "{{.spectro.system.appdeployment.tiername}}-ns"
+          releaseNameOverride: "{{.spectro.system.appdeployment.tiername}}"
+        postReadinessHooks:
+          outputParameters:
+            - name: CONTAINER_NAMESPACE
+              type: lookupSecret
+              spec:
+                namespace: "{{.spectro.system.appdeployment.tiername}}-ns"
+                secretName: "{{.spectro.system.appdeployment.tiername}}-custom-secret"
+                ownerReference:
+                  apiVersion: v1
+                  kind: Service
+                  name: "{{.spectro.system.appdeployment.tiername}}-svc"
+                keyToCheck: metadata.namespace
+            - name: CONTAINER_SVC
+              type: lookupSecret
+              spec:
+                namespace: "{{.spectro.system.appdeployment.tiername}}-ns"
+                secretName: "{{.spectro.system.appdeployment.tiername}}-custom-secret"
+                ownerReference:
+                  apiVersion: v1
+                  kind: Service
+                  name: "{{.spectro.system.appdeployment.tiername}}-svc"
+                keyToCheck: metadata.annotations["spectrocloud.com/service-fqdn"]
+            - name: CONTAINER_SVC_EXTERNALHOSTNAME
+              type: lookupSecret
+              spec:
+                namespace: "{{.spectro.system.appdeployment.tiername}}-ns"
+                secretName: "{{.spectro.system.appdeployment.tiername}}-custom-secret"
+                ownerReference:
+                  apiVersion: v1
+                  kind: Service
+                  name: "{{.spectro.system.appdeployment.tiername}}-svc"
+                keyToCheck: status.loadBalancer.ingress[0].hostname
+                conditional: true
+            - name: CONTAINER_SVC_EXTERNALIP
+              type: lookupSecret
+              spec:
+                namespace: "{{.spectro.system.appdeployment.tiername}}-ns"
+                secretName: "{{.spectro.system.appdeployment.tiername}}-custom-secret"
+                ownerReference:
+                  apiVersion: v1
+                  kind: Service
+                  name: "{{.spectro.system.appdeployment.tiername}}-svc"
+                keyToCheck: status.loadBalancer.ingress[0].ip
+                conditional: true
+            - name: CONTAINER_SVC_PORT
+              type: lookupSecret
+              spec:
+                namespace: "{{.spectro.system.appdeployment.tiername}}-ns"
+                secretName: "{{.spectro.system.appdeployment.tiername}}-custom-secret"
+                ownerReference:
+                  apiVersion: v1
+                  kind: Service
+                  name: "{{.spectro.system.appdeployment.tiername}}-svc"
+                keyToCheck: spec.ports[0].port
+        containerService:
+          serviceName: "{{.spectro.system.appdeployment.tiername}}-svc"
+          registryUrl: ""
+          image: ${var.multiple_container_images["ui"]}
+          access: public
+          ports:
+            - "8080"
+          env:
+            - name: "API_URI"
+              value: "http://{{.spectro.app.$appDeploymentName.api.CONTAINER_SVC_EXTERNALHOSTNAME}}:3000"
+            - name: "TOKEN"
+              value: "${var.token}"
+          serviceType: LoadBalancer
+    EOT
+  }
+  tags = concat(var.tags, ["scenario-2"])
+}

--- a/examples/tutorials/pde-virtual-cluster-app/application.tf
+++ b/examples/tutorials/pde-virtual-cluster-app/application.tf
@@ -1,0 +1,41 @@
+##########################################
+# Scenario 1: Single Application
+##########################################
+resource "spectrocloud_application" "scenario-1" {
+  name                    = "scenario-1"
+  application_profile_uid = spectrocloud_application_profile.hello-universe-ui.id
+
+  config {
+    cluster_name    = spectrocloud_virtual_cluster.cluster-1.name
+    cluster_uid     = spectrocloud_virtual_cluster.cluster-1.id
+    cluster_context = "project"
+  }
+  tags = concat(var.tags, ["scenario-1"])
+
+  timeouts {
+    create = "10m"
+    update = "10m"
+  }
+}
+
+##########################################
+# Scenario 2: Multiple Applications
+##########################################
+resource "spectrocloud_application" "scenario-2" {
+  count = var.enable-second-scenario == true ? 1 : 0
+
+  name                    = "scenario-2"
+  application_profile_uid = spectrocloud_application_profile.hello-universe-complete[0].id
+
+  config {
+    cluster_name    = spectrocloud_virtual_cluster.cluster-2[0].name
+    cluster_uid     = spectrocloud_virtual_cluster.cluster-2[0].id
+    cluster_context = "project"
+  }
+  tags = concat(var.tags, ["scenario-2"])
+
+  timeouts {
+    create = "10m"
+    update = "10m"
+  }
+}

--- a/examples/tutorials/pde-virtual-cluster-app/data.tf
+++ b/examples/tutorials/pde-virtual-cluster-app/data.tf
@@ -1,0 +1,22 @@
+data "spectrocloud_cluster_group" "cluster-group" {
+  name    = var.cluster-group-name
+  context = "project"
+}
+
+data "spectrocloud_registry" "public_registry" {
+  name = "Public Repo"
+}
+
+data "spectrocloud_pack_simple" "container_pack" {
+  type         = "container"
+  name         = "container"
+  version      = "1.0.2"
+  registry_uid = data.spectrocloud_registry.public_registry.id
+}
+
+data "spectrocloud_pack_simple" "postgres_service" {
+  name         = "postgresql-operator"
+  type         = "operator-instance"
+  version      = "1.8.2"
+  registry_uid = data.spectrocloud_registry.public_registry.id
+}

--- a/examples/tutorials/pde-virtual-cluster-app/outputs.tf
+++ b/examples/tutorials/pde-virtual-cluster-app/outputs.tf
@@ -1,0 +1,6 @@
+output "advisory" {
+  value = <<-EOT
+    It takes between one to three minutes for DNS to properly resolve the public load balancer URL.
+    We recommend waiting a few moments before clicking on the service URL to prevent the browser from caching an unresolved DNS request.
+  EOT
+}

--- a/examples/tutorials/pde-virtual-cluster-app/providers.tf
+++ b/examples/tutorials/pde-virtual-cluster-app/providers.tf
@@ -1,0 +1,29 @@
+terraform {
+  required_providers {
+    spectrocloud = {
+      version = ">= 0.21.6"
+      source  = "spectrocloud/spectrocloud"
+    }
+  }
+}
+
+variable "sc_host" {
+  description = "The Palette API endpoint to connect to."
+  default     = "api.spectrocloud.com"
+}
+
+variable "sc_api_key" {
+  description = "Your Palette API key. Can also be set via the SPECTROCLOUD_APIKEY environment variable instead of this variable."
+  default     = null
+}
+
+variable "sc_project_name" {
+  description = "The Palette project to deploy resources into (e.g. Default)."
+  default     = "Default"
+}
+
+provider "spectrocloud" {
+  host         = var.sc_host
+  api_key      = var.sc_api_key
+  project_name = var.sc_project_name
+}

--- a/examples/tutorials/pde-virtual-cluster-app/terraform.template.tfvars
+++ b/examples/tutorials/pde-virtual-cluster-app/terraform.template.tfvars
@@ -1,0 +1,3 @@
+cluster-group-name = "REPLACE ME" # Name of an existing cluster group (created via Palette Dev Engine / App Mode) to host the virtual cluster(s).
+
+enable-second-scenario = false # Set to true to also deploy the three-tier app (UI + API + Postgres) alongside the single-container UI app.

--- a/examples/tutorials/pde-virtual-cluster-app/variables.tf
+++ b/examples/tutorials/pde-virtual-cluster-app/variables.tf
@@ -1,0 +1,79 @@
+variable "cluster-group-name" {
+  type        = string
+  description = "The name of an existing cluster group (created via Palette Dev Engine / App Mode) to host the virtual cluster(s)."
+}
+
+variable "scenario-one-cluster-name" {
+  type        = string
+  default     = "cluster-1"
+  description = "The name of the virtual cluster used for scenario 1 (single-container UI app)."
+}
+
+variable "scenario-two-cluster-name" {
+  type        = string
+  default     = "cluster-2"
+  description = "The name of the virtual cluster used for scenario 2 (three-tier app), when enable-second-scenario is true."
+}
+
+variable "single-container-image" {
+  type        = string
+  description = "The container image for the standalone Hello Universe UI app in scenario 1."
+  default     = "ghcr.io/spectrocloud/hello-universe:1.1.3"
+}
+
+variable "multiple_container_images" {
+  type        = map(string)
+  description = "The UI and API container images for the three-tier Hello Universe app in scenario 2."
+  default = {
+    ui  = "ghcr.io/spectrocloud/hello-universe:1.1.3"
+    api = "ghcr.io/spectrocloud/hello-universe-api:1.0.12"
+  }
+}
+
+variable "database-version" {
+  type        = string
+  description = "The Postgres version for scenario 2's database tier."
+  default     = "14"
+}
+
+variable "database-name" {
+  type        = string
+  description = "The database name for scenario 2's database tier."
+  default     = "counter"
+}
+
+variable "database-user" {
+  type        = string
+  description = "The database user for scenario 2's database tier."
+  default     = "pguser"
+}
+
+variable "database-ssl-mode" {
+  type        = string
+  description = "The SSL mode used when the scenario 2 API tier connects to the database."
+  default     = "require"
+}
+
+variable "token" {
+  type        = string
+  default     = "931A3B02-8DCC-543F-A1B2-69423D1A0B94"
+  description = "A fixed anonymous usage token baked into the Hello Universe UI app (scenario 2) — shared across all deployments of this tutorial, not a per-user credential."
+}
+
+variable "enable-second-scenario" {
+  type        = bool
+  description = "Whether to also deploy scenario 2 (the three-tier app: UI + API + Postgres) alongside scenario 1."
+  default     = false
+}
+
+variable "tags" {
+  type        = list(string)
+  description = "The default tags to apply to Palette resources."
+  default = [
+    "spectro-cloud-education",
+    "app:hello-universe",
+    "repository:spectrocloud/tutorials/",
+    "terraform_managed:true",
+    "tutorial:hello-universe-tf"
+  ]
+}

--- a/examples/tutorials/pde-virtual-cluster-app/virtual_clusters.tf
+++ b/examples/tutorials/pde-virtual-cluster-app/virtual_clusters.tf
@@ -1,0 +1,50 @@
+##########################################
+# Scenario 1: Single Application
+##########################################
+resource "spectrocloud_virtual_cluster" "cluster-1" {
+  name              = var.scenario-one-cluster-name
+  cluster_group_uid = data.spectrocloud_cluster_group.cluster-group.id
+
+  resources {
+    max_cpu           = 4
+    max_mem_in_mb     = 4096
+    min_cpu           = 0
+    min_mem_in_mb     = 0
+    max_storage_in_gb = "2"
+    min_storage_in_gb = "0"
+  }
+
+  tags = concat(var.tags, ["scenario-1"])
+
+  timeouts {
+    create = "15m"
+    delete = "15m"
+  }
+}
+
+##########################################
+# Scenario 2: Multiple Applications
+##########################################
+resource "spectrocloud_virtual_cluster" "cluster-2" {
+
+  count = var.enable-second-scenario == true ? 1 : 0
+
+  name              = var.scenario-two-cluster-name
+  cluster_group_uid = data.spectrocloud_cluster_group.cluster-group.id
+
+  resources {
+    max_cpu           = 8
+    max_mem_in_mb     = 12288
+    min_cpu           = 0
+    min_mem_in_mb     = 0
+    max_storage_in_gb = "12"
+    min_storage_in_gb = "0"
+  }
+
+  tags = concat(var.tags, ["scenario-2"])
+
+  timeouts {
+    create = "15m"
+    delete = "15m"
+  }
+}


### PR DESCRIPTION
Ports hello-universe-tf from github.com/spectrocloud/tutorials into examples/tutorials/pde-virtual-cluster-app/, reshaped to this repo's file-naming convention.

Deploys Hello Universe on Palette Dev Engine virtual clusters: a standalone single-container UI app (scenario 1, always deployed) and an optional three-tier UI+API+Postgres app (scenario 2, via enable-second-scenario).

Adaptations made during porting:
- Fixed the source's virutal-clusters.tf filename typo -> virtual_clusters.tf.
- No terraform.tfvars existed in the source; created terraform.template.tfvars from scratch based on the declared variables.
- Dropped three dead, commented-out output stubs left over in the source; normalized the Advisory output name to lowercase.
- README makes explicit that this example assumes a pre-existing cluster group (the source's own README warned the code 'may not execute if invoked directly' without clarifying why).

All attributes verified against the current provider schema (spectrocloud_virtual_cluster, spectrocloud_application_profile via AppPackSchema, spectrocloud_application's config block, spectrocloud_pack_simple, spectrocloud_cluster_group) - no drift found. terraform validate passes against the published provider.

Covers PLT-2391 (port), PLT-2392 (README), and PLT-2393 (validation). This is the 7th and final tutorial-aligned example.