### PR TITLE
PLT-2398: Cross-link examples/tutorials from top-level examples/READM…

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -8,3 +8,4 @@ This directory contains examples that are mostly used for documentation, but can
 * **data-sources/\<full data source name\>/data-source.tf** example file for the named data source page
 * **resources/\<full resource name\>/resource.tf** example file for the named data source page
 * **e2e/\<cloud\>/** directory contains end-to-end examples of provisioning K8s clusters.
+* **tutorials/\<name\>/** directory contains examples aligned to specific tutorials at [docs.spectrocloud.com/tutorials](https://docs.spectrocloud.com/tutorials/) — see [tutorials/README.md](tutorials/README.md) for the full list.


### PR DESCRIPTION
…E.md

Adds a bullet pointing to examples/tutorials/ alongside the existing provider/, data-sources/, resources/, and e2e/ bullets, completing Story PLT-2371 and the epic's documentation requirements.

The examples/tutorials/README.md index itself (PLT-2397) has already been kept current after each of the 7 examples was ported, with every row marked Done.